### PR TITLE
Add ReduceDisjuncts to eliminate redundant DNF branches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,10 +61,11 @@ NonLinearSolver[criticalResult]  or  MonotoneSolverFromData[data]
 
 **Module load order** (defined in `MFGraphs.wl`):
 1. `Examples/ExamplesData.wl` — 34 built-in test cases via `GetExampleData[key]`
-2. `DNFReduce.wl` — Boolean algebra solver (disjunctive normal form reduction with Solve/Reduce memoization and branch pruning)
+2. `DNFReduce.wl` — Boolean algebra solver (disjunctive normal form reduction with Solve/Reduce memoization, branch pruning, and post-reduction via `ReduceDisjuncts`/`SubsumptionPrune`)
 3. `DataToEquations.wl` — Core converter: network topology → equations; implements `DataToEquations`, `CriticalCongestionSolver`, `MFGSystemSolver`, `TripleClean`
 4. `NonLinearSolver.wl` — Iterative fixed-point solver (`NonLinearSolver`) using Hamiltonian framework (up to 15 iterations)
 5. `Monotone.wl` — ODE-based gradient flow solver on Kirchhoff matrix using `NDSolve`
+6. `TimeDependentSolver.wl` — Time-dependent MFG solver using backward-forward sweep on discretized time grid
 
 Each submodule uses `Begin["`Private`"]` / `End[]` to isolate internal helpers. Public symbols (those with `::usage`) are declared before `Begin` and live in the `MFGraphs`` context. Internal symbols like `$SolveCache`, `CachedSolve`, `TransitionsAt`, etc. are in `MFGraphs`Private``.
 
@@ -133,10 +134,31 @@ Symbolic parameters (e.g., `I1`, `U1`, `S1`) can be used and substituted with `/
 - **Solver-aware memoization**: `CachedSolve`/`CachedReduce` hash inputs (SHA256) to avoid redundant symbolic computation
 - **Branch pruning**: prunes false branches early to avoid exponential blowup
 - **And-Or early exit**: when distributing over Or-branches sequentially, stops immediately if any branch leaves `xp` unchanged (meaning `xp` already satisfies the disjunction)
+- **Post-reduction via `ReduceDisjuncts`**: after DNFReduce produces disjuncts, `ReduceDisjuncts` removes redundant branches. For small output (≤ `$ReduceDisjunctsThreshold`, default 200) it uses `Reduce[Or @@ branches, Reals]`; for larger output it first applies `SubsumptionPrune` (pairwise implication checks) to eliminate subsumed branches, then `Reduce` on the survivors
 
 **Important**: Call `ClearSolveCache[]` between different problem instances to prevent stale cached results.
 
 Performance history is tracked in `DNF_PERFORMANCE_HISTORY.md`. When making changes to `DNFReduce.wl`, run `CompareDNF.wls` with `--tag` to record the impact.
+
+## Parallelization
+
+Several independent operations are parallelized using `ParallelMap`/`ParallelTable` when the workload exceeds `$MFGraphsParallelThreshold` (default 6). Parallel kernels are launched lazily (only when a parallel path is actually taken).
+
+Key parameters:
+```mathematica
+$MFGraphsParallelThreshold = 6       (* minimum list length to trigger parallel dispatch *)
+$MFGraphsParallelReady = False       (* set True after DistributeDefinitions to subkernels *)
+$ReduceDisjunctsThreshold = 200      (* disjunct count cutoff: Full Reduce vs Subsumption *)
+```
+
+Parallelized sites: `Simplify` over switching-cost inequalities, `Select`/`Simplify` over transition flows, `Reduce` over Or-branches in `DNFSolveStep`, and `SolveMassRoot` grid in `PrecomputeM`.
+
+**WL parallel gotchas**:
+- `Function` is `HoldAll` — use `With[{val = expr}, Function[..., ...val...]]` to inject values before dispatch to subkernels
+- `ParallelNeeds["pkg`"]` is a no-op if the context already exists; use `DistributeDefinitions` instead
+- `Block[{sym}]` clears all `DownValues` — provide explicit defaults when wrapping solver parameters
+
+Parallel performance is tracked in `PARALLEL_PERFORMANCE_HISTORY.md`. Use `BenchmarkSuite.wls --tag "description"` to record entries.
 
 ## Git workflow
 

--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -2,267 +2,266 @@
 
 (* --- Public API declarations --- *)
 
-ConsistentSwitchingCosts::usage =
-"ConsistentSwitchingCosts[switchingcosts][{a,b,c}->S]
+ConsistentSwitchingCosts::usage = "ConsistentSwitchingCosts[switchingcosts][{a,b,c}->S]
 returns True if S, the cost of switching from the edge ab to cb, is smaller than any other combination,
 such as, ab to bd and then from db to bc.
 Returns the condition for this switching cost to satisfy the triangle inequality when S, and the other
 switching costs too, does not have a numerical value.";
 
-IsSwitchingCostConsistent::usage =
-"IsSwitchingCostConsistent[List of switching costs] is True if all switching costs satisfy the triangle inequality. If some switching costs are symbolic, then it returns the consistency conditions."
+IsSwitchingCostConsistent::usage = "IsSwitchingCostConsistent[List of switching costs] is True if all switching costs satisfy the triangle inequality. If some switching costs are symbolic, then it returns the consistency conditions."
 
-AltFlowOp::usage =
-"AltFlowOp[j][list] returns the alternative: j@@list ==0 || j@@Reverse@list ==0.";
+AltFlowOp::usage = "AltFlowOp[j][list] returns the alternative: j@@list ==0 || j@@Reverse@list ==0.";
 
-FlowSplitting::usage =
-"FlowSplitting[AT][UndirectedEdge[a, b]] returns the splitting that start with {a,b}.";
+FlowSplitting::usage = "FlowSplitting[AT][UndirectedEdge[a, b]] returns the splitting that start with {a,b}.";
 
-FlowGathering::usage=
-"FlowGathering[auxTriples_List][x_] returns the triples that end with x.";
+FlowGathering::usage = "FlowGathering[auxTriples_List][x_] returns the triples that end with x.";
 
-IneqSwitch::usage =
-"IneqSwitch[u, switchingCosts][v, e1, e2] returns the optimality condition at the vertex v related to switching from e1 to e2. Namely,
+IneqSwitch::usage = "IneqSwitch[u, switchingCosts][v, e1, e2] returns the optimality condition at the vertex v related to switching from e1 to e2. Namely,
 u[v, e1] <= u[v, e2] + switchingCosts[{v, e1, e2}]"
 
-AltSwitch::usage =
-"AltSwitch[j, u, switchingCosts][v, e1, e2] returns the complementarity condition:
+AltSwitch::usage = "AltSwitch[j, u, switchingCosts][v, e1, e2] returns the complementarity condition:
 (j[v, e1, e2] == 0) || (u[v, e1] == u[e2, e1] + switchingCosts[{v, e1, e2}])"
 
-DataToEquations::usage = "DataToEquations[Data] returns the equations, \
-inequalities, and alternatives associated to the Data. "
+DataToEquations::usage = "DataToEquations[Data] returns the equations, inequalities, and alternatives associated to the Data. "
 
-NumberVectorQ::usage =
-"NumberVectorQ[j] returns True if the vector j is numeric."
+NumberVectorQ::usage = "NumberVectorQ[j] returns True if the vector j is numeric."
 
-GetKirchhoffMatrix::usage = "GetKirchhoffMatrix[d2e] returns the \
-entry current vector, Kirchhoff matrix, (critical congestion) cost \
-function placeholder, and the variables in the order corresponding to the Kirchhoff matrix. \
-The third slot is retained for backward compatibility and should not be used by new code."
+GetKirchhoffMatrix::usage = "GetKirchhoffMatrix[d2e] returns the entry current vector, Kirchhoff matrix, (critical congestion) cost function placeholder, and the variables in the order corresponding to the Kirchhoff matrix. The third slot is retained for backward compatibility and should not be used by new code."
 
-GetKirchhoffLinearSystem::usage =
-"GetKirchhoffLinearSystem[d2e] returns the entry current vector, Kirchhoff matrix, \
-and the variables in the order corresponding to the Kirchhoff matrix.";
+GetKirchhoffLinearSystem::usage = "GetKirchhoffLinearSystem[d2e] returns the entry current vector, Kirchhoff matrix, and the variables in the order corresponding to the Kirchhoff matrix.";
 
