### PR TITLE
Short-circuit infeasible reduced systems in MFGSystemSolver

### DIFF
--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -467,7 +467,9 @@ MFGSystemSolver[Eqs_][approxJs_] :=
              time, " seconds."];
         InitRules = Expand /@ (InitRules /. Ncpc);
         NewSystem = NewSystem /. Ncpc;
-        If[And @@ ((# === False)& /@ NewSystem),
+        (* Any False component makes the reduced system infeasible, so stop
+           before attempting to bucket inequalities by transition flow. *)
+        If[MemberQ[NewSystem, False],
             Message[MFGSystemSolver::nosolution];
             Return[Null, Module]
         ];

--- a/MFGraphs/Tests/infeasible-status.mt
+++ b/MFGraphs/Tests/infeasible-status.mt
@@ -39,3 +39,22 @@ Test[
     ,
     TestID -> "IsFeasible: case 12 is feasible"
 ]
+
+(* Test: MFGSystemSolver short-circuits as soon as the reduced system is infeasible *)
+Test[
+    Quiet[
+        fakeSystem = <|
+            "us" -> {},
+            "js" -> {},
+            "jts" -> {fakeJT},
+            "InitRules" -> <||>,
+            "NewSystem" -> {True, False, True},
+            "costpluscurrents" -> <||>
+        |>;
+        MFGSystemSolver[fakeSystem][<||>] === Null
+    ]
+    ,
+    True
+    ,
+    TestID -> "MFGSystemSolver: early exit when inequality block is False"
+]


### PR DESCRIPTION
## Summary
- stop `MFGSystemSolver` as soon as any reduced-system component is `False`
- avoid bucketing inequalities from an already infeasible system
- add a regression test covering the early-exit path

## Testing
- `wolframscript -file Scripts/RunTests.wls fast`