### PR TITLE
Fix Wolfram GitHub Actions workflow inputs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,26 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      WOLFRAM_ID: ${{ secrets.WOLFRAM_ID }}
+      WOLFRAM_PASS: ${{ secrets.WOLFRAM_PASS }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Wolfram Engine
-        uses: miRoox/wolfram-action@v1
+      - name: Validate Wolfram secrets
+        run: |
+          if [ -z "$WOLFRAM_ID" ]; then
+            echo "::error::Missing repository secret WOLFRAM_ID"
+            exit 1
+          fi
+          if [ -z "$WOLFRAM_PASS" ]; then
+            echo "::error::Missing repository secret WOLFRAM_PASS"
+            exit 1
+          fi
 
       - name: Run Fast Test Suite
-        run: wolframscript -file Scripts/RunTests.wls fast
+        uses: miRoox/wolfram-action@v1
+        with:
+          file: Scripts/RunTests.wls
+          args: fast


### PR DESCRIPTION
## Summary
- wire `miRoox/wolfram-action@v1` as the script runner it actually is
- pass the required `file` and `args` inputs instead of using it as a setup-only step
- fail early with a clear error if `WOLFRAM_ID` or `WOLFRAM_PASS` repository secrets are missing

## Why
The current workflow fails before tests start with:
- `Input 'file' is missing.`

Upstream action metadata and README show that `file` is a required input, and the action also expects `WOLFRAM_ID` / `WOLFRAM_PASS` in the environment.

## Follow-up
- add repository secrets `WOLFRAM_ID` and `WOLFRAM_PASS` if they are not already configured
- re-run the workflow after merging or on this PR once secrets are available