### PR TITLE
Harden Wolfram CI secret handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,24 +6,29 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      WOLFRAM_ID: ${{ secrets.WOLFRAM_ID }}
-      WOLFRAM_PASS: ${{ secrets.WOLFRAM_PASS }}
+    environment:
+      name: wolfram-ci
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate Wolfram secrets
+      - name: Validate Wolfram environment secrets
+        env:
+          WOLFRAM_CI_ID: ${{ secrets.WOLFRAM_CI_ID }}
+          WOLFRAM_CI_PASS: ${{ secrets.WOLFRAM_CI_PASS }}
         run: |
-          if [ -z "$WOLFRAM_ID" ]; then
-            echo "::error::Missing repository secret WOLFRAM_ID"
+          if [ -z "$WOLFRAM_CI_ID" ]; then
+            echo "::error::Missing environment secret WOLFRAM_CI_ID on environment 'wolfram-ci'"
             exit 1
           fi
-          if [ -z "$WOLFRAM_PASS" ]; then
-            echo "::error::Missing repository secret WOLFRAM_PASS"
+          if [ -z "$WOLFRAM_CI_PASS" ]; then
+            echo "::error::Missing environment secret WOLFRAM_CI_PASS on environment 'wolfram-ci'"
             exit 1
           fi
 
@@ -32,3 +37,6 @@ jobs:
         with:
           file: Scripts/RunTests.wls
           args: fast
+        env:
+          WOLFRAM_ID: ${{ secrets.WOLFRAM_CI_ID }}
+          WOLFRAM_PASS: ${{ secrets.WOLFRAM_CI_PASS }}


### PR DESCRIPTION
## Summary
- move Wolfram credentials to a dedicated GitHub Actions environment named `wolfram-ci`
- inject credentials only into the Wolfram action step instead of exposing them to the whole job
- reduce default `GITHUB_TOKEN` permissions to `contents: read`
- require environment-scoped secrets `WOLFRAM_CI_ID` and `WOLFRAM_CI_PASS`

## Why
This is safer than repository-level password secrets because:
- secrets can be isolated to a dedicated environment
- the environment can use protection rules such as required reviewers before the job accesses those secrets
- the credentials are no longer available to unrelated steps in the job

## GitHub setup
Create an environment named `wolfram-ci` and add these environment secrets:
- `WOLFRAM_CI_ID`
- `WOLFRAM_CI_PASS`

Optional hardening:
- add required reviewers on the `wolfram-ci` environment before allowing secret access

## References
- GitHub environments and protection rules: https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment
- GitHub secret scopes: https://docs.github.com/en/code-security/getting-started/understanding-github-secret-types
- Action input contract: https://github.com/miRoox/wolfram-action/blob/v1/action.yml