### PR TITLE
Fix MonotoneSolver: context mismatch and cache bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,3 +125,7 @@ Symbolic parameters (e.g., `I1`, `U1`, `S1`) can be used and substituted with `/
 **Important**: Call `ClearSolveCache[]` between different problem instances to prevent stale cached results.
 
 Performance history is tracked in `DNF_PERFORMANCE_HISTORY.md`. When making changes to `DNFReduce.wl`, run `CompareDNF.wls` with `--tag` to record the impact.
+
+## Git workflow
+
+**Never commit directly to `master`.** All changes must be made on a new branch and merged via pull request.

--- a/MFGraphs/Examples/ExamplesData.wl
+++ b/MFGraphs/Examples/ExamplesData.wl
@@ -9,6 +9,33 @@ Supports test cases with 5 fields (basic), 6 fields (+cost function 'a'), or 7 f
 
 DataG::usage = "DataG is a backward-compatibility alias for GetExampleData.";
 
+(* Declare symbolic parameters in the MFGraphs` context so that user-level
+   substitution rules like {I1 -> 100, U1 -> 0} match the symbols returned
+   by GetExampleData. Without these declarations the symbols end up in
+   MFGraphs`Private` and substitution silently fails. *)
+I1::usage = "Symbolic parameter: input flow at entrance 1.";
+I2::usage = "Symbolic parameter: input flow at entrance 2.";
+I3::usage = "Symbolic parameter: input flow at entrance 3.";
+U1::usage = "Symbolic parameter: terminal cost at exit 1.";
+U2::usage = "Symbolic parameter: terminal cost at exit 2.";
+U3::usage = "Symbolic parameter: terminal cost at exit 3.";
+S1::usage  = "Symbolic parameter: switching cost 1.";
+S2::usage  = "Symbolic parameter: switching cost 2.";
+S3::usage  = "Symbolic parameter: switching cost 3.";
+S4::usage  = "Symbolic parameter: switching cost 4.";
+S5::usage  = "Symbolic parameter: switching cost 5.";
+S6::usage  = "Symbolic parameter: switching cost 6.";
+S7::usage  = "Symbolic parameter: switching cost 7.";
+S8::usage  = "Symbolic parameter: switching cost 8.";
+S9::usage  = "Symbolic parameter: switching cost 9.";
+S10::usage = "Symbolic parameter: switching cost 10.";
+S11::usage = "Symbolic parameter: switching cost 11.";
+S12::usage = "Symbolic parameter: switching cost 12.";
+S13::usage = "Symbolic parameter: switching cost 13.";
+S14::usage = "Symbolic parameter: switching cost 14.";
+S15::usage = "Symbolic parameter: switching cost 15.";
+S16::usage = "Symbolic parameter: switching cost 16.";
+
 Begin["`Private`"];
 
 		eme=3;

--- a/MFGraphs/Monotone.wl
+++ b/MFGraphs/Monotone.wl
@@ -112,16 +112,29 @@ MonotoneSolver[d2e_, opts:OptionsPattern[]] :=
 	];
 
 MonotoneSolverODE[x0_, K_, jj_, cc_, opts:OptionsPattern[]] :=
-	Module[{At, dim, sol, x, xx, n, useCache, piCache, gradFn},
+	Module[{At, dim, sol, x, xx, n, useCache, cachedX, cachedPI, gradFn},
 		n = OptionValue["TimeSteps"];
 		useCache = OptionValue["UseCachedGradient"];
 		At = Transpose[K];
 		dim = Length[x0];
 
 		If[useCache,
-			(* Use cached version to avoid redundant PseudoInverse calls *)
-			piCache = {Null};
-			gradFn[xv_?NumberVectorQ] := CachedGradientProjection[xv, K, dim, At, piCache],
+			(* Inline caching via Module variables (avoids part-assignment on
+			   function arguments, which fails in Wolfram Language). *)
+			cachedX = None;
+			cachedPI = None;
+			gradFn[xv_?NumberVectorQ] :=
+				Module[{invH, AinvHAt, pi},
+					invH = InverseHessian[xv];
+					If[cachedX =!= None && Norm[xv - cachedX, Infinity] < 10^-6,
+						invH . (IdentityMatrix[dim] - At . cachedPI . K . invH),
+						AinvHAt = K . invH . At;
+						pi = PseudoInverse[AinvHAt];
+						cachedX = xv;
+						cachedPI = pi;
+						invH . (IdentityMatrix[dim] - At . pi . K . invH)
+					]
+				],
 			(* Use original uncached version *)
 			gradFn[xv_?NumberVectorQ] := GradientProjection[xv, K, dim, At]
 		];

--- a/Scripts/Profile.wls
+++ b/Scripts/Profile.wls
@@ -17,7 +17,7 @@ Get[FileNameJoin[{Directory[], "Scripts", "ProfileInstrument.wls"}]];
 
 (* --- Configuration --- *)
 $CaseToProfile = 7;
-$SolverToProfile = "NonLinearSolver";
+$SolverToProfile = "CriticalCongestion";
 
 (* --- Main execution --- *)
 Module[{tier, timeout, data, d2eResult, d2e, solverResult, report},
@@ -47,21 +47,16 @@ Module[{tier, timeout, data, d2eResult, d2e, solverResult, report},
 
   (* Run solver with profiling *)
   Print["  Running ", $SolverToProfile, " with profiling..."];
-
-  critResult = SafeExecute[CriticalCongestionSolver[d2e], timeout];
-  If[critResult["Status"] =!= "OK",
-      Print["CriticalCongestionSolver failed. Aborting."];
-      Quit[];
-  ];
   
   InitProfile[];
+  InstallProfileWrappers[];
 
-  Print["Entering profiled NonLinearSolver block..."];
-  solverResult = Block[{V = Function[{x, edge}, 0]},
-      SafeExecute[NonLinearSolver[critResult["Result"]], timeout]
-  ];
-  Print["...left profiled NonLinearSolver block."];
+  Print["Entering profiled CriticalCongestionSolver block..."];
+  solverResult = SafeExecute[CriticalCongestionSolver[d2e], timeout];
+  Print["...left profiled CriticalCongestionSolver block."];
   
+  UninstallProfileWrappers[];
+
   Print["    Solver Status: ", solverResult["Status"]];
   Print["    Total Time: ", FormatTime[solverResult["Time"]], "s"];
   Print[];


### PR DESCRIPTION
## Summary
- **Fix symbolic parameter context mismatch**: Parameters (`I1`, `U1`, `S1`, etc.) in `ExamplesData.wl` were declared inside `Begin["`Private`"]`, placing them in `MFGraphs`Private`` context. User substitution rules like `{I1 -> 100}` use `Global`` context, so they silently failed. Fixed by declaring parameters as public symbols in the `MFGraphs`` context.
- **Fix cache part-assignment bug in MonotoneSolver**: `CachedGradientProjection` tried `cache[[1]] = ...` on a function argument, which Wolfram Language replaces by its value — making part-assignment impossible. Fixed by inlining cache as Module-level variables in `MonotoneSolverODE`.
- Update Profile.wls to target CriticalCongestionSolver and add git workflow note to CLAUDE.md

## Test plan
- [x] Small tier benchmark: 21/21 OK (was 14/21 — all 7 Monotone cases now pass)
- [ ] Run medium tier benchmark to verify Monotone on more complex cases
- [ ] Run full benchmark suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)