### PR TITLE
Fix NonLinearSolver crash: Cost context mismatch and solver robustness

### DIFF
--- a/MFGraphs/DNFReduce.wl
+++ b/MFGraphs/DNFReduce.wl
@@ -116,10 +116,11 @@ DNFReduce[xp_, leq_] := xp && leq
 
 (* Equality: solve, substitute into both xp and rst, recurse *)
 DNFReduce[xp_, rst_, fst_Equal] :=
-    Module[{newfst = Simplify@fst, fsol, newxp, newrst},
+    Module[{newfst = Simplify@fst, fsol, sol, newxp, newrst},
         If[ newfst === False,
             False,
-            fsol = First@CachedSolve@newfst;
+            sol = Quiet[CachedSolve@newfst];
+            fsol = If[MatchQ[sol, {{__Rule}, ___}], First[sol], {}];
             newxp = SubstituteSolution[xp, fsol];
             If[ newxp === False,
                 False,

--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -462,6 +462,9 @@ MFGSystemSolver[Eqs_][approxJs_] :=
             True,
          	MFGPrint["MFGSS: System is ", System]
          ];
+        (* Resolve transitive rule chains, e.g. j[2,4] -> j[1,2,4]+j[3,2,4]
+           with j[1,2,4] -> 50 becomes j[2,4] -> 50 *)
+        InitRules = Expand /@ FixedPoint[Function[r, ReplaceAll[r] /@ r], InitRules, 10];
         InitRules = Join[KeyTake[InitRules, us], KeyTake[InitRules, js], KeyTake[InitRules, jts]];
         InitRules
     ];
@@ -523,6 +526,12 @@ SystemToTriple[system_] :=
 
 (* --- TripleStep / TripleClean: fixed-point simplification --- *)
 
+(* SafeFirstSolve: returns a list of Rules from CachedSolve, or {} on failure *)
+SafeFirstSolve[eq_] := Module[{sol},
+    sol = Quiet[CachedSolve[eq]];
+    If[MatchQ[sol, {{__Rule}, ___}], First[sol], {}]
+];
+
 TripleStep[{{EEs_, NNs_, ORs_}, rules_List}] :=
     TripleStep[{{EEs, NNs, ORs}, Association@rules}]
 
@@ -531,7 +540,7 @@ TripleStep[{{EE_?BooleanQ, NN_?BooleanQ, OR_?BooleanQ}, rules_Association}] :=
 
 TripleStep[{{EE_, NN_?TrueQ, OR_?TrueQ}, rules_Association}] :=
     Module[ {newrules = {}},
-        newrules = First@CachedSolve[EE /. rules] // Quiet;
+        newrules = SafeFirstSolve[EE /. rules];
         newrules = Join[rules /. newrules, Association@newrules];
         {{True, NN, OR}, Expand /@ newrules}
     ];
@@ -542,7 +551,7 @@ TripleStep[{{True, NNs_, ORs_}, rules_Association}] :=
 TripleStep[{{EEs_, NNs_, ORs_}, rules_Association}] :=
 	Module[{EE = EEs /. rules, NN, OR, NNE, NNO, ORE, ORN, newrules ={}},
 	If[ EE =!= True && EE =!= False,
-    	newrules = First@CachedSolve[EE] // Quiet
+    	newrules = SafeFirstSolve[EE]
     ];
     newrules = Expand /@ Join[rules /. newrules, Association@newrules];
     NN = Expand /@ (NNs /. newrules);

--- a/MFGraphs/Examples/ExamplesData.wl
+++ b/MFGraphs/Examples/ExamplesData.wl
@@ -1,3 +1,5 @@
+(* ::Package:: *)
+
 (* Wolfram Language package *)
 (* Built-in test cases for MFGraphs *)
 
@@ -38,9 +40,7 @@ S16::usage = "Symbolic parameter: switching cost 16.";
 
 Begin["`Private`"];
 
-		eme=3;
-        ene=3;
-        test = Association[
+		test = Association[
     (* One vertex *)
     1 -> {
         (*VL=*){1},

--- a/MFGraphs/Getting started.wl
+++ b/MFGraphs/Getting started.wl
@@ -1,0 +1,5 @@
+(* ::Package:: *)
+
+
+(*TODO: Add documentation and examples here*)
+(*I expect to have a text explaining the context of each of the examples*)

--- a/MFGraphs/NonLinearSolver.wl
+++ b/MFGraphs/NonLinearSolver.wl
@@ -29,8 +29,6 @@ interpM should be the result of PrecomputeM.";
 IsFeasible::usage =
 "IsFeasible[result] returns True if result[\"Status\"] is \"Feasible\".";
 
-Clear[H, Cost];
-
 Options[NonLinearSolver] = {"MaxIterations" -> 15, "Tolerance" -> 0};
 
 Begin["`Private`"];


### PR DESCRIPTION
## Summary
- **Fix Cost context mismatch**: `Clear[H, Cost]` before `Begin["\`Private\`"]` in NonLinearSolver.wl created `MFGraphs\`Cost` in the public context, while DataToEquations.wl uses `MFGraphs\`Private\`Cost`. The definition never matched, so `Cost[50, {2,3}]` stayed unevaluated, crashing TripleStep with `ReplaceAll::reps` errors on Case 7+.
- **Resolve transitive rule chains** in MFGSystemSolver: e.g. `j[2,4] -> j[1,2,4]+j[3,2,4]` with `j[1,2,4] -> 50` now correctly becomes `j[2,4] -> 50`.
- **Add SafeFirstSolve** to handle `CachedSolve` failures gracefully instead of crashing when `Solve` returns `{}` or stays unevaluated.
- Add Getting started notebook and clean up ExamplesData.

## Test plan
- [x] MonotoneTests: 6/6 pass
- [x] Small tier benchmark: 21/21 OK (0 FAILED)
- [x] Case 7 NonLinearSolver: Feasible, all numeric values
- [x] Cases 1-10 CriticalCongestionSolver: all Feasible, all numeric
- [ ] Run full medium tier benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)