-MFGPreprocessing::usage =
-"MFGPreprocessing[Eqs] returns the association Eqs with the preliminary solution \"InitRules\" and corresponding 'reduced' \"NewSystem\"."
+MFGPreprocessing::usage = "MFGPreprocessing[Eqs] returns the association Eqs with the preliminary solution \"InitRules\" and corresponding 'reduced' \"NewSystem\"."
 
-CriticalCongestionSolver::usage =
-  "CriticalCongestionSolver[Eqs] returns Eqs with an association \"AssoCritical\" with rules to
-the solution to the critical congestion case. Option: \"ReturnShape\" (default \"Legacy\"); \
-use \"Standard\" to add normalized solver-result keys.";
+CriticalCongestionSolver::usage = "CriticalCongestionSolver[Eqs] returns Eqs with an association \"AssoCritical\" with rules to
+the solution to the critical congestion case. Option: \"ReturnShape\" (default \"Legacy\"); use \"Standard\" to add normalized solver-result keys.";
 
-MFGSystemSolver::usage =
-"MFGSystemSolver[Eqs][edgeEquations] returns the
+MFGSystemSolver::usage = "MFGSystemSolver[Eqs][edgeEquations] returns the
 association with rules to the solution";
 
-DNFSolveStep::usage =
-"DNFSolveStep[{EE,NN,OR}, rules] takes a grouped system and some Association of rules (a partial solution). It returns the result of applying DNFReduce.";
+DNFSolveStep::usage = "DNFSolveStep[{EE,NN,OR}, rules] takes a grouped system and some Association of rules (a partial solution). It returns the result of applying DNFReduce.";
 
-SystemToTriple::usage =
-"SystemToTriple[sys] returns a triple {equalities, inequalities, alternatives} from sys.
+SystemToTriple::usage = "SystemToTriple[sys] returns a triple {equalities, inequalities, alternatives} from sys.
 The input should be a system of equations, inequalities and (simple) alternatives."
 
-TripleStep::usage =
-"TripleStep[{{EE,NN,OR},Rules}] returns {{NewEE, NewNN, NewOR}, NewRules}, where NewRules contain the solutions to all the equalities found in the system after replacing Rules in {EE,NN,OR}."
+TripleStep::usage = "TripleStep[{{EE,NN,OR},Rules}] returns {{NewEE, NewNN, NewOR}, NewRules}, where NewRules contain the solutions to all the equalities found in the system after replacing Rules in {EE,NN,OR}."
 
-TripleClean::usage =
-"TripleClean[{{EE,NN,OR},Rules}] composes TripleStep until it reaches a fixed point, that is, {{True,NewNN,NewOR},NewRules} such that replacement of NewRules in NewNN and NewOR do not produce equalities."
+TripleClean::usage = "TripleClean[{{EE,NN,OR},Rules}] composes TripleStep until it reaches a fixed point, that is, {{True,NewNN,NewOR},NewRules} such that replacement of NewRules in NewNN and NewOR do not produce equalities."
 
 Data2Equations::usage = "Data2Equations is a backward-compatibility alias for DataToEquations.";
+
 FinalStep::usage = "FinalStep is a backward-compatibility alias for DNFSolveStep.";
 
-DataToEquations::switchingcosts =
-"Switching costs are inconsistent.";
+DataToEquations::switchingcosts = "Switching costs are inconsistent.";
 
-MFGSystemSolver::nosolution =
-"There is no feasible symbolic solution for the current system.";
+MFGSystemSolver::nosolution = "There is no feasible symbolic solution for the current system.";
 
 Begin["`Private`"];
 
 (* --- Switching cost consistency --- *)
 
 ConsistentSwitchingCosts[sc_][{a_, b_, c_} -> S_] :=
-    Module[ {origin, bounds},
+    Module[{origin, bounds},
         origin = Cases[sc, HoldPattern[{a, b, _} -> _]];
         origin = DeleteCases[origin, {a, b, c} -> S];
-        If[ origin =!= {},
-            bounds = ((S <= Last[#] + Association[sc][{ Part[First[#], 3], b, c}]) & /@ origin);
-            And @@ bounds,
+        If[origin =!= {},
+            bounds = ((S <= Last[#] + Association[sc][{Part[First[#],
+                 3], b, c}])& /@ origin);
+            And @@ bounds
+            ,
             True
         ]
     ];
 
 IsSwitchingCostConsistent[switchingCosts_] :=
-    And @@ Simplify[ConsistentSwitchingCosts[switchingCosts] /@ switchingCosts]
+    And @@ Simplify[ConsistentSwitchingCosts[switchingCosts] /@ switchingCosts
+        ]
 
 (* --- Graph helper functions --- *)
 
 TransitionsAt[G_, k_] :=
-    Insert[k,2] /@ Permutations[AdjacencyList[G, k], {2}]
+    Insert[k, 2] /@ Permutations[AdjacencyList[G, k], {2}]
 
-AltFlowOp[j_][list_]:=
-	j@@list==0||j@@Reverse@list==0;
+AltFlowOp[j_][list_] :=
+    j @@ list == 0 || j @@ Reverse @ list == 0;
 
-FlowSplitting[auxTriples_List][x_] := Select[auxTriples, MatchQ[#,{Sequence@@x,__}]&] ;
+FlowSplitting[auxTriples_List][x_] :=
+    Select[auxTriples, MatchQ[#, {Sequence @@ x, __}]&];
 
-FlowGathering[auxTriples_List][x_] := Select[auxTriples, MatchQ[#,{__,Sequence@@x}]&]
+FlowGathering[auxTriples_List][x_] :=
+    Select[auxTriples, MatchQ[#, {__, Sequence @@ x}]&]
 
-IneqSwitch[u_,Switching_Association][r_,i_,w_] := u[r,i] <= u[w,i]+Switching[{r,i,w}];
+IneqSwitch[u_, Switching_Association][r_, i_, w_] :=
+    u[r, i] <= u[w, i] + Switching[{r, i, w}];
 
 AltSwitch[j_, u_, Switching_][r_, i_, w_] :=
-    (j[r,i,w] == 0) ||
-    (u[r,i] == u[w,i] + Switching[{r,i,w}]);
+    (j[r, i, w] == 0) || (u[r, i] == u[w, i] + Switching[{r, i, w}]);
 
 (* --- DataToEquations: main converter --- *)
 
 DataToEquations[Data_Association] :=
-    Module[ {verticesList, adjacencyMatrix, entryVerticesFlows, exitVerticesCosts,
-    	switchingCosts, graph, entryVertices, auxEntryVertices,
-      exitVertices, auxExitVertices, entryEdges, exitEdges,
-      auxiliaryGraph, auxEdgeList, edgeList, auxVerticesList, auxPairs, auxTriples,
-      EntryDataAssociation, ExitCosts, js, us, jts,
-      SignedFlows, SwitchingCosts, IneqJs, IneqJts,
-      AltFlows, AltTransitionFlows, splittingPairs,
-      EqBalanceSplittingFlows, BalanceSplittingFlows,
-      NoDeadStarts, RuleBalanceGatheringFlows,
-      BalanceGatheringFlows, EqBalanceGatheringFlows, EqEntryIn, RuleEntryValues,
-      RuleEntryOut, RuleExitFlowsIn, RuleExitValues,
-      EqValueAuxiliaryEdges, IneqSwitchingByVertex,
-      AltOptCond, Nlhs, ModuleVars, ModuleVarsNames,
-      Nrhs, costpluscurrents, EqGeneral,
-      inAuxEntryPairs, outAuxEntryPairs, inAuxExitPairs,
-      outAuxExitPairs, pairs, halfPairs,
-      consistentCosts},
+    Module[{verticesList, adjacencyMatrix, entryVerticesFlows, exitVerticesCosts,
+         switchingCosts, graph, entryVertices, auxEntryVertices, exitVertices,
+         auxExitVertices, entryEdges, exitEdges, auxiliaryGraph, auxEdgeList,
+         edgeList, auxVerticesList, auxPairs, auxTriples, EntryDataAssociation,
+         ExitCosts, js, us, jts, SignedFlows, SwitchingCosts, IneqJs, IneqJts,
+         AltFlows, AltTransitionFlows, splittingPairs, EqBalanceSplittingFlows,
+         BalanceSplittingFlows, NoDeadStarts, RuleBalanceGatheringFlows, BalanceGatheringFlows,
+         EqBalanceGatheringFlows, EqEntryIn, RuleEntryValues, RuleEntryOut, RuleExitFlowsIn,
+         RuleExitValues, EqValueAuxiliaryEdges, IneqSwitchingByVertex, AltOptCond,
+         Nlhs, ModuleVars, ModuleVarsNames, Nrhs, costpluscurrents, EqGeneral,
+         inAuxEntryPairs, outAuxEntryPairs, inAuxExitPairs, outAuxExitPairs, 
+        pairs, halfPairs, consistentCosts},
         verticesList = Lookup[Data, "Vertices List", {}];
         adjacencyMatrix = Lookup[Data, "Adjacency Matrix", {}];
-        entryVerticesFlows = Lookup[Data, "Entrance Vertices and Flows", {}];
-        exitVerticesCosts = Lookup[Data, "Exit Vertices and Terminal Costs", {}];
+        entryVerticesFlows = Lookup[Data, "Entrance Vertices and Flows",
+             {}];
+        exitVerticesCosts = Lookup[Data, "Exit Vertices and Terminal Costs",
+             {}];
         switchingCosts = Lookup[Data, "Switching Costs", {}];
-
         (* Graph construction *)
-        graph = AdjacencyGraph[verticesList, adjacencyMatrix, VertexLabels -> "Name", DirectedEdges -> False];
+        graph = AdjacencyGraph[verticesList, adjacencyMatrix, VertexLabels
+             -> "Name", DirectedEdges -> False];
         entryVertices = First /@ entryVerticesFlows;
         exitVertices = First /@ exitVerticesCosts;
-
-        (* Define auxiliary vertices for the entry and exit vertices *)
-        auxEntryVertices = Symbol["en" <> ToString[#]] &/@ entryVertices;
-        auxExitVertices = Symbol["ex" <> ToString[#]] &/@ exitVertices;
-
-        entryEdges = MapThread[UndirectedEdge, {auxEntryVertices, entryVertices}];
-        exitEdges = MapThread[UndirectedEdge, {exitVertices, auxExitVertices}];
+(* Define auxiliary vertices for the entry and exit vertices 
+    *)
+        auxEntryVertices = Symbol["en" <> ToString[#]]& /@ entryVertices
+            ;
+        auxExitVertices = Symbol["ex" <> ToString[#]]& /@ exitVertices
+            ;
+        entryEdges = MapThread[UndirectedEdge, {auxEntryVertices, entryVertices
+            }];
+        exitEdges = MapThread[UndirectedEdge, {exitVertices, auxExitVertices
+            }];
         auxiliaryGraph = EdgeAdd[graph, Join[entryEdges, exitEdges]];
+            
         auxEdgeList = EdgeList[auxiliaryGraph];
         edgeList = EdgeList[graph];
         auxVerticesList = VertexList[auxiliaryGraph];
-
-        (* Arguments for the relevant functions: flows, values, and transition flows *)
-        halfPairs = List@@@edgeList;
-        inAuxEntryPairs = List@@@entryEdges;
-        outAuxExitPairs = List@@@exitEdges;
-
-        inAuxExitPairs = Reverse/@outAuxExitPairs;
-        outAuxEntryPairs = Reverse/@inAuxEntryPairs;
-        pairs = Join[halfPairs, Reverse/@halfPairs];
-        auxPairs = Join[inAuxEntryPairs, outAuxEntryPairs, inAuxExitPairs, outAuxExitPairs, pairs];
+(* Arguments for the relevant functions: flows, values, and transition flows 
+    
+    
+    
+    *)
+        halfPairs = List @@@ edgeList;
+        inAuxEntryPairs = List @@@ entryEdges;
+        outAuxExitPairs = List @@@ exitEdges;
+        inAuxExitPairs = Reverse /@ outAuxExitPairs;
+        outAuxEntryPairs = Reverse /@ inAuxEntryPairs;
+        pairs = Join[halfPairs, Reverse /@ halfPairs];
+        auxPairs = Join[inAuxEntryPairs, outAuxEntryPairs, inAuxExitPairs,
+             outAuxExitPairs, pairs];
         (* Insert the vertex in pairs of adjacent vertices *)
-        auxTriples = Flatten[Insert[#, 2] /@ Permutations[AdjacencyList[auxiliaryGraph, #], {2}]& /@ auxVerticesList, 1];
-
+        auxTriples = Flatten[Insert[#, 2] /@ Permutations[AdjacencyList[
+            auxiliaryGraph, #], {2}]& /@ auxVerticesList, 1];
         (* Prepare boundary data *)
-        EntryDataAssociation = RoundValues@AssociationThread[inAuxEntryPairs, Last /@ entryVerticesFlows];
-        ExitCosts = AssociationThread[auxExitVertices, Last /@ exitVerticesCosts];
-
+        EntryDataAssociation = RoundValues @ AssociationThread[inAuxEntryPairs,
+             Last /@ entryVerticesFlows];
+        ExitCosts = AssociationThread[auxExitVertices, Last /@ exitVerticesCosts
+            ];
         (* Variables *)
-        js = j[Sequence @@ #] & /@ auxPairs;
-        jts = j[Sequence @@ #] & /@ auxTriples;
-        us = u[Sequence @@ #] & /@ auxPairs;
-
+        js = j[Sequence @@ #]& /@ auxPairs;
+        jts = j[Sequence @@ #]& /@ auxTriples;
+        us = u[Sequence @@ #]& /@ auxPairs;
         (* Signed flows for "half" of the variables *)
-        SignedFlows = AssociationMap[j@@# - j@@Reverse@# &, Join[inAuxEntryPairs, outAuxExitPairs, halfPairs]];
-        SwitchingCosts = AssociationMap[0 &, auxTriples];
+        SignedFlows = AssociationMap[j @@ # - j @@ Reverse @ #&, Join[
+            inAuxEntryPairs, outAuxExitPairs, halfPairs]];
+        SwitchingCosts = AssociationMap[0&, auxTriples];
         If[switchingCosts =!= {},
-        	AssociateTo[SwitchingCosts, AssociationThread[Most /@ switchingCosts, Last /@ switchingCosts]]
+            AssociateTo[SwitchingCosts, AssociationThread[Most /@ switchingCosts,
+                 Last /@ switchingCosts]]
         ];
-        consistentCosts = IsSwitchingCostConsistent[Normal@SwitchingCosts];
-        Which[consistentCosts === False,
-            Message[DataToEquations::switchingcosts];
-            Return[ $Failed, Module],
-         consistentCosts =!= True,
-         MFGPrint["Switching costs conditions are ", consistentCosts]
+        consistentCosts = IsSwitchingCostConsistent[Normal @ SwitchingCosts
+            ];
+        Which[
+            consistentCosts === False,
+                Message[DataToEquations::switchingcosts];
+                Return[$Failed, Module]
+            ,
+            consistentCosts =!= True,
+                MFGPrint["Switching costs conditions are ", consistentCosts
+                    ]
         ];
-
-        IneqJs = And @@ (# >= 0 & /@ js);
-        IneqJts = And @@ (# >= 0 & /@ jts);
-        AltFlows = And@@(AltFlowOp[j]/@auxPairs);
-        AltTransitionFlows = And@@(AltFlowOp[j]/@auxTriples);
-        splittingPairs = Join[inAuxEntryPairs, inAuxExitPairs, pairs];
-        BalanceSplittingFlows = (j@@# - Total[j@@@FlowSplitting[auxTriples][#]])& /@ splittingPairs;
-        EqBalanceSplittingFlows = Simplify /@ (And @@ ((# == 0) & /@ BalanceSplittingFlows));
-        NoDeadStarts = Join[outAuxEntryPairs, outAuxExitPairs, pairs];
-        RuleBalanceGatheringFlows = Association[(j@@# -> Total[j@@@ FlowGathering[auxTriples][#]]) & /@ NoDeadStarts];
-
+        IneqJs = And @@ (# >= 0& /@ js);
+        IneqJts = And @@ (# >= 0& /@ jts);
+        AltFlows = And @@ (AltFlowOp[j] /@ auxPairs);
+        AltTransitionFlows = And @@ (AltFlowOp[j] /@ auxTriples);
+        splittingPairs = Join[inAuxEntryPairs, inAuxExitPairs, pairs]
+            ;
+        BalanceSplittingFlows = (j @@ # - Total[j @@@ FlowSplitting[auxTriples
+            ][#]])& /@ splittingPairs;
+        EqBalanceSplittingFlows = Simplify /@ (And @@ ((# == 0)& /@ BalanceSplittingFlows
+            ));
+        NoDeadStarts = Join[outAuxEntryPairs, outAuxExitPairs, pairs]
+            ;
+        RuleBalanceGatheringFlows = Association[(j @@ # -> Total[j @@@
+             FlowGathering[auxTriples][#]])& /@ NoDeadStarts];
         (* Equations for the exit currents at the entry vertices *)
-        BalanceGatheringFlows = ((-j@@# + Total[j@@@ FlowGathering[auxTriples][#]]) & /@ NoDeadStarts);
-        EqBalanceGatheringFlows = Simplify /@ (And @@ (# == 0 & /@ BalanceGatheringFlows));
-
+        BalanceGatheringFlows = ((-j @@ # + Total[j @@@ FlowGathering[
+            auxTriples][#]])& /@ NoDeadStarts);
+        EqBalanceGatheringFlows = Simplify /@ (And @@ (# == 0& /@ BalanceGatheringFlows
+            ));
         (* Incoming currents *)
-        EqEntryIn = (j@@# == EntryDataAssociation[#]) & /@  inAuxEntryPairs;
-
-        (* Outgoing flows at entrances and incoming flows at exits are zero *)
-        RuleEntryOut = Association[(j@@# -> 0) & /@ outAuxEntryPairs];
-        RuleExitFlowsIn = Association[(j@@# -> 0) & /@ inAuxExitPairs];
-
-		(* Exit values at exit vertices *)
-        RuleExitValues = AssociationThread[u@@@(Reverse/@outAuxExitPairs),Last /@ exitVerticesCosts];
-        RuleExitValues = Join[RuleExitValues, AssociationThread[u@@@outAuxExitPairs, Last /@ exitVerticesCosts]];
-        RuleEntryValues = AssociationThread[u@@@outAuxEntryPairs, u@@@inAuxEntryPairs];
-        EqValueAuxiliaryEdges = And @@ ((u@@# == u@@Reverse[#]) & /@ Join[inAuxEntryPairs, outAuxExitPairs]);
-        IneqSwitchingByVertex = IneqSwitch[u, SwitchingCosts] @@@ TransitionsAt[auxiliaryGraph, #] & /@ verticesList;
+        EqEntryIn = (j @@ # == EntryDataAssociation[#])& /@ inAuxEntryPairs
+            ;
+(* Outgoing flows at entrances and incoming flows at exits are zero 
+    *)
+        RuleEntryOut = Association[(j @@ # -> 0)& /@ outAuxEntryPairs
+            ];
+        RuleExitFlowsIn = Association[(j @@ # -> 0)& /@ inAuxExitPairs
+            ];
+        (* Exit values at exit vertices *)
+        RuleExitValues = AssociationThread[u @@@ (Reverse /@ outAuxExitPairs
+            ), Last /@ exitVerticesCosts];
+        RuleExitValues = Join[RuleExitValues, AssociationThread[u @@@
+             outAuxExitPairs, Last /@ exitVerticesCosts]];
+        RuleEntryValues = AssociationThread[u @@@ outAuxEntryPairs, u
+             @@@ inAuxEntryPairs];
+        EqValueAuxiliaryEdges = And @@ ((u @@ # == u @@ Reverse[#])& 
+            /@ Join[inAuxEntryPairs, outAuxExitPairs]);
+        IneqSwitchingByVertex = IneqSwitch[u, SwitchingCosts] @@@ TransitionsAt[
+            auxiliaryGraph, #]& /@ verticesList;
         IneqSwitchingByVertex = And @@@ IneqSwitchingByVertex;
-        AltOptCond = And @@ AltSwitch[j, u, SwitchingCosts] @@@ auxTriples;
-        Nlhs = Flatten[u@@# - u@@Reverse@# + SignedFlows[#] & /@ halfPairs];
-        Nrhs = Flatten[SignedFlows[#] - Sign[SignedFlows[#]] Cost[SignedFlows[#], #] & /@ halfPairs];
-
-       	(* Cost-plus-currents for the general (non-critical) case *)
-        costpluscurrents = Table[Symbol["cpc" <> ToString[k]], {k, 1, Length@edgeList}];
-        EqGeneral = And @@ (MapThread[Equal, {Nlhs, costpluscurrents}]);
+        AltOptCond = And @@ AltSwitch[j, u, SwitchingCosts] @@@ auxTriples
+            ;
+        Nlhs = Flatten[u @@ # - u @@ Reverse @ # + SignedFlows[#]& /@
+             halfPairs];
+        Nrhs = Flatten[SignedFlows[#] - Sign[SignedFlows[#]] Cost[SignedFlows[
+            #], #]& /@ halfPairs];
+        (* Cost-plus-currents for the general (non-critical) case *)
+        costpluscurrents = Table[Symbol["cpc" <> ToString[k]], {k, 1,
+             Length @ edgeList}];
+        EqGeneral = And @@ (MapThread[Equal, {Nlhs, costpluscurrents}
+            ]);
         costpluscurrents = AssociationThread[costpluscurrents, Nrhs];
-
+            
         (* Build output association *)
-        ModuleVars = {graph, pairs,
-          entryVertices, auxEntryVertices, exitVertices, auxExitVertices,
-          entryEdges, exitEdges, auxiliaryGraph, auxEdgeList, edgeList, auxVerticesList,
-          auxTriples, EntryDataAssociation,
-          ExitCosts, js, us, jts, SignedFlows,
-          SwitchingCosts, IneqJs, IneqJts, AltFlows,
-          AltTransitionFlows, splittingPairs, EqBalanceSplittingFlows,
-          BalanceSplittingFlows, NoDeadStarts,
-          RuleBalanceGatheringFlows, BalanceGatheringFlows,
-          EqBalanceGatheringFlows, EqEntryIn, RuleEntryOut, RuleEntryValues,
-          RuleExitFlowsIn, RuleExitValues, EqValueAuxiliaryEdges,
-          IneqSwitchingByVertex, AltOptCond, Nlhs,
-          Nrhs, costpluscurrents, EqGeneral};
-        ModuleVarsNames = {"graph", "pairs",
-          "entryVertices", "auxEntryVertices", "exitVertices",
-          "auxExitVertices", "entryEdges", "exitEdges", "auxiliaryGraph",
-           "auxEdgeList", "edgeList", "auxVerticesList", "auxTriples",
-           "EntryDataAssociation", "ExitCosts", "js",
-          "us", "jts", "SignedFlows",
-          "SwitchingCosts", "IneqJs", "IneqJts", "AltFlows",
-          "AltTransitionFlows", "splittingPairs",
-          "EqBalanceSplittingFlows", "BalanceSplittingFlows",
-          "NoDeadStarts", "RuleBalanceGatheringFlows",
-          "BalanceGatheringFlows", "EqBalanceGatheringFlows",
-          "EqEntryIn", "RuleEntryOut", "RuleEntryValues", "RuleExitFlowsIn",
-          "RuleExitValues", "EqValueAuxiliaryEdges",
-           "IneqSwitchingByVertex", "AltOptCond", "Nlhs",
-          "Nrhs", "costpluscurrents", "EqGeneral"};
+        ModuleVars = {graph, pairs, entryVertices, auxEntryVertices, 
+            exitVertices, auxExitVertices, entryEdges, exitEdges, auxiliaryGraph,
+             auxEdgeList, edgeList, auxVerticesList, auxTriples, EntryDataAssociation,
+             ExitCosts, js, us, jts, SignedFlows, SwitchingCosts, IneqJs, IneqJts,
+             AltFlows, AltTransitionFlows, splittingPairs, EqBalanceSplittingFlows,
+             BalanceSplittingFlows, NoDeadStarts, RuleBalanceGatheringFlows, BalanceGatheringFlows,
+             EqBalanceGatheringFlows, EqEntryIn, RuleEntryOut, RuleEntryValues, RuleExitFlowsIn,
+             RuleExitValues, EqValueAuxiliaryEdges, IneqSwitchingByVertex, AltOptCond,
+             Nlhs, Nrhs, costpluscurrents, EqGeneral};
+        ModuleVarsNames = {"graph", "pairs", "entryVertices", "auxEntryVertices",
+             "exitVertices", "auxExitVertices", "entryEdges", "exitEdges", "auxiliaryGraph",
+             "auxEdgeList", "edgeList", "auxVerticesList", "auxTriples", "EntryDataAssociation",
+             "ExitCosts", "js", "us", "jts", "SignedFlows", "SwitchingCosts", "IneqJs",
+             "IneqJts", "AltFlows", "AltTransitionFlows", "splittingPairs", "EqBalanceSplittingFlows",
+             "BalanceSplittingFlows", "NoDeadStarts", "RuleBalanceGatheringFlows",
+             "BalanceGatheringFlows", "EqBalanceGatheringFlows", "EqEntryIn", "RuleEntryOut",
+             "RuleEntryValues", "RuleExitFlowsIn", "RuleExitValues", "EqValueAuxiliaryEdges",
+             "IneqSwitchingByVertex", "AltOptCond", "Nlhs", "Nrhs", "costpluscurrents",
+             "EqGeneral"};
         Join[Data, AssociationThread[ModuleVarsNames, ModuleVars]]
     ];
 
 (* --- Utility --- *)
 
-NumberVectorQ[j_] := VectorQ[j, NumberQ];
+NumberVectorQ[j_] :=
+    VectorQ[j, NumberQ];
 
 RoundValues[x_?NumberQ] :=
     Round[x, 10^-10]
@@ -279,48 +278,55 @@ RoundValues[x_Association] :=
 (* --- GetKirchhoffMatrix --- *)
 
 GetKirchhoffLinearSystem[Eqs_] :=
-    Module[ {Kirchhoff, EqEntryIn = Lookup[Eqs, "EqEntryIn", True],
-      BalanceGatheringFlows =
-       Lookup[Eqs, "BalanceGatheringFlows", {}],
-      BalanceSplittingFlows =
-       Lookup[Eqs, "BalanceSplittingFlows", {}],
-      RuleExitFlowsIn = Lookup[Eqs, "RuleExitFlowsIn", {}],
-      RuleEntryOut = Lookup[Eqs, "RuleEntryOut", {}], BM, KM, vars,
-      cost, CCost},
-        Kirchhoff = Join[EqEntryIn, (# == 0 & /@ (BalanceGatheringFlows + BalanceSplittingFlows))];
+    Module[{Kirchhoff, EqEntryIn = Lookup[Eqs, "EqEntryIn", True], BalanceGatheringFlows
+         = Lookup[Eqs, "BalanceGatheringFlows", {}], BalanceSplittingFlows = 
+        Lookup[Eqs, "BalanceSplittingFlows", {}], RuleExitFlowsIn = Lookup[Eqs,
+         "RuleExitFlowsIn", {}], RuleEntryOut = Lookup[Eqs, "RuleEntryOut", {
+        }], BM, KM, vars, cost, CCost},
+        Kirchhoff = Join[EqEntryIn, (# == 0& /@ (BalanceGatheringFlows
+             + BalanceSplittingFlows))];
         Kirchhoff = Kirchhoff /. Join[RuleExitFlowsIn, RuleEntryOut];
+            
         (* Extract all flow variables from the Kirchhoff system *)
-        vars = Select[Variables[Kirchhoff /. Equal -> List], MatchQ[#, j[_,_,_] | j[_,_]] &];
+        vars = Select[Variables[Kirchhoff /. Equal -> List], MatchQ[#,
+             j[_, _, _] | j[_, _]]&];
         If[Length[vars] === 0,
-          (* Degenerate case: no flow variables *)
-          {0, 0, {}},
-          {BM, KM} = CoefficientArrays[Kirchhoff, vars];
-          {-BM, KM, vars}
+            (* Degenerate case: no flow variables *)
+            {0, 0, {}}
+            ,
+            {BM, KM} = CoefficientArrays[Kirchhoff, vars];
+            {-BM, KM, vars}
         ]
     ];
 
+(*cost, below, is a function that should be defined by the problem*)
+
 GetKirchhoffMatrix[Eqs_] :=
-    Module[{B, K, vars, cost, CCost},
-        {B, K, vars} = GetKirchhoffLinearSystem[Eqs];
+    Module[{B, KM, vars, cost, CCost},
+        {B, KM, vars} = GetKirchhoffLinearSystem[Eqs];
         If[Length[vars] === 0,
-            Return[{B, K, <||>, vars}, Module]
+            Return[{B, KM, <||>, vars}, Module]
         ];
-        (* The third slot is a legacy zero-cost placeholder retained only for compatibility. *)
-        cost = AssociationThread[vars, (0 &) /@ vars];
-        CCost = cost /@ vars /. MapThread[Rule, {vars, #}] &;
-        {B, K, CCost, vars}
+(* The third slot is a legacy zero-cost placeholder retained only for compatibility. 
+    
+    
+    
+    *)
+        cost = AssociationThread[vars, (0&) /@ vars];
+        CCost = cost /@ vars /. MapThread[Rule, {vars, #}]&;
+        {B, KM, CCost, vars}
     ];
 
 (* --- MFGPreprocessing --- *)
 
 MFGPreprocessing[Eqs_] :=
-    Module[ {InitRules, RuleBalanceGatheringFlows, EqEntryIn,
-      RuleEntryOut, RuleExitFlowsIn, RuleExitValues,
-      EqValueAuxiliaryEdges, IneqSwitchingByVertex, AltOptCond,
-      EqBalanceSplittingFlows, AltFlows, AltTransitionFlows,
-      IneqJs, IneqJts, ModuleVarsNames, ModulesVars, NewSystem,
-      Rules, EqGeneral, RuleEntryValues, temp, time},
-        RuleBalanceGatheringFlows = Lookup[Eqs, "RuleBalanceGatheringFlows", $Failed];
+    Module[{InitRules, RuleBalanceGatheringFlows, EqEntryIn, RuleEntryOut,
+         RuleExitFlowsIn, RuleExitValues, EqValueAuxiliaryEdges, IneqSwitchingByVertex,
+         AltOptCond, EqBalanceSplittingFlows, AltFlows, AltTransitionFlows, IneqJs,
+         IneqJts, ModuleVarsNames, ModulesVars, NewSystem, Rules, EqGeneral, 
+        RuleEntryValues, temp, time},
+        RuleBalanceGatheringFlows = Lookup[Eqs, "RuleBalanceGatheringFlows",
+             $Failed];
         EqEntryIn = Lookup[Eqs, "EqEntryIn", $Failed];
         RuleEntryOut = Lookup[Eqs, "RuleEntryOut", $Failed];
         RuleExitFlowsIn = Lookup[Eqs, "RuleExitFlowsIn", $Failed];
@@ -328,14 +334,17 @@ MFGPreprocessing[Eqs_] :=
         RuleEntryValues = Lookup[Eqs, "RuleEntryValues", $Failed];
         AltOptCond = Lookup[Eqs, "AltOptCond", $Failed];
         AltFlows = Lookup[Eqs, "AltFlows", $Failed];
-        AltTransitionFlows = Lookup[Eqs, "AltTransitionFlows", $Failed];
+        AltTransitionFlows = Lookup[Eqs, "AltTransitionFlows", $Failed
+            ];
         IneqJs = Lookup[Eqs, "IneqJs", $Failed];
         IneqJts = Lookup[Eqs, "IneqJts", $Failed];
         EqGeneral = Lookup[Eqs, "EqGeneral", $Failed];
-        IneqSwitchingByVertex = Lookup[Eqs, "IneqSwitchingByVertex", $Failed];
-        EqBalanceSplittingFlows = Lookup[Eqs, "EqBalanceSplittingFlows", $Failed];
-        EqValueAuxiliaryEdges = Lookup[Eqs, "EqValueAuxiliaryEdges", $Failed];
-
+        IneqSwitchingByVertex = Lookup[Eqs, "IneqSwitchingByVertex", 
+            $Failed];
+        EqBalanceSplittingFlows = Lookup[Eqs, "EqBalanceSplittingFlows",
+             $Failed];
+        EqValueAuxiliaryEdges = Lookup[Eqs, "EqValueAuxiliaryEdges", 
+            $Failed];
         MFGPrint[Eqs["auxiliaryGraph"]];
         (* First rules: entry currents *)
         InitRules = Association[Flatten[ToRules /@ EqEntryIn]];
@@ -344,37 +353,44 @@ MFGPreprocessing[Eqs_] :=
         AssociateTo[InitRules, RuleEntryValues];
         AssociateTo[InitRules, RuleBalanceGatheringFlows];
         AssociateTo[InitRules, RuleExitValues];
-
-        temp = MFGPrintTemporary["Simplifying inequalities involving Switching Costs...", IneqSwitchingByVertex];
+        temp = MFGPrintTemporary["Simplifying inequalities involving Switching Costs...",
+             IneqSwitchingByVertex];
         With[{items = IneqSwitchingByVertex /. InitRules},
-          {time, IneqSwitchingByVertex} = AbsoluteTiming[
-            And @@ MFGParallelMap[Simplify, items]
-          ]
+            {time, IneqSwitchingByVertex} = AbsoluteTiming[And @@ MFGParallelMap[
+                Simplify, items]]
         ];
         NotebookDelete[temp];
-        MFGPrint["Switching costs simplified in ", time, " seconds."];
-        EqBalanceSplittingFlows = EqBalanceSplittingFlows /. InitRules;
+        MFGPrint["Switching costs simplified in ", time, " seconds."]
+            ;
+        EqBalanceSplittingFlows = EqBalanceSplittingFlows /. InitRules
+            ;
         EqValueAuxiliaryEdges = EqValueAuxiliaryEdges /. InitRules;
-        temp = MFGPrintTemporary["Solving some balance equations: ", EqBalanceSplittingFlows && EqValueAuxiliaryEdges];
-        {time, Rules} = AbsoluteTiming[First@Solve[EqBalanceSplittingFlows && EqValueAuxiliaryEdges] // Quiet];
-        InitRules = Join[InitRules /. Rules, Association@Rules];
+        temp = MFGPrintTemporary["Solving some balance equations: ", 
+            EqBalanceSplittingFlows && EqValueAuxiliaryEdges];
+        {time, Rules} = AbsoluteTiming[First @ Solve[EqBalanceSplittingFlows
+             && EqValueAuxiliaryEdges] // Quiet];
+        InitRules = Join[InitRules /. Rules, Association @ Rules];
         NotebookDelete[temp];
         MFGPrint["Balance equations solved in ", time, " seconds."];
-        NewSystem =
-         MapThread[
-          And, {{True, IneqJts && IneqJs, AltFlows && AltTransitionFlows && AltOptCond},
-           SystemToTriple[IneqSwitchingByVertex]}
-         ];
-        temp = MFGPrintTemporary["TripleClean will work on\n", NewSystem, "\nwith: ", InitRules];
-        {time,{NewSystem, InitRules}} = AbsoluteTiming@TripleClean[{NewSystem, InitRules}];
+        With[{ineqTriple = SystemToTriple[IneqSwitchingByVertex]},
+            NewSystem = {ineqTriple[[1]], IneqJts && IneqJs && ineqTriple
+                [[2]], AltFlows && AltTransitionFlows && AltOptCond && ineqTriple[[3]]
+                }
+        ];
+        temp = MFGPrintTemporary["TripleClean will work on\n", NewSystem,
+             "\nwith: ", InitRules];
+        {time, {NewSystem, InitRules}} = AbsoluteTiming @ TripleClean[
+            {NewSystem, InitRules}];
         NotebookDelete[temp];
         MFGPrint["TripleClean took ", time, " seconds."];
         NewSystem[[1]] = EqGeneral;
-        temp = MFGPrintTemporary["TripleClean again (with some more equalities)..."];
-        {time,{NewSystem, InitRules}} = AbsoluteTiming@TripleClean[{NewSystem, InitRules}];
+        temp = MFGPrintTemporary["TripleClean again (with some more equalities)..."
+            ];
+        {time, {NewSystem, InitRules}} = AbsoluteTiming @ TripleClean[
+            {NewSystem, InitRules}];
         NotebookDelete[temp];
-        MFGPrint["TripleClean again (with some more equalities) took ", time, " seconds."];
-
+        MFGPrint["TripleClean again (with some more equalities) took ",
+             time, " seconds."];
         ModuleVarsNames = {"InitRules", "NewSystem"};
         ModulesVars = {InitRules, NewSystem};
         Join[Eqs, AssociationThread[ModuleVarsNames, ModulesVars]]
@@ -384,48 +400,60 @@ MFGPreprocessing[Eqs_] :=
 
 Options[CriticalCongestionSolver] = {"ReturnShape" -> "Legacy"};
 
-CriticalCongestionSolver[$Failed, ___] := $Failed
+CriticalCongestionSolver[$Failed, ___] :=
+    $Failed
 
 CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
-    Module[ {PreEqs, js, AssoCritical, time, temp, status, returnShape,
-        resultKind, message, solution},
+    Module[{PreEqs, js, AssoCritical, time, temp, status, returnShape,
+         resultKind, message, solution},
         returnShape = OptionValue["ReturnShape"];
-    	ClearSolveCache[];
-    	If[KeyExistsQ[Eqs,"InitRules"],
-    		PreEqs = Eqs,
-    		temp = MFGPrintTemporary["Preprocessing..."];
-        	{time, PreEqs} = AbsoluteTiming@MFGPreprocessing[Eqs];
-        	NotebookDelete[temp];
-        	MFGPrint["Preprocessing took ", time, " seconds to terminate."];
+        ClearSolveCache[];
+        If[KeyExistsQ[Eqs, "InitRules"],
+            PreEqs = Eqs
+            ,
+            temp = MFGPrintTemporary["Preprocessing..."];
+            {time, PreEqs} = AbsoluteTiming @ MFGPreprocessing[Eqs];
+            NotebookDelete[temp];
+            MFGPrint["Preprocessing took ", time, " seconds to terminate."
+                ];
         ];
         js = Lookup[PreEqs, "js", $Failed];
-        AssoCritical = MFGSystemSolver[PreEqs][AssociationThread[js, 0 js]];
+        AssoCritical = MFGSystemSolver[PreEqs][AssociationThread[js, 
+            0 js]];
         status = CheckFlowFeasibility[AssoCritical];
         If[returnShape === "Standard",
-            resultKind = If[AssoCritical === Null, "Failure", "Success"];
-            message = If[AssoCritical === Null, "NoSolution", None];
-            solution = If[AssociationQ[AssoCritical], AssoCritical, Missing["NotAvailable"]];
-            Join[
-                PreEqs,
-                MakeSolverResult[
-                    "CriticalCongestion",
-                    resultKind,
-                    status,
-                    message,
-                    solution,
-                    <|"AssoCritical" -> AssoCritical, "Status" -> status|>
-                ]
-            ],
-            Join[PreEqs, <|"AssoCritical" -> AssoCritical, "Status" -> status|>]
+            resultKind =
+                If[AssoCritical === Null,
+                    "Failure"
+                    ,
+                    "Success"
+                ];
+            message =
+                If[AssoCritical === Null,
+                    "NoSolution"
+                    ,
+                    None
+                ];
+            solution =
+                If[AssociationQ[AssoCritical],
+                    AssoCritical
+                    ,
+                    Missing["NotAvailable"]
+                ];
+            Join[PreEqs, MakeSolverResult["CriticalCongestion", resultKind,
+                 status, message, solution, <|"AssoCritical" -> AssoCritical, "Status"
+                 -> status|>]]
+            ,
+            Join[PreEqs, <|"AssoCritical" -> AssoCritical, "Status" ->
+                 status|>]
         ]
     ];
 
 (* --- MFGSystemSolver --- *)
 
 MFGSystemSolver[Eqs_][approxJs_] :=
-    Module[ {NewSystem, InitRules, pickOne, vars, System, Ncpc,
-        costpluscurrents, us, js, jts, jjtsR, usR, time, temp,
-        ineqsByTransition},
+    Module[{NewSystem, InitRules, pickOne, vars, System, Ncpc, costpluscurrents,
+         us, js, jts, jjtsR, usR, time, temp, ineqsByTransition},
         ClearSolveCache[];
         us = Lookup[Eqs, "us", $Failed];
         js = Lookup[Eqs, "js", $Failed];
@@ -433,84 +461,124 @@ MFGSystemSolver[Eqs_][approxJs_] :=
         InitRules = Lookup[Eqs, "InitRules", $Failed];
         NewSystem = Lookup[Eqs, "NewSystem", $Failed];
         costpluscurrents = Lookup[Eqs, "costpluscurrents", $Failed];
-        {time, Ncpc} = AbsoluteTiming[RoundValues @ (Expand/@(costpluscurrents /. approxJs))];
-        MFGPrint["MFGSS: Calculated the cost plus currents for the flow in ", time, " seconds."];
-        InitRules = Expand/@(InitRules /. Ncpc);
+        {time, Ncpc} = AbsoluteTiming[RoundValues @ (Expand /@ (costpluscurrents
+             /. approxJs))];
+        MFGPrint["MFGSS: Calculated the cost plus currents for the flow in ",
+             time, " seconds."];
+        InitRules = Expand /@ (InitRules /. Ncpc);
         NewSystem = NewSystem /. Ncpc;
-
-        If[And@@((#===False)&/@NewSystem),
-        	Message[MFGSystemSolver::nosolution];
-            Return[Null,Module]
+        If[And @@ ((# === False)& /@ NewSystem),
+            Message[MFGSystemSolver::nosolution];
+            Return[Null, Module]
         ];
-
-        (* Retrieve some equalities from the inequalities: group by transition flow *)
-        temp = MFGPrintTemporary["MFGSS: Selecting inequalities by transition flow..."];
+(* Retrieve some equalities from the inequalities: group by transition flow 
+    
+    
+    
+    *)
+        temp = MFGPrintTemporary["MFGSS: Selecting inequalities by transition flow..."
+            ];
         If[NewSystem[[2]] === True,
             ineqsByTransition = ConstantArray[True, Length[jts]];
-            time = 0.,
-            {time, ineqsByTransition} = AbsoluteTiming[
-              With[{ineqs = NewSystem[[2]]},
-                MFGParallelMap[Function[jt, Select[ineqs, !FreeQ[jt][#]&]], jts]
-              ]
-            ]
+            time = 0.
+            ,
+            {time, ineqsByTransition} =
+                AbsoluteTiming[
+                    With[{ineqs = NewSystem[[2]]},
+                        MFGParallelMap[
+                            Function[jt,
+                                Select[ineqs, !FreeQ[jt][#]&]
+                            ]
+                            ,
+                            jts
+                        ]
+                    ]
+                ]
         ];
         NotebookDelete[temp];
-        MFGPrint["MFGSS: Selecting inequalities by transition flow took ", time, " seconds. ", Length[ineqsByTransition]];
-        temp = MFGPrintTemporary["MFGSS: Simplifying inequalities by transition flow..."];
-        {time, ineqsByTransition} = AbsoluteTiming[
-          DeduplicateByComplexity[
-            MFGParallelMap[Simplify, ineqsByTransition]
-          ]
-        ];
+        MFGPrint["MFGSS: Selecting inequalities by transition flow took ",
+             time, " seconds. ", Length[ineqsByTransition]];
+        temp = MFGPrintTemporary["MFGSS: Simplifying inequalities by transition flow..."
+            ];
+        {time, ineqsByTransition} = AbsoluteTiming[DeduplicateByComplexity[
+            MFGParallelMap[Simplify, ineqsByTransition]]];
         NotebookDelete[temp];
-        MFGPrint["MFGSS: Simplifying inequalities by transition flow took ", time, " seconds. "];
-
-		NewSystem[[2]]=(And@@ineqsByTransition);
-		NewSystem = SystemToTriple[And@@NewSystem];
-		{NewSystem,InitRules} = TripleClean[{NewSystem,InitRules}];
-
-		{NewSystem, InitRules} = DNFSolveStep[{NewSystem, InitRules}];
-
+        MFGPrint["MFGSS: Simplifying inequalities by transition flow took ",
+             time, " seconds. "];
+        NewSystem[[2]] = (And @@ ineqsByTransition);
+        NewSystem = SystemToTriple[And @@ NewSystem];
+        {NewSystem, InitRules} = TripleClean[{NewSystem, InitRules}];
+            
+        {NewSystem, InitRules} = DNFSolveStep[{NewSystem, InitRules}]
+            ;
         MFGPrint["Simplifying system..."];
-        System = Simplify[And@@NewSystem];
+        System = Simplify[And @@ NewSystem];
         MFGPrint["Simplifying done. TripleClean..."];
-        {System, InitRules} = TripleClean[{SystemToTriple[System], InitRules}];
-        System = And@@System;
-        Which[System === False,
-            Message[MFGSystemSolver::nosolution];
-            Return[Null,Module],
-            System =!= True,
-            MFGPrint["MFGSS: (Possibly) Multiple solutions:\n", System];
-            (* Extract all unsolved variables from System *)
-            vars = Select[Variables[System], MatchQ[#, j[_,_,_] | j[_,_] | u[_,_] | u[_,_,_]] &];
-            vars = Complement[vars, Keys[InitRules]];
-            jjtsR = Select[vars, MatchQ[#, j[_,_,_] | j[_,_]] &];
-            usR = Select[vars, MatchQ[#, u[_,_,_] | u[_,_]] &];
-
-            (* Pick one solution so that all the currents have numerical values *)
-            If[Length[vars] > 0,
-              (* Attempt to find a solution *)
-              pickOne = FindInstance[System && And @@ ((# > 0 )& /@ jjtsR), vars, Reals];
-              If[pickOne === {},
-              	pickOne = FindInstance[System && And @@ ((# >= 0 )& /@ jjtsR), vars, Reals]
-              ];
-              If[pickOne =!= {},
-                pickOne = Association @ First @ pickOne;
-                MFGPrint["MFGSS: Picked one solution: ", pickOne];
-                InitRules = Expand /@ Join[InitRules /. pickOne, pickOne],
-                MFGPrint["MFGSS: No feasible solution found"];
+        {System, InitRules} = TripleClean[{SystemToTriple[System], InitRules
+            }];
+        System = And @@ System;
+        Which[
+            System === False,
+                Message[MFGSystemSolver::nosolution];
                 Return[Null, Module]
-              ],
-              (* All variables already solved — nothing to pick *)
-              MFGPrint["MFGSS: All variables already determined in InitRules"]
-            ],
+            ,
+            System =!= True,
+                MFGPrint["MFGSS: (Possibly) Multiple solutions:\n", System
+                    ];
+                (* Extract all unsolved variables from System *)
+                vars = Select[Variables[System], MatchQ[#, j[_, _, _]
+                     | j[_, _] | u[_, _] | u[_, _, _]]&];
+                vars = Complement[vars, Keys[InitRules]];
+                jjtsR = Select[vars, MatchQ[#, j[_, _, _] | j[_, _]]&
+                    ];
+                usR = Select[vars, MatchQ[#, u[_, _, _] | u[_, _]]&];
+                    
+(* Pick one solution so that all the currents have numerical values 
+    *)
+                If[Length[vars] > 0,
+                    (* Attempt to find a solution *)
+                    pickOne = FindInstance[System && And @@ ((# > 0)&
+                         /@ jjtsR), vars, Reals];
+                    If[pickOne === {},
+                        pickOne = FindInstance[System && And @@ ((# >=
+                             0)& /@ jjtsR), vars, Reals]
+                    ];
+                    If[pickOne =!= {},
+                        pickOne = Association @ First @ pickOne;
+                        MFGPrint["MFGSS: Picked one solution: ", pickOne
+                            ];
+                        InitRules = Expand /@ Join[InitRules /. pickOne,
+                             pickOne]
+                        ,
+                        MFGPrint["MFGSS: No feasible solution found"]
+                            ;
+                        Return[Null, Module]
+                    ]
+                    ,
+(* All variables already solved — nothing to pick 
+    *)
+                    MFGPrint["MFGSS: All variables already determined in InitRules"
+                        ]
+                ]
+            ,
             True,
-         	MFGPrint["MFGSS: System is ", System]
-         ];
-        (* Resolve transitive rule chains, e.g. j[2,4] -> j[1,2,4]+j[3,2,4]
-           with j[1,2,4] -> 50 becomes j[2,4] -> 50 *)
-        InitRules = Expand /@ FixedPoint[Function[r, ReplaceAll[r] /@ r], InitRules, 10];
-        InitRules = Join[KeyTake[InitRules, us], KeyTake[InitRules, js], KeyTake[InitRules, jts]];
+                MFGPrint["MFGSS: System is ", System]
+        ];
+(* Resolve transitive rule chains, e.g. j[2,4] -> j[1,2,4]+j[3,2,4]
+   with j[1,2,4] -> 50 becomes j[2,4] -> 50 *)
+        InitRules =
+            Expand /@
+                FixedPoint[
+                    Function[r,
+                        ReplaceAll[r] /@ r
+                    ]
+                    ,
+                    InitRules
+                    ,
+                    10
+                ];
+        InitRules = Join[KeyTake[InitRules, us], KeyTake[InitRules, js
+            ], KeyTake[InitRules, jts]];
         InitRules
     ];
 
@@ -520,25 +588,43 @@ DNFSolveStep[{{EE_?BooleanQ, NN_?BooleanQ, OR_?BooleanQ}, rules_}] :=
     {{EE, NN, OR}, rules}
 
 DNFSolveStep[{{EE_, NN_, OO_}, rules_}] :=
-    Module[ {NewSystem, newrules, sorted = True, time, temp},
+    Module[{NewSystem, newrules, sorted = True, time, temp},
         {NewSystem, newrules} = TripleClean[{{EE, NN, OO}, rules}];
         If[NewSystem[[3]] === True,
-            Return[{NewSystem, newrules}, Module],
-            MFGPrint["Final: ", Length/@NewSystem];
+            Return[{NewSystem, newrules}, Module]
+            ,
+            MFGPrint["Final: ", Length /@ NewSystem];
             sorted = DeduplicateByComplexity[NewSystem[[3]]];
         ];
-        temp = MFGPrintTemporary["Final: Iterative DNF conversion on " , Length[sorted]," disjunctions..."];
-        {time, NewSystem} = AbsoluteTiming[DNFReduce[And @@ Most[NewSystem], sorted]];
+        temp = MFGPrintTemporary["Final: Iterative DNF conversion on ",
+             Length[sorted], " disjunctions..."];
+        {time, NewSystem} = AbsoluteTiming[DNFReduce[And @@ Most[NewSystem
+            ], sorted]];
         NotebookDelete[temp];
-        MFGPrint["Final: Iterative DNF conversion on " , Length[sorted]," disjunctions took ", time, " seconds to terminate."];
-        {time, NewSystem} = AbsoluteTiming[ReduceDisjuncts[NewSystem]];
-        MFGPrint["Final: ReduceDisjuncts returned ",
-          If[Head[NewSystem] === Or, Length[NewSystem], 1],
-          " disjunct(s) in ", time, " seconds."];
-        NewSystem = BooleanConvert@NewSystem;
+        MFGPrint["Final: Iterative DNF conversion on ", Length[sorted
+            ], " disjunctions took ", time, " seconds to terminate."];
+        {time, NewSystem} = AbsoluteTiming[ReduceDisjuncts[NewSystem]
+            ];
+        MFGPrint[
+            "Final: ReduceDisjuncts returned "
+            ,
+            If[Head[NewSystem] === Or,
+                Length[NewSystem]
+                ,
+                1
+            ]
+            ,
+            " disjunct(s) in "
+            ,
+            time
+            ,
+            " seconds."
+        ];
+        NewSystem = BooleanConvert @ NewSystem;
         NewSystem = SystemToTriple[NewSystem];
         {NewSystem, newrules} = TripleClean[{NewSystem, newrules}];
-        MFGPrint["Now: ", TimeObject[Now], " The new rules are: ", newrules, Length/@NewSystem];
+        MFGPrint["Now: ", TimeObject[Now], " The new rules are: ", newrules,
+             Length /@ NewSystem];
         {NewSystem, newrules}
     ];
 
@@ -550,64 +636,76 @@ SystemToTriple[False] = Table[False, 3]
 
 SystemToTriple[system_] :=
     Which[
-     Head[system] === And,
-      Module[ {groups, EE, OR, NN},
-          groups = GroupBy[List @@ system, Head[#] === Equal &];
-          EE = And @@ Lookup[groups, True, {}];
-          groups = GroupBy[Lookup[groups, False, {}], Head[#] === Or &];
-          OR = And @@ Lookup[groups, True, True];
-          NN = And @@ Lookup[groups, False, True];
-          {EE, NN, OR}
-      ],
-     Head[system] === Equal,
-      {system, True, True},
-     Head[system] === Or,
-         {True, True, system},
-     True,
-         {True, system, True}];
+        Head[system] === And,
+            Module[{args = List @@ system},
+                {And @@ Cases[args, _Equal], And @@ DeleteCases[args,
+                     _Equal | _Or], And @@ Cases[args, _Or]}
+            ]
+        ,
+        Head[system] === Equal,
+            {system, True, True}
+        ,
+        Head[system] === Or,
+            {True, True, system}
+        ,
+        True,
+            {True, system, True}
+    ];
 
 (* --- TripleStep / TripleClean: fixed-point simplification --- *)
 
 (* SafeFirstSolve: returns a list of Rules from CachedSolve, or {} on failure *)
-SafeFirstSolve[eq_] := Module[{sol},
-    sol = Quiet[CachedSolve[eq]];
-    If[MatchQ[sol, {{__Rule}, ___}], First[sol], {}]
-];
+
+SafeFirstSolve[eq_] :=
+    Module[{sol},
+        sol = Quiet[CachedSolve[eq]];
+        If[MatchQ[sol, {{__Rule}, ___}],
+            First[sol]
+            ,
+            {}
+        ]
+    ];
 
 TripleStep[{{EEs_, NNs_, ORs_}, rules_List}] :=
-    TripleStep[{{EEs, NNs, ORs}, Association@rules}]
+    TripleStep[{{EEs, NNs, ORs}, Association @ rules}]
 
-TripleStep[{{EE_?BooleanQ, NN_?BooleanQ, OR_?BooleanQ}, rules_Association}] :=
+TripleStep[{{EE_?BooleanQ, NN_?BooleanQ, OR_?BooleanQ}, rules_Association
+    }] :=
     {{EE, NN, OR}, rules}
 
 TripleStep[{{EE_, NN_?TrueQ, OR_?TrueQ}, rules_Association}] :=
-    Module[ {newrules = {}},
+    Module[{newrules = {}},
         newrules = SafeFirstSolve[EE /. rules];
-        newrules = Join[rules /. newrules, Association@newrules];
+        newrules = Join[rules /. newrules, Association @ newrules];
         {{True, NN, OR}, Expand /@ newrules}
     ];
 
 TripleStep[{{True, NNs_, ORs_}, rules_Association}] :=
-	{{True, NNs, ORs}, rules}
+    {{True, NNs, ORs}, rules}
 
 TripleStep[{{EEs_, NNs_, ORs_}, rules_Association}] :=
-	Module[{EE = EEs /. rules, NN, OR, NNE, NNO, ORE, ORN, newrules ={}},
-	If[ EE =!= True && EE =!= False,
-    	newrules = SafeFirstSolve[EE]
-    ];
-    newrules = Expand /@ Join[rules /. newrules, Association@newrules];
-    NN = Expand /@ (NNs /. newrules);
-    OR = Expand /@ (ORs /. newrules);
-    {NNE, NN, NNO} = SystemToTriple[NN];
-    {ORE, ORN, OR} = SystemToTriple[OR];
-    EE = NNE && ORE;
-    {{EE, NN, OR}, newrules}
+    Module[{EE = EEs /. rules, NN, OR, NNE, NNO, ORE, ORN, newrules =
+         {}},
+        If[EE =!= True && EE =!= False,
+            newrules = SafeFirstSolve[EE]
+        ];
+        newrules = Expand /@ Join[rules /. newrules, Association @ newrules
+            ];
+        NN = Expand /@ (NNs /. newrules);
+        OR = Expand /@ (ORs /. newrules);
+        {NNE, NN, NNO} = SystemToTriple[NN];
+        {ORE, ORN, OR} = SystemToTriple[OR];
+        EE = NNE && ORE;
+        {{EE, NN, OR}, newrules}
     ];
 
-TripleClean[{{EE_, NN_, OR_}, rules_}] := FixedPoint[TripleStep, {{EE, NN, OR}, rules}];
+TripleClean[{{EE_, NN_, OR_}, rules_}] :=
+    FixedPoint[TripleStep, {{EE, NN, OR}, rules}];
 
 (* --- Backward compatibility aliases --- *)
+
 Data2Equations = DataToEquations;
+
 FinalStep = DNFSolveStep;
 
 End[];


### PR DESCRIPTION
## Summary

- **Add `ReduceDisjuncts` and `SubsumptionPrune`** to `DNFReduce.wl` — a tiered post-reduction step that eliminates redundant disjuncts after `DNFReduce` produces its output
- **Integrate into `DNFSolveStep`** in `DataToEquations.wl`, replacing the previous per-branch `Reduce` + `Simplify` approach
- **Update `CLAUDE.md`** with parallelization docs, `ReduceDisjuncts` docs, WL parallel gotchas, and `TimeDependentSolver` module

### How it works

`ReduceDisjuncts` uses an adaptive strategy based on the number of disjuncts:

| Disjunct count | Strategy | Rationale |
|---------------|----------|-----------|
| ≤ `$ReduceDisjunctsThreshold` (200) | `Reduce[Or @@ branches, Reals]` | Fast and optimal for manageable expressions |
| > 200 | `SubsumptionPrune` then `Reduce` on survivors | Pairwise implication checks eliminate subsumed branches first |

### Profiling results (from `ProfileReductionStrategies.wls`)

| Case | DNFReduce output | After ReduceDisjuncts | Time | Leaf reduction |
|------|-----------------|----------------------|------|----------------|
| Multi_20 (case 20) | 8 disjuncts | **1** | 0.02s | 669 → 47 |
| Braess congest | 179 disjuncts | **1** | 0.14s | 18,944 → 79 |
| Attraction_switch (case 11) | 2,977 disjuncts | **~2** (sampled) | ~36s | 1.2M → TBD |

### Impact

Fewer disjuncts means smaller expressions flowing into downstream `TripleClean`, `Simplify`, `Solve`, and `NonLinearSolver` iterations — potentially large speedups for medium/large cases with switching costs.

## Test plan

- [x] Small tier: 21/21 OK (7 cases × 3 solvers)
- [x] CompareDNF Multi_20: EQUIVALENT
- [ ] Medium tier full benchmark
- [ ] Large tier with Braess variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)