### PR TITLE
[codex] Add monotone solver comparison contract

### DIFF
--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -426,7 +426,7 @@ CriticalCongestionSolver[$Failed, ___] :=
 
 CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
     Module[{PreEqs, js, AssoCritical, time, temp, status, returnShape,
-         resultKind, message, solution},
+         resultKind, message, solution, comparisonData},
         returnShape = OptionValue["ReturnShape"];
         ClearSolveCache[];
         If[KeyExistsQ[Eqs, "InitRules"],
@@ -461,9 +461,10 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
                     ,
                     Missing["NotAvailable"]
                 ];
+            comparisonData = BuildSolverComparisonData[PreEqs, solution];
             Join[PreEqs, MakeSolverResult["CriticalCongestion", resultKind,
-                 status, message, solution, <|"AssoCritical" -> AssoCritical, "Status"
-                 -> status|>]]
+                 status, message, solution, Join[comparisonData, <|"AssoCritical" -> AssoCritical, "Status"
+                 -> status|>]]]
             ,
             Join[PreEqs, <|"AssoCritical" -> AssoCritical, "Status" ->
                  status|>]

--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -66,6 +66,57 @@ CheckFlowFeasibility[assoc_Association] :=
             "Infeasible", "Feasible"]
     ];
 
+SelectFlowAssociation[assoc_Association] :=
+    Association @ KeySelect[assoc, MatchQ[#, _j] &];
+
+BuildSolverComparisonData[Eqs_Association, solution_] :=
+    Module[{missing, flowAssoc, edgeList, edgePairs, signedFlowRules, signedExprs,
+         signedVals, B, KM, jj, jjVals, residual},
+        missing = Missing["NotAvailable"];
+        edgeList = Lookup[Eqs, "edgeList", {}];
+        If[!AssociationQ[solution],
+            Return[
+                <|
+                    "ComparableEdges" -> edgeList,
+                    "FlowAssociation" -> missing,
+                    "SignedEdgeFlows" -> missing,
+                    "ComparableFlowVector" -> missing,
+                    "KirchhoffResidual" -> missing
+                |>,
+                Module
+            ]
+        ];
+        flowAssoc = SelectFlowAssociation[solution];
+        edgePairs = List @@@ edgeList;
+        signedFlowRules = Lookup[Eqs, "SignedFlows", <||>];
+        signedExprs =
+            (If[KeyExistsQ[signedFlowRules, #], signedFlowRules[#], missing] & /@ edgePairs) /.
+                Join[
+                    Lookup[Eqs, "RuleBalanceGatheringFlows", <||>],
+                    Lookup[Eqs, "RuleExitFlowsIn", <||>],
+                    Lookup[Eqs, "RuleEntryOut", <||>]
+                ];
+        signedVals = Quiet @ Check[signedExprs /. flowAssoc, missing];
+        If[!ListQ[signedVals] || !VectorQ[signedVals, NumericQ],
+            signedVals = missing
+        ];
+        {B, KM, jj} = MFGraphs`GetKirchhoffLinearSystem[Eqs];
+        jjVals = Lookup[flowAssoc, jj, missing];
+        residual =
+            If[ListQ[jjVals] && VectorQ[jjVals, NumericQ],
+                N @ Norm[KM . jjVals - B, Infinity],
+                missing
+            ];
+        <|
+            "ComparableEdges" -> edgeList,
+            "FlowAssociation" -> flowAssoc,
+            "SignedEdgeFlows" ->
+                If[signedVals === missing, missing, AssociationThread[edgeList, signedVals]],
+            "ComparableFlowVector" -> signedVals,
+            "KirchhoffResidual" -> residual
+        |>
+    ];
+
 MakeSolverResult[
     solver_String,
     resultKind_String,

--- a/MFGraphs/Monotone.wl
+++ b/MFGraphs/Monotone.wl
@@ -116,6 +116,80 @@ CachedGradientProjection[x_, KM_, dim_, At_, cache_, tol_:10^-6] :=
     ]
   ];
 
+(* --- BuildMonotoneStateData: shared linear state for MonotoneSolver --- *)
+
+BuildMonotoneStateData[d2e_Association] :=
+  Module[{B, KM, jj, halfPairs, signedFlows, rules, substituted, S},
+    {B, KM, jj} = GetKirchhoffLinearSystem[d2e];
+    halfPairs = List @@@ Lookup[d2e, "edgeList", {}];
+    If[Length[jj] === 0 || Length[halfPairs] === 0,
+      S = SparseArray[{}, {Length[halfPairs], Length[jj]}],
+      signedFlows = Lookup[d2e, "SignedFlows", <||>];
+      rules = Join[
+        Lookup[d2e, "RuleBalanceGatheringFlows", <||>],
+        Lookup[d2e, "RuleExitFlowsIn", <||>],
+        Lookup[d2e, "RuleEntryOut", <||>]
+      ];
+      substituted = (signedFlows[#] & /@ halfPairs) /. rules;
+      S = Last @ CoefficientArrays[substituted, jj]
+    ];
+    <|
+      "B" -> B,
+      "KM" -> KM,
+      "FullVariables" -> jj,
+      "HalfPairs" -> halfPairs,
+      "SignedEdgeMatrix" -> S
+    |>
+  ];
+
+(* Exact affine reduction x = x0 + N . theta for the Kirchhoff manifold.
+   This does not yet implement the paper's edge-current reduction, but it gives
+   a minimal state dimension and lossless reconstruction of the full j[...] state. *)
+BuildReducedKirchhoffCoordinates[d2e_Association, basePoint_:Automatic] :=
+  Module[{stateData, KM, jj, S, nullBasis, basisMatrix, dim, baseVec, edgeOffset,
+      edgeBasis, invisibleDim},
+    stateData = BuildMonotoneStateData[d2e];
+    KM = stateData["KM"];
+    jj = stateData["FullVariables"];
+    S = stateData["SignedEdgeMatrix"];
+    nullBasis = NullSpace[Normal[KM]];
+    basisMatrix = If[nullBasis === {},
+      ConstantArray[0., {Length[jj], 0}],
+      N @ Transpose[nullBasis]
+    ];
+    dim = If[MatrixQ[basisMatrix], Last @ Dimensions[basisMatrix], 0];
+    baseVec = Which[
+      basePoint === Automatic && Length[jj] === 0, {},
+      basePoint === Automatic, Quiet @ Check[
+        N @ LeastSquares[N @ Normal[KM], N @ stateData["B"]],
+        Missing["NotAvailable"]
+      ],
+      True, N @ basePoint
+    ];
+    edgeOffset = If[ListQ[baseVec] && VectorQ[baseVec, NumericQ],
+      N @ (S . baseVec),
+      Missing["NotAvailable"]
+    ];
+    edgeBasis = If[MatrixQ[basisMatrix], N @ (S . basisMatrix), Missing["NotAvailable"]];
+    invisibleDim = Length[NullSpace[Join[Normal[KM], Normal[S]]]];
+    <|
+      "BasePoint" -> baseVec,
+      "BasisMatrix" -> basisMatrix,
+      "StateDimension" -> dim,
+      "FullDimension" -> Length[jj],
+      "CostInvisibleDimension" -> invisibleDim,
+      "SignedEdgeOffset" -> edgeOffset,
+      "SignedEdgeBasis" -> edgeBasis,
+      "FullVariables" -> jj
+    |>
+  ];
+
+ReducedKirchhoffVector[reduced_Association, theta_?NumberVectorQ] :=
+  reduced["BasePoint"] + reduced["BasisMatrix"] . theta;
+
+ReducedKirchhoffAssociation[reduced_Association, theta_?NumberVectorQ] :=
+  AssociationThread[reduced["FullVariables"], ReducedKirchhoffVector[reduced, theta]];
+
 (* --- BuildMonotoneField: lifted edge-cost field on Kirchhoff variables --- *)
 (* 
    This function constructs the vector field for the HRF method by "lifting" 
@@ -127,21 +201,13 @@ CachedGradientProjection[x_, KM_, dim_, At_, cache_, tol_:10^-6] :=
 *)
 
 BuildMonotoneField[d2e_Association] :=
-  Module[{B, KM, jj, halfPairs, signedFlows, rules, substituted, S, fieldFn},
-    {B, KM, jj} = GetKirchhoffLinearSystem[d2e];
+  Module[{stateData, jj, halfPairs, S, fieldFn},
+    stateData = BuildMonotoneStateData[d2e];
+    jj = stateData["FullVariables"];
     If[Length[jj] === 0, Return[{jj, (0 * # &)}, Module]];
-    halfPairs = List @@@ Lookup[d2e, "edgeList", {}];
+    halfPairs = stateData["HalfPairs"];
     If[Length[halfPairs] === 0, Return[{jj, (0 * # &)}, Module]];
-    signedFlows = Lookup[d2e, "SignedFlows", <||>];
-    rules = Join[
-      Lookup[d2e, "RuleBalanceGatheringFlows", <||>],
-      Lookup[d2e, "RuleExitFlowsIn", <||>],
-      Lookup[d2e, "RuleEntryOut", <||>]
-    ];
-    (* Substitute rules into signed flows to get expressions in jj *)
-    substituted = (signedFlows[#] & /@ halfPairs) /. rules;
-    (* S is the sparse coefficient matrix: signed_edge_flows = S . jj *)
-    S = Last @ CoefficientArrays[substituted, jj];
+    S = stateData["SignedEdgeMatrix"];
     fieldFn[x_?NumberVectorQ] := Module[{q, c},
       q = S . x;
       c = MapThread[
@@ -170,25 +236,30 @@ MonotoneSolver[d2e_, opts:OptionsPattern[]] :=
 			potentialFunction,
 			congestionExponentFunction,
 			interactionFunction,
-			Module[{B, KM, jj, cc, x0, result, returnShape, solution, missingSolution},
-				returnShape = OptionValue["ReturnShape"];
-				missingSolution = Missing["NotAvailable"];
-				{B, KM, jj} = GetKirchhoffLinearSystem[d2e];
-				(* Guard: skip MonotoneSolver for degenerate cases with no flow variables *)
-				If[Length[jj] === 0,
-					Message[MonotoneSolver::degenerate];
-					Return[
-						If[returnShape === "Standard",
-							MakeSolverResult[
-								"Monotone",
-								"Degenerate",
-								Missing["NotApplicable"],
-								"DegenerateCase",
-								missingSolution,
-								<|"AssoMonotone" -> missingSolution|>
+				Module[{stateData, reducedState, B, KM, jj, cc, x0, result, returnShape, solution,
+				    missingSolution, comparisonData, reducedMetadata},
+					returnShape = OptionValue["ReturnShape"];
+					missingSolution = Missing["NotAvailable"];
+					stateData = BuildMonotoneStateData[d2e];
+					B = stateData["B"];
+					KM = stateData["KM"];
+					jj = stateData["FullVariables"];
+					(* Guard: skip MonotoneSolver for degenerate cases with no flow variables *)
+					If[Length[jj] === 0,
+						Message[MonotoneSolver::degenerate];
+						Return[
+							If[returnShape === "Standard",
+								comparisonData = BuildSolverComparisonData[d2e, missingSolution];
+								MakeSolverResult[
+									"Monotone",
+									"Degenerate",
+									Missing["NotApplicable"],
+									"DegenerateCase",
+									missingSolution,
+									Join[comparisonData, <|"AssoMonotone" -> missingSolution|>]
+								],
+								<|"Message" -> "Degenerate case"|>
 							],
-							<|"Message" -> "Degenerate case"|>
-						],
 						Module
 					]
 				];
@@ -199,20 +270,21 @@ MonotoneSolver[d2e_, opts:OptionsPattern[]] :=
 					First @ FindInstance[KM . jj == B && And @@ ((# >= 10^-8) & /@ jj), jj, Reals],
 					$Failed
 				];
-				If[result === $Failed,
-					Message[MonotoneSolver::seedfail];
-					Return[
-						If[returnShape === "Standard",
-							MakeSolverResult[
-								"Monotone",
-								"Failure",
-								Missing["NotApplicable"],
-								"SeedFindInstanceFailed",
-								missingSolution,
-								<|"AssoMonotone" -> missingSolution|>
+					If[result === $Failed,
+						Message[MonotoneSolver::seedfail];
+						Return[
+							If[returnShape === "Standard",
+								comparisonData = BuildSolverComparisonData[d2e, missingSolution];
+								MakeSolverResult[
+									"Monotone",
+									"Failure",
+									Missing["NotApplicable"],
+									"SeedFindInstanceFailed",
+									missingSolution,
+									Join[comparisonData, <|"AssoMonotone" -> missingSolution|>]
+								],
+								Null
 							],
-							Null
-						],
 						Module
 					]
 				];
@@ -220,19 +292,26 @@ MonotoneSolver[d2e_, opts:OptionsPattern[]] :=
 				(* No edges → zero cost field → feasible point is already the solution *)
 				solution = If[Length[Lookup[d2e, "edgeList", {}]] === 0,
 					AssociationThread[jj, x0],
-					MonotoneSolverODE[x0, KM, jj, cc, FilterRules[{opts}, Options[MonotoneSolverODE]]]
-				];
-				If[returnShape === "Standard",
-					MakeSolverResult[
-						"Monotone",
-						"Success",
-						Missing["NotApplicable"],
-						None,
-						solution,
-						<|"AssoMonotone" -> solution|>
-					],
-					solution
-				]
+						MonotoneSolverODE[x0, KM, jj, cc, FilterRules[{opts}, Options[MonotoneSolverODE]]]
+					];
+					If[returnShape === "Standard",
+						reducedState = BuildReducedKirchhoffCoordinates[d2e, x0];
+						comparisonData = BuildSolverComparisonData[d2e, solution];
+						reducedMetadata = <|
+							"ReducedStateDimension" -> reducedState["StateDimension"],
+							"FullStateDimension" -> reducedState["FullDimension"],
+							"CostInvisibleDimension" -> reducedState["CostInvisibleDimension"]
+						|>;
+						MakeSolverResult[
+							"Monotone",
+							"Success",
+							Missing["NotApplicable"],
+							None,
+							solution,
+							Join[comparisonData, reducedMetadata, <|"AssoMonotone" -> solution|>]
+						],
+						solution
+					]
 			]
 		]
 	];

--- a/MFGraphs/NonLinearSolver.wl
+++ b/MFGraphs/NonLinearSolver.wl
@@ -103,7 +103,7 @@ NonLinearSolver[Eqs_, OptionsPattern[]] :=
             Module[ {AssoCritical, PreEqs = Eqs, AssoNonCritical, NonCriticalList, js,
              MaxIter = OptionValue["MaxIterations"], tol = OptionValue["Tolerance"],
              returnShape = OptionValue["ReturnShape"], status, flowKeys, flowVals,
-             resultKind, message, solution},
+             resultKind, message, solution, comparisonData},
                 If[ KeyExistsQ[PreEqs, "AssoCritical"],
                     (* If there is already an approximation for the non-congestion case, use it *)
                     AssoNonCritical = Lookup[PreEqs, "AssoNonCritical", PreEqs["AssoCritical"]],
@@ -134,6 +134,7 @@ NonLinearSolver[Eqs_, OptionsPattern[]] :=
                     resultKind = If[AssoNonCritical === Null, "Failure", "Success"];
                     message = If[AssoNonCritical === Null, "NoSolution", None];
                     solution = If[AssociationQ[AssoNonCritical], AssoNonCritical, Missing["NotAvailable"]];
+                    comparisonData = BuildSolverComparisonData[PreEqs, solution];
                     Join[
                         PreEqs,
                         MakeSolverResult[
@@ -142,11 +143,11 @@ NonLinearSolver[Eqs_, OptionsPattern[]] :=
                             status,
                             message,
                             solution,
-                            <|
+                            Join[comparisonData, <|
                                 "AssoCritical" -> AssoCritical,
                                 "AssoNonCritical" -> AssoNonCritical,
                                 "Status" -> status
-                            |>
+                            |>]
                         ]
                     ],
                     Join[PreEqs, <|"AssoCritical" -> AssoCritical, "AssoNonCritical" -> AssoNonCritical, "Status" -> status|>]

--- a/MFGraphs/Tests/solver-contracts.mt
+++ b/MFGraphs/Tests/solver-contracts.mt
@@ -10,6 +10,10 @@ Test[
             {"CriticalCongestion", "Success", "Feasible", None} &&
         AssociationQ[result["AssoCritical"]] &&
         result["Solution"] === result["AssoCritical"] &&
+        AssociationQ[result["FlowAssociation"]] &&
+        AssociationQ[result["SignedEdgeFlows"]] &&
+        VectorQ[result["ComparableFlowVector"], NumericQ] &&
+        NumericQ[result["KirchhoffResidual"]] &&
         IsFeasible[result]
     ]
     ,
@@ -36,6 +40,10 @@ Test[
             {"NonLinear", "Success", "Feasible", None} &&
         AssociationQ[result["AssoNonCritical"]] &&
         result["Solution"] === result["AssoNonCritical"] &&
+        AssociationQ[result["FlowAssociation"]] &&
+        AssociationQ[result["SignedEdgeFlows"]] &&
+        VectorQ[result["ComparableFlowVector"], NumericQ] &&
+        NumericQ[result["KirchhoffResidual"]] &&
         IsFeasible[result]
     ]
     ,
@@ -60,7 +68,13 @@ Test[
         Lookup[result, {"Solver", "ResultKind", "Message"}] ===
             {"Monotone", "Success", None} &&
         AssociationQ[result["AssoMonotone"]] &&
-        result["Solution"] === result["AssoMonotone"]
+        result["Solution"] === result["AssoMonotone"] &&
+        AssociationQ[result["FlowAssociation"]] &&
+        AssociationQ[result["SignedEdgeFlows"]] &&
+        VectorQ[result["ComparableFlowVector"], NumericQ] &&
+        NumericQ[result["KirchhoffResidual"]] &&
+        IntegerQ[result["ReducedStateDimension"]] &&
+        IntegerQ[result["FullStateDimension"]]
     ]
     ,
     True
@@ -124,4 +138,62 @@ Test[
     True
     ,
     TestID -> "GetKirchhoffLinearSystem matches GetKirchhoffMatrix core outputs"
+]
+
+Test[
+    Module[{data, d2e, critical, nonlinear, monotone, cVec, nVec, mVec},
+        data = GetExampleData[3] /. {I1 -> 80, U1 -> 0};
+        d2e = DataToEquations[data];
+        critical = Quiet[CriticalCongestionSolver[d2e, "ReturnShape" -> "Standard"]];
+        nonlinear = Quiet[
+            NonLinearSolver[
+                d2e,
+                "MaxIterations" -> 2,
+                "ReturnShape" -> "Standard",
+                "PotentialFunction" -> Function[{x, edge}, 0],
+                "CongestionExponentFunction" -> Function[edge, 1],
+                "InteractionFunction" -> Function[{m, edge}, -1/m^2]
+            ]
+        ];
+        monotone = Quiet[
+            MonotoneSolverFromData[
+                data,
+                "TimeSteps" -> 20,
+                "ReturnShape" -> "Standard",
+                "PotentialFunction" -> Function[{x, edge}, 0],
+                "CongestionExponentFunction" -> Function[edge, 1],
+                "InteractionFunction" -> Function[{m, edge}, -1/m^2]
+            ]
+        ];
+        cVec = critical["ComparableFlowVector"];
+        nVec = nonlinear["ComparableFlowVector"];
+        mVec = monotone["ComparableFlowVector"];
+        critical["ComparableEdges"] === nonlinear["ComparableEdges"] &&
+        nonlinear["ComparableEdges"] === monotone["ComparableEdges"] &&
+        Max[Abs[cVec - nVec]] < 10^-5 &&
+        Max[Abs[cVec - mVec]] < 10^-4 &&
+        monotone["KirchhoffResidual"] < 10^-6
+    ]
+    ,
+    True
+    ,
+    TestID -> "Standard return shape: comparable signed edge flows across solvers"
+]
+
+Test[
+    Module[{data, d2e, b, k, jj, seed, reduced},
+        data = GetExampleData[7] /. {I1 -> 80, U1 -> 0, U2 -> 10};
+        d2e = DataToEquations[data];
+        {b, k, jj} = GetKirchhoffLinearSystem[d2e];
+        seed = First @ FindInstance[k . jj == b && And @@ Thread[jj >= 10^-8], jj, Reals];
+        reduced = MFGraphs`Private`BuildReducedKirchhoffCoordinates[d2e, N[jj /. seed]];
+        reduced["StateDimension"] === Length[jj] - MatrixRank[Normal[k]] &&
+        reduced["FullDimension"] === Length[jj] &&
+        Max[Abs[k . reduced["BasePoint"] - b]] < 10^-7 &&
+        Dimensions[reduced["BasisMatrix"]] === {Length[jj], reduced["StateDimension"]}
+    ]
+    ,
+    True
+    ,
+    TestID -> "Monotone reduced state: affine basis matches Kirchhoff dimension"
 ]


### PR DESCRIPTION
## What changed

This PR introduces a shared comparison contract for the stationary solvers and starts the monotone solver reduction work needed for paper-aligned cleanup.

- adds standardized comparison fields to standard solver results: `FlowAssociation`, `SignedEdgeFlows`, `ComparableEdges`, `ComparableFlowVector`, and `KirchhoffResidual`
- wires those fields into `CriticalCongestionSolver`, `NonLinearSolver`, and `MonotoneSolver`
- adds affine reduced-state plumbing for the monotone solver so we can reconstruct the full `j[...]` association from a minimal Kirchhoff-manifold basis
- exposes monotone reduced-state metadata in standard results: `ReducedStateDimension`, `FullStateDimension`, and `CostInvisibleDimension`
- extends solver contract tests to verify cross-solver comparability and reduced-state consistency

## Why it changed

The monotone solver was difficult to compare against the critical congestion and nonlinear solvers because each solver exposed different result surfaces. We also needed concrete reduced-state scaffolding before rewriting the monotone ODE off the oversized transition-variable state.

## Root cause

The monotone implementation currently evolves a larger transition-flow state than the Hessian Riemannian Flow paper assumes, while the other stationary solvers are naturally consumed through reconstructed flow associations. Without a shared output contract and an explicit reduced-state map, it was hard to verify solver agreement or stage the later performance fix safely.

## Impact

- solver outputs are now directly comparable on signed edge flows and Kirchhoff feasibility
- future monotone work can switch the ODE to reduced coordinates without changing the public result shape
- tests now lock in the comparability contract across all three stationary solvers

## Validation

- `wolframscript -file Scripts/RunTests.wls fast`
