### PR TITLE
feat/fix: Monotone strict HJB gating, ODE warm-start fallback, and benchmark process isolation

### DIFF
--- a/MFGraphs/Monotone.wl
+++ b/MFGraphs/Monotone.wl
@@ -450,11 +450,25 @@ CleanCriticalQuadraticSolution[model_Association, rawSolution_List] :=
   ];
 
 TryCriticalQuadraticMonotoneSolve[d2e_Association, residualTolerance_:10^-6] :=
-  Module[{model, vars, rawSolution, time, solution, comparisonData, status,
-      reducedMetadata, convergenceData, resultKind, message, optimizer},
+  Module[{model, vars, rawSolution, time = 0., solution, comparisonData, status,
+      reducedMetadata, convergenceData, optimizer, nonLinearResidual,
+      kirchhoffResidual, isValidShortcut, telemetry, rejectReason, finalResult},
     model = BuildCriticalQuadraticObjective[d2e];
     If[model === $Failed,
-      Return[$Failed, Module]
+      Return[
+        <|
+          "Outcome" -> "Unavailable",
+          "Telemetry" -> <|
+            "QuadraticShortcutAttempted" -> False,
+            "QuadraticShortcutAccepted" -> False,
+            "QuadraticShortcutNonLinearResidual" -> Missing["NotComputed"],
+            "QuadraticShortcutKirchhoffResidual" -> Missing["NotComputed"],
+            "QuadraticShortcutSolveTime" -> 0.,
+            "QuadraticShortcutRejectReason" -> "ModelUnavailable"
+          |>
+        |>,
+        Module
+      ]
     ];
     vars = model["Variables"];
     reducedMetadata = BuildReducedKirchhoffMetadata[model["StateData"]];
@@ -472,41 +486,78 @@ TryCriticalQuadraticMonotoneSolve[d2e_Association, residualTolerance_:10^-6] :=
         $Failed
       ];
     If[!MatchQ[rawSolution, {_Rule ..}],
-      Return[$Failed, Module]
+      telemetry = <|
+        "QuadraticShortcutAttempted" -> True,
+        "QuadraticShortcutAccepted" -> False,
+        "QuadraticShortcutNonLinearResidual" -> Missing["NotComputed"],
+        "QuadraticShortcutKirchhoffResidual" -> Missing["NotComputed"],
+        "QuadraticShortcutSolveTime" -> time,
+        "QuadraticShortcutRejectReason" -> "OptimizerFailed"
+      |>;
+      Return[<|"Outcome" -> "Unavailable", "Telemetry" -> telemetry|>, Module]
     ];
     solution = AssociationThread[vars, N[vars /. rawSolution]];
+    solution = ReconstructUtilities[solution, d2e];
     comparisonData = BuildMonotoneComparisonData[d2e, model["StateData"], solution];
+    nonLinearResidual = ComputeMonotoneEquationResidual[d2e, solution];
+    comparisonData = Join[comparisonData, <|"NonLinearResidual" -> nonLinearResidual|>];
     status = CheckFlowFeasibility[solution];
-    convergenceData = <|
-      "StopReason" -> "QuadraticCriticalSolve",
-      "FinalResidual" -> Lookup[comparisonData, "KirchhoffResidual", Missing["NotAvailable"]],
-      "Iterations" -> 0,
-      "SolveTime" -> time,
-      "SeedMethod" -> "QuadraticCriticalSolve"
-    |>;
-    resultKind =
-      If[
+    kirchhoffResidual = Lookup[comparisonData, "KirchhoffResidual", Missing["NotAvailable"]];
+    isValidShortcut =
+      TrueQ[
         status === "Feasible" &&
-        NumericQ[Lookup[comparisonData, "KirchhoffResidual", Missing["NotAvailable"]]] &&
-        Lookup[comparisonData, "KirchhoffResidual", Infinity] <= residualTolerance,
-        "Success",
-        "NonConverged"
+        NumericQ[nonLinearResidual] &&
+        nonLinearResidual <= residualTolerance &&
+        NumericQ[kirchhoffResidual] &&
+        kirchhoffResidual <= residualTolerance
       ];
-    message = If[resultKind === "Success", None, "QuadraticCriticalSolveFailed"];
-    MakeSolverResult[
-      "Monotone",
-      resultKind,
-      status,
-      message,
-      solution,
-      Join[
-        comparisonData,
-        reducedMetadata,
-        <|
-          "AssoMonotone" -> solution,
-          "Convergence" -> convergenceData
-        |>
-      ]
+    rejectReason =
+      Which[
+        isValidShortcut, None,
+        status =!= "Feasible", "FlowInfeasible",
+        !NumericQ[nonLinearResidual], "ResidualNotComputable",
+        nonLinearResidual > residualTolerance, "NonLinearResidualExceedsTolerance",
+        !NumericQ[kirchhoffResidual], "KirchhoffResidualNotComputable",
+        kirchhoffResidual > residualTolerance, "KirchhoffResidualExceedsTolerance",
+        True, "Unknown"
+      ];
+    telemetry = <|
+      "QuadraticShortcutAttempted" -> True,
+      "QuadraticShortcutAccepted" -> isValidShortcut,
+      "QuadraticShortcutNonLinearResidual" -> nonLinearResidual,
+      "QuadraticShortcutKirchhoffResidual" -> kirchhoffResidual,
+      "QuadraticShortcutSolveTime" -> time,
+      "QuadraticShortcutRejectReason" -> rejectReason
+    |>;
+    If[isValidShortcut,
+      convergenceData = <|
+        "StopReason" -> "QuadraticCriticalSolve",
+        "FinalResidual" -> kirchhoffResidual,
+        "Iterations" -> 0,
+        "SolveTime" -> time,
+        "SeedMethod" -> "QuadraticCriticalSolve"
+      |>;
+      finalResult = MakeSolverResult[
+        "Monotone",
+        "Success",
+        "Feasible",
+        None,
+        solution,
+        Join[
+          comparisonData,
+          reducedMetadata,
+          <|
+            "AssoMonotone" -> solution,
+            "Convergence" -> Join[convergenceData, telemetry]
+          |>
+        ]
+      ];
+      <|"Outcome" -> "Accepted", "Result" -> finalResult, "Telemetry" -> telemetry|>,
+      <|
+        "Outcome" -> "Rejected",
+        "Telemetry" -> telemetry,
+        "CandidateSolution" -> solution
+      |>
     ]
   ];
 
@@ -610,6 +661,78 @@ BuildMonotonePairCostAssociation[halfPairs_List, edgeList_List, q_?NumberVectorQ
       ]
     ],
     {halfPairs, edgeList, q}
+  ];
+
+ComputeMonotoneEquationResidual[d2e_Association, solution_Association] :=
+  Module[{nlhs, nrhs, diff},
+    nlhs = Lookup[d2e, "Nlhs", {}];
+    nrhs = Lookup[d2e, "Nrhs", {}];
+    If[
+      !ListQ[nlhs] || !ListQ[nrhs] || nlhs === {} || nrhs === {} ||
+      Length[nlhs] =!= Length[nrhs],
+      Return[Missing["NoData"], Module]
+    ];
+    diff = Quiet @ Check[(nlhs - nrhs) /. solution, $Failed];
+    If[diff === $Failed,
+      Return[Missing["ComputeError"], Module]
+    ];
+    diff = Quiet @ Check[N @ diff, $Failed];
+    If[diff === $Failed || !VectorQ[diff, NumericQ],
+      Missing["NotComputable"],
+      Quiet @ Check[N @ Norm[diff, Infinity], Missing["ComputeError"]]
+    ]
+  ];
+
+ReconstructMonotoneEdgeFlows[solution_Association, d2e_Association] :=
+  Module[{entryInRules, flowRules, replacementRules, resolve, edgeFlows},
+    entryInRules = Association @ Flatten[ToRules /@ Lookup[d2e, "EqEntryIn", {}]];
+    flowRules = Join[
+      entryInRules,
+      Lookup[d2e, "RuleEntryOut", <||>],
+      Lookup[d2e, "RuleExitFlowsIn", <||>],
+      Lookup[d2e, "RuleBalanceGatheringFlows", <||>]
+    ];
+    replacementRules = Join[Normal[solution], Normal[flowRules]];
+    resolve[expr_] := FixedPoint[ReplaceAll[#, replacementRules] &, expr, 10];
+    edgeFlows = Association @ Cases[
+      Map[
+        Function[{var},
+          Module[{val},
+            val = Quiet @ Check[N @ resolve[var], Missing["NotAvailable"]];
+            If[NumericQ[val], var -> val, Nothing]
+          ]
+        ],
+        Lookup[d2e, "js", {}]
+      ],
+      _Rule
+    ];
+    Join[edgeFlows, solution]
+  ];
+
+ReconstructUtilities[solution_Association, d2e_Association] :=
+  Module[{solutionWithFlows, stateData, jj, jjVals, halfPairs, edgeList, q,
+      pairCosts, valueSystem, utilityAsso},
+    solutionWithFlows = ReconstructMonotoneEdgeFlows[solution, d2e];
+    stateData = BuildMonotoneStateData[d2e];
+    jj = stateData["FullVariables"];
+    jjVals = Lookup[solutionWithFlows, jj, Missing["NotAvailable"]];
+    If[!ListQ[jjVals] || !VectorQ[jjVals, NumericQ],
+      Return[solutionWithFlows, Module]
+    ];
+    halfPairs = stateData["HalfPairs"];
+    edgeList = Lookup[d2e, "edgeList", {}];
+    q = If[Length[halfPairs] === 0, {}, N @ (stateData["SignedEdgeMatrix"] . jjVals)];
+    pairCosts =
+      If[Length[halfPairs] === 0,
+        <||>,
+        BuildMonotonePairCostAssociation[halfPairs, edgeList, q]
+      ];
+    valueSystem = BuildMonotoneValueSystem[d2e];
+    utilityAsso = Lookup[valueSystem, "StateValueAssociation", (<||> &)][pairCosts];
+    If[AssociationQ[utilityAsso],
+      Join[utilityAsso, solutionWithFlows],
+      solutionWithFlows
+    ]
   ];
 
 BuildMonotoneField[d2e_Association] :=
@@ -716,9 +839,14 @@ MonotoneSolver[d2e_, opts:OptionsPattern[]] :=
 			interactionFunction,
 				Module[{stateData, reducedState, B, KM, jj, cc, x0, result, solution, odeResult,
 				    missingSolution, comparisonData, reducedMetadata, convergenceData,
-                    resultKind, message, residualTolerance, status},
+                    resultKind, message, residualTolerance, status, nonLinearResidual,
+                    residualViolationQ, shortcutCandidate, shortcutOutcome,
+                    shortcutTelemetry, defaultShortcutTelemetry, candidateSolution,
+                    warmStartVector, seedMethod, warmStartFloor},
 					missingSolution = Missing["NotAvailable"];
                     residualTolerance = N @ OptionValue["ResidualTolerance"];
+                    warmStartFloor = 10^-6;
+                    seedMethod = "InteriorFindInstance";
 					stateData = BuildMonotoneStateData[d2e];
 					B = stateData["B"];
 					KM = stateData["KM"];
@@ -749,41 +877,70 @@ MonotoneSolver[d2e_, opts:OptionsPattern[]] :=
 					]
 					];
 					(* Build the lifted edge-cost field *)
-                    result = TryCriticalQuadraticMonotoneSolve[d2e, residualTolerance];
-                    If[AssociationQ[result],
-                        Return[result]
+                    defaultShortcutTelemetry = <|
+                        "QuadraticShortcutAttempted" -> False,
+                        "QuadraticShortcutAccepted" -> False,
+                        "QuadraticShortcutNonLinearResidual" -> Missing["NotComputed"],
+                        "QuadraticShortcutKirchhoffResidual" -> Missing["NotComputed"],
+                        "QuadraticShortcutSolveTime" -> 0.,
+                        "QuadraticShortcutRejectReason" -> "ModelUnavailable"
+                    |>;
+                    shortcutCandidate = TryCriticalQuadraticMonotoneSolve[d2e, residualTolerance];
+                    shortcutOutcome = Lookup[shortcutCandidate, "Outcome", "Unavailable"];
+                    shortcutTelemetry = Lookup[shortcutCandidate, "Telemetry", defaultShortcutTelemetry];
+                    candidateSolution = Lookup[shortcutCandidate, "CandidateSolution", Missing["NotAvailable"]];
+                    If[
+                        shortcutOutcome === "Accepted" &&
+                        AssociationQ[shortcutCandidate] &&
+                        KeyExistsQ[shortcutCandidate, "Result"],
+                        Return[shortcutCandidate["Result"]]
                     ];
 					{jj, cc} = BuildMonotoneField[d2e];
-					(* Find numerically interior feasible seed *)
-					result = Quiet @ Check[
-						First @ FindInstance[KM . jj == B && And @@ ((# >= 10^-8) & /@ jj), jj, Reals],
-					$Failed
-				];
-					If[result === $Failed,
-						Message[MonotoneSolver::seedfail];
-                        comparisonData = BuildSolverComparisonData[d2e, missingSolution];
-                        convergenceData = <|
-                            "StopReason" -> "SeedFindInstanceFailed",
-                            "FinalResidual" -> Missing["NotApplicable"],
-                            "Iterations" -> 0,
-                            "SolveTime" -> 0.,
-                            "SeedMethod" -> "InteriorFindInstance"
-                        |>;
-						Return[
-							MakeSolverResult[
-								"Monotone",
-								"Failure",
-								Missing["NotApplicable"],
-								"SeedFindInstanceFailed",
-								missingSolution,
-								Join[comparisonData, <|
-                                    "AssoMonotone" -> missingSolution,
-                                    "Convergence" -> convergenceData
-                                |>]
-								]
-					]
-				];
-				x0 = N[jj /. result];
+                    (* Warm start from rejected quadratic candidate when available *)
+                    warmStartVector =
+                        If[AssociationQ[candidateSolution],
+                            Lookup[candidateSolution, jj, Missing["NotAvailable"]],
+                            Missing["NotAvailable"]
+                        ];
+                    If[ListQ[warmStartVector] && VectorQ[warmStartVector, NumericQ],
+                        x0 = N @ Map[Max[#, warmStartFloor] &, warmStartVector];
+                        seedMethod = "QuadraticWarmStart";
+                        ,
+                        (* Find numerically interior feasible seed *)
+                        result = Quiet @ Check[
+                            First @ FindInstance[KM . jj == B && And @@ ((# >= 10^-8) & /@ jj), jj, Reals],
+                        $Failed
+                    ];
+                        If[result === $Failed,
+                            Message[MonotoneSolver::seedfail];
+                            comparisonData = BuildSolverComparisonData[d2e, missingSolution];
+                            convergenceData = Join[
+                                <|
+                                    "StopReason" -> "SeedFindInstanceFailed",
+                                    "FinalResidual" -> Missing["NotApplicable"],
+                                    "Iterations" -> 0,
+                                    "SolveTime" -> 0.,
+                                    "SeedMethod" -> seedMethod
+                                |>,
+                                shortcutTelemetry
+                            ];
+                            Return[
+                                MakeSolverResult[
+                                    "Monotone",
+                                    "Failure",
+                                    Missing["NotApplicable"],
+                                    "SeedFindInstanceFailed",
+                                    missingSolution,
+                                    Join[comparisonData, <|
+                                        "AssoMonotone" -> missingSolution,
+                                        "Convergence" -> convergenceData
+                                    |>]
+                                    ]
+                        ]
+                    ];
+                        x0 = N[jj /. result];
+                    ];
+                    shortcutTelemetry = Join[shortcutTelemetry, <|"SeedMethod" -> seedMethod|>];
                     reducedState = BuildReducedKirchhoffCoordinates[d2e, x0];
 				(* No edges → zero cost field → feasible point is already the solution *)
 				odeResult = If[Length[Lookup[d2e, "edgeList", {}]] === 0,
@@ -794,20 +951,23 @@ MonotoneSolver[d2e_, opts:OptionsPattern[]] :=
                                 "FinalResidual" -> 0.,
                                 "Iterations" -> 0,
                                 "SolveTime" -> 0.,
-                                "SeedMethod" -> "InteriorFindInstance"
+                                "SeedMethod" -> seedMethod
                             |>
                         |>,
 						MonotoneSolverODE[reducedState, KM, B, cc, FilterRules[{opts}, Options[MonotoneSolverODE]]]
 					];
                     solution = Lookup[odeResult, "Solution", missingSolution];
-                    convergenceData = Lookup[odeResult, "Convergence",
-                        <|
-                            "StopReason" -> "ODEFailure",
-                            "FinalResidual" -> Missing["NotAvailable"],
-                            "Iterations" -> 0,
-                            "SolveTime" -> 0.,
-                            "SeedMethod" -> "InteriorFindInstance"
-                        |>
+                    convergenceData = Join[
+                        Lookup[odeResult, "Convergence",
+                            <|
+                                "StopReason" -> "ODEFailure",
+                                "FinalResidual" -> Missing["NotAvailable"],
+                                "Iterations" -> 0,
+                                "SolveTime" -> 0.,
+                                "SeedMethod" -> seedMethod
+                            |>
+                        ],
+                        shortcutTelemetry
                     ];
                     If[MissingQ[solution],
                         Message[MonotoneSolver::odefail];
@@ -826,10 +986,16 @@ MonotoneSolver[d2e_, opts:OptionsPattern[]] :=
                             ]
                         ]
                     ];
+					solution = ReconstructUtilities[solution, d2e];
 					comparisonData = BuildSolverComparisonData[d2e, solution];
+                    nonLinearResidual = ComputeMonotoneEquationResidual[d2e, solution];
+                    comparisonData = Join[comparisonData, <|"NonLinearResidual" -> nonLinearResidual|>];
                     status = CheckFlowFeasibility[solution];
+                    residualViolationQ =
+                        NumericQ[nonLinearResidual] && nonLinearResidual > residualTolerance;
                     resultKind =
                         If[
+                            !residualViolationQ &&
                             status === "Feasible" &&
                             NumericQ[Lookup[convergenceData, "FinalResidual", Missing["NotAvailable"]]] &&
                             Lookup[convergenceData, "FinalResidual", Infinity] <= residualTolerance &&
@@ -838,9 +1004,11 @@ MonotoneSolver[d2e_, opts:OptionsPattern[]] :=
                             "Success",
                             "NonConverged"
                         ];
+                    If[residualViolationQ, status = "Infeasible"];
                     message =
                         Which[
                             resultKind === "Success", None,
+                            residualViolationQ, "ResidualExceedsTolerance",
                             status =!= "Feasible", "InfeasibleProjectedSolution",
                             True, Lookup[convergenceData, "StopReason", "NonConverged"]
                         ];
@@ -909,7 +1077,7 @@ MonotoneSolverODE[reduced_Association, KM_, B_, cc_, opts:OptionsPattern[]] :=
                         MaxSteps -> maxSteps,
                         StepMonitor :> (iterations++)
                     ],
-                    {NDSolveValue::mxst}
+                    {NDSolveValue::mxst, NDSolveValue::nbnum1}
                 ];
                 messages = $MessageList;
                 sol

--- a/Scripts/BenchmarkHelpers.wls
+++ b/Scripts/BenchmarkHelpers.wls
@@ -58,7 +58,8 @@ SafeExecuteIsolated[expr_, timeout_:300, opts:OptionsPattern[]] :=
       rawResult = Missing["NotAvailable"], status = "FAILED", result = Missing["Failed"],
       stderr = "", heldExpr, concretizedExpr, exprString, scriptLines, processTimeout,
       proc, startTime, timedOut = False, info = <||>, stdout = "", startOK = False,
-      ignored, procStatus = "Unknown"},
+      ignored, procStatus = "Unknown", rawPayload = Missing["NotAvailable"],
+      childTime = Missing["NotAvailable"], childMem = Missing["NotAvailable"]},
 
     kernelPath = OptionValue["KernelPath"];
     buffer = OptionValue["ProcessTimeBuffer"];
@@ -81,15 +82,20 @@ SafeExecuteIsolated[expr_, timeout_:300, opts:OptionsPattern[]] :=
       "SetDirectory[" <> ToString[InputForm[Directory[]]] <> "];",
       "PrependTo[$Path, Directory[]];",
       "Needs[\"MFGraphs`\"];",
-      "res = TimeConstrained[",
-      "  Check[",
-      "    " <> exprString <> ",",
-      "    $Failed",
-      "  ],",
-      "  " <> ToString[InputForm[N[timeout]]] <> ",",
-      "  \"TIMEOUT\"",
+      "Quiet[Check[ResetMaxMemoryUsed[], Null]];",
+      "{innerTime, rawRes} = AbsoluteTiming[",
+      "  TimeConstrained[",
+      "    Check[",
+      "      " <> exprString <> ",",
+      "      $Failed",
+      "    ],",
+      "    " <> ToString[InputForm[N[timeout]]] <> ",",
+      "    \"TIMEOUT\"",
+      "  ]",
       "];",
-      "Export[" <> ToString[InputForm[outFile]] <> ", res, \"WXF\"];"
+      "childMem = Quiet @ Check[MaxMemoryUsed[], Missing[\"NotAvailable\"]];",
+      "payload = <|\"Result\" -> rawRes, \"InnerSolveTime\" -> innerTime, \"ChildMaxMemoryUsed\" -> childMem|>;",
+      "Export[" <> ToString[InputForm[outFile]] <> ", payload, \"WXF\"];"
     };
     Export[scriptFile, StringRiffle[scriptLines, "\n"], "Text"];
 
@@ -134,7 +140,16 @@ SafeExecuteIsolated[expr_, timeout_:300, opts:OptionsPattern[]] :=
       status =
         If[timedOut, "TIMEOUT", "FAILED"];
       result = Missing[If[status === "TIMEOUT", "Timeout", "KernelPanic"]],
-      rawResult = Quiet @ Check[Import[outFile, "WXF"], $Failed];
+      rawPayload = Quiet @ Check[Import[outFile, "WXF"], $Failed];
+      If[AssociationQ[rawPayload] && KeyExistsQ[rawPayload, "Result"],
+        rawResult = Lookup[rawPayload, "Result", $Failed];
+        childTime = Lookup[rawPayload, "InnerSolveTime", Missing["NotAvailable"]];
+        childMem = Lookup[rawPayload, "ChildMaxMemoryUsed", Missing["NotAvailable"]];
+        ,
+        rawResult = $Failed;
+        childTime = Missing["NotAvailable"];
+        childMem = Missing["NotAvailable"]
+      ];
       Which[
         rawResult === "TIMEOUT",
           status = "TIMEOUT";
@@ -153,9 +168,12 @@ SafeExecuteIsolated[expr_, timeout_:300, opts:OptionsPattern[]] :=
 
     <|
       "Time" -> runTime,
-      "Memory" -> Missing["IsolatedProcess"],
+      "WallTime" -> runTime,
+      "Memory" -> childMem,
       "Status" -> status,
       "Result" -> result,
+      "InnerSolveTime" -> childTime,
+      "ChildMaxMemoryUsed" -> childMem,
       "ExecutionMode" -> "Process",
       "ExitCode" -> Lookup[runResult, "ExitCode", Missing["NotAvailable"]],
       "StandardError" -> stderr
@@ -175,16 +193,24 @@ ComputeResidual::usage =
 solKey should be \"AssoCritical\", \"AssoNonCritical\", or \"AssoMonotone\".";
 
 ComputeResidual[eqs_Association, solKey_String:"AssoNonCritical"] :=
-  Module[{sol, nlhs, nrhs},
+  Module[{sol, nlhs, nrhs, diff},
     sol = Lookup[eqs, solKey, <||>];
     nlhs = Lookup[eqs, "Nlhs", {}];
     nrhs = Lookup[eqs, "Nrhs", {}];
-    If[sol === <||> || nlhs === {} || nrhs === {},
-      Missing["NoData"],
-      Quiet @ Check[
-        Norm[N[nlhs /. sol] - (nrhs /. sol), Infinity],
-        Missing["ComputeError"]
-      ]
+    If[
+      !AssociationQ[sol] || sol === <||> ||
+      !ListQ[nlhs] || !ListQ[nrhs] || nlhs === {} || nrhs === {} ||
+      Length[nlhs] =!= Length[nrhs],
+      Return[Missing["NoData"], Module]
+    ];
+    diff = Quiet @ Check[(nlhs - nrhs) /. sol, $Failed];
+    If[diff === $Failed,
+      Return[Missing["ComputeError"], Module]
+    ];
+    diff = Quiet @ Check[N @ diff, $Failed];
+    If[diff === $Failed || !VectorQ[diff, NumericQ],
+      Missing["NotComputable"],
+      Quiet @ Check[N @ Norm[diff, Infinity], Missing["ComputeError"]]
     ]
   ];
 

--- a/Scripts/BenchmarkHelpers.wls
+++ b/Scripts/BenchmarkHelpers.wls
@@ -13,7 +13,22 @@ Status is \"OK\", \"TIMEOUT\", or \"FAILED\".";
 
 SetAttributes[SafeExecute, HoldFirst];
 
-SafeExecute[expr_, timeout_:300] :=
+SafeExecuteIsolated::usage =
+"SafeExecuteIsolated[expr, timeout] evaluates expr in an isolated child wolframscript process.
+Returns the same status envelope as SafeExecute and prevents child-kernel crashes from
+terminating the benchmark master process.";
+
+Options[SafeExecuteIsolated] = {
+  "KernelPath" -> "wolframscript",
+  "ProcessTimeBuffer" -> 5
+};
+
+$SafeExecuteMode = "InProcess";
+
+SetAttributes[SafeExecuteIsolated, HoldFirst];
+SetAttributes[SafeExecuteInProcess, HoldFirst];
+
+SafeExecuteInProcess[expr_, timeout_:300] :=
   Module[{result, time, memBefore, memAfter, status},
     memBefore = MemoryInUse[];
     {time, result} = AbsoluteTiming[
@@ -36,6 +51,121 @@ SafeExecute[expr_, timeout_:300] :=
       "Status" -> status,
       "Result" -> result
     |>
+  ];
+
+SafeExecuteIsolated[expr_, timeout_:300, opts:OptionsPattern[]] :=
+  Module[{kernelPath, buffer, scriptFile, outFile, runResult = <||>, runTime = 0.,
+      rawResult = Missing["NotAvailable"], status = "FAILED", result = Missing["Failed"],
+      stderr = "", heldExpr, concretizedExpr, exprString, scriptLines, processTimeout,
+      proc, startTime, timedOut = False, info = <||>, stdout = "", startOK = False,
+      ignored, procStatus = "Unknown"},
+
+    kernelPath = OptionValue["KernelPath"];
+    buffer = OptionValue["ProcessTimeBuffer"];
+    processTimeout = Max[1, timeout + buffer];
+
+    scriptFile = CreateFile[];
+    outFile = CreateFile[];
+
+    heldExpr = HoldComplete[expr];
+    concretizedExpr = heldExpr /. s_Symbol /; (Context[s] === "Global`" && OwnValues[s] =!= {}) :> Evaluate[s];
+    exprString = StringReplace[
+      ToString[concretizedExpr, InputForm],
+      {
+        StartOfString ~~ "HoldComplete[" -> "",
+        "]" ~~ EndOfString -> ""
+      }
+    ];
+
+    scriptLines = {
+      "SetDirectory[" <> ToString[InputForm[Directory[]]] <> "];",
+      "PrependTo[$Path, Directory[]];",
+      "Needs[\"MFGraphs`\"];",
+      "res = TimeConstrained[",
+      "  Check[",
+      "    " <> exprString <> ",",
+      "    $Failed",
+      "  ],",
+      "  " <> ToString[InputForm[N[timeout]]] <> ",",
+      "  \"TIMEOUT\"",
+      "];",
+      "Export[" <> ToString[InputForm[outFile]] <> ", res, \"WXF\"];"
+    };
+    Export[scriptFile, StringRiffle[scriptLines, "\n"], "Text"];
+
+    {runTime, ignored} = AbsoluteTiming[
+      Quiet @ Check[
+        proc = StartProcess[{kernelPath, "-file", scriptFile}];
+        startOK = True,
+        startOK = False
+      ];
+      If[startOK,
+        startTime = AbsoluteTime[];
+        procStatus = Quiet @ Check[ProcessStatus[proc], "Unknown"];
+        While[
+          procStatus === "Running" && AbsoluteTime[] - startTime < processTimeout,
+          Pause[0.05]
+          ;
+          procStatus = Quiet @ Check[ProcessStatus[proc], "Unknown"]
+        ];
+        If[procStatus === "Running",
+          timedOut = True;
+          Quiet @ Check[KillProcess[proc], Null];
+          Pause[0.1];
+          procStatus = Quiet @ Check[ProcessStatus[proc], "Unknown"]
+        ];
+        info = Quiet @ Check[ProcessInformation[proc], <||>];
+        If[procStatus =!= "Running",
+          stdout = Quiet @ Check[ReadString[proc["StandardOutput"]], ""];
+          stderr = Quiet @ Check[ReadString[proc["StandardError"]], ""];
+        ];
+      ];
+      runResult = <|
+        "ExitCode" -> Lookup[info, "ExitCode", If[startOK, Missing["NotAvailable"], 1]],
+        "StandardOutput" -> stdout,
+        "StandardError" -> stderr
+      |>;
+    ];
+
+    If[timedOut ||
+       Lookup[runResult, "ExitCode", 1] =!= 0 ||
+       !FileExistsQ[outFile] ||
+       Quiet @ Check[FileByteCount[outFile], 0] == 0,
+      status =
+        If[timedOut, "TIMEOUT", "FAILED"];
+      result = Missing[If[status === "TIMEOUT", "Timeout", "KernelPanic"]],
+      rawResult = Quiet @ Check[Import[outFile, "WXF"], $Failed];
+      Which[
+        rawResult === "TIMEOUT",
+          status = "TIMEOUT";
+          result = Missing["Timeout"],
+        rawResult === $Failed || rawResult === $Aborted || rawResult === Null,
+          status = "FAILED";
+          result = Missing["Failed"],
+        True,
+          status = "OK";
+          result = rawResult
+      ]
+    ];
+
+    Quiet @ Check[DeleteFile[scriptFile], Null];
+    Quiet @ Check[DeleteFile[outFile], Null];
+
+    <|
+      "Time" -> runTime,
+      "Memory" -> Missing["IsolatedProcess"],
+      "Status" -> status,
+      "Result" -> result,
+      "ExecutionMode" -> "Process",
+      "ExitCode" -> Lookup[runResult, "ExitCode", Missing["NotAvailable"]],
+      "StandardError" -> stderr
+    |>
+  ];
+
+SafeExecute[expr_, timeout_:300] :=
+  If[$SafeExecuteMode === "Process",
+    SafeExecuteIsolated[expr, timeout],
+    SafeExecuteInProcess[expr, timeout]
   ];
 
 (* --- Residual computation --- *)

--- a/Scripts/BenchmarkSuite.wls
+++ b/Scripts/BenchmarkSuite.wls
@@ -1,4 +1,4 @@
-(* Usage: wolframscript -file Scripts/BenchmarkSuite.wls [tier] [case=key] [timeout=seconds] [tag=label] [rationale=...] [changes=...] [interpretation=...] *)
+(* Usage: wolframscript -file Scripts/BenchmarkSuite.wls [tier] [case=key] [timeout=seconds] [isolation=mode] [tag=label] [rationale=...] [changes=...] [interpretation=...] *)
 (* tier: "small", "core", "stress", "paper", "inconsistent-switching", "large", "vlarge", legacy "medium", or "all" (default: "all") *)
 
 (* :!CodeAnalysis::Disable::SuspiciousSessionSymbol::Print *)
@@ -21,9 +21,15 @@ $MFGraphsVerbose = False;
 Get[FileNameJoin[{Directory[], "Scripts", "BenchmarkHelpers.wls"}]];
 
 (* --- Parse command-line arguments --- *)
-(* Support: wolframscript -file Scripts/BenchmarkSuite.wls [tier] [case=key] [timeout=seconds] [tag=description] *)
+(* Support: wolframscript -file Scripts/BenchmarkSuite.wls [tier] [case=key] [timeout=seconds] [isolation=process|inprocess] [tag=description] *)
 NormalizeCaseArg[arg_String] := If[StringMatchQ[arg, NumberString], ToExpression[arg], arg];
 NormalizeCaseArg[arg_] := arg;
+NormalizeIsolationMode[arg_String] := Switch[ToLowerCase[arg],
+  "process" | "isolated", "Process",
+  "inprocess" | "in-process" | "none", "InProcess",
+  _, $Failed
+];
+NormalizeIsolationMode[_] := $Failed;
 
 $HistoryTag = None;
 $HistoryRationale = None;
@@ -32,8 +38,9 @@ $HistoryInterpretation = None;
 $SelectedTier = "all";
 $SelectedCase = All;
 $TimeoutOverride = Automatic;
+$IsolationModeArg = "inprocess";
 
-Module[{args = Rest[$ScriptCommandLine], i = 1, arg, parsedTimeout},
+Module[{args = Rest[$ScriptCommandLine], i = 1, arg, parsedTimeout, parsedIsolation},
   While[i <= Length[args],
     arg = args[[i]];
     Switch[arg,
@@ -60,6 +67,9 @@ Module[{args = Rest[$ScriptCommandLine], i = 1, arg, parsedTimeout},
             $TimeoutOverride = parsedTimeout
           ]
         ],
+      "--isolation",
+        i++;
+        If[i <= Length[args], $IsolationModeArg = args[[i]]],
       _ /; StringStartsQ[arg, "case="],
         $SelectedCase = NormalizeCaseArg[StringDrop[arg, StringLength["case="]]],
       _ /; StringStartsQ[arg, "timeout="],
@@ -67,6 +77,8 @@ Module[{args = Rest[$ScriptCommandLine], i = 1, arg, parsedTimeout},
         If[NumericQ[parsedTimeout] && parsedTimeout > 0,
           $TimeoutOverride = parsedTimeout
         ],
+      _ /; StringStartsQ[arg, "isolation="],
+        $IsolationModeArg = StringDrop[arg, StringLength["isolation="]],
       _ /; StringStartsQ[arg, "tag="],
         $HistoryTag = StringDrop[arg, StringLength["tag="]],
       _ /; StringStartsQ[arg, "rationale="],
@@ -80,6 +92,14 @@ Module[{args = Rest[$ScriptCommandLine], i = 1, arg, parsedTimeout},
     ];
     i++;
   ];
+
+  parsedIsolation = NormalizeIsolationMode[$IsolationModeArg];
+  If[parsedIsolation === $Failed,
+    Print["Invalid isolation mode: ", $IsolationModeArg];
+    Print["Valid values: inprocess, process"];
+    Exit[2]
+  ];
+  $SafeExecuteMode = parsedIsolation;
 ];
 
 $RequestedTier = $SelectedTier;
@@ -89,6 +109,7 @@ Print["Selected tier: ", $SelectedTier];
 If[$RequestedTier =!= $SelectedTier, Print["Requested alias: ", $RequestedTier]];
 If[$SelectedCase =!= All, Print["Selected case: ", $SelectedCase]];
 If[NumericQ[$TimeoutOverride], Print["Timeout override: ", $TimeoutOverride, "s"]];
+Print["Isolation mode: ", $SafeExecuteMode];
 If[$HistoryTag =!= None, Print["History tag:   ", $HistoryTag]];
 If[$HistoryTag =!= None &&
    MemberQ[{$HistoryRationale, $HistoryChanges, $HistoryInterpretation}, None],

--- a/Scripts/BenchmarkSuite.wls
+++ b/Scripts/BenchmarkSuite.wls
@@ -21,12 +21,13 @@ $MFGraphsVerbose = False;
 Get[FileNameJoin[{Directory[], "Scripts", "BenchmarkHelpers.wls"}]];
 
 (* --- Parse command-line arguments --- *)
-(* Support: wolframscript -file Scripts/BenchmarkSuite.wls [tier] [case=key] [timeout=seconds] [isolation=process|inprocess] [tag=description] *)
+(* Support: wolframscript -file Scripts/BenchmarkSuite.wls [tier] [case=key] [timeout=seconds] [isolation=process|inprocess|auto] [tag=description] *)
 NormalizeCaseArg[arg_String] := If[StringMatchQ[arg, NumberString], ToExpression[arg], arg];
 NormalizeCaseArg[arg_] := arg;
 NormalizeIsolationMode[arg_String] := Switch[ToLowerCase[arg],
   "process" | "isolated", "Process",
   "inprocess" | "in-process" | "none", "InProcess",
+  "auto", "Auto",
   _, $Failed
 ];
 NormalizeIsolationMode[_] := $Failed;
@@ -96,10 +97,11 @@ Module[{args = Rest[$ScriptCommandLine], i = 1, arg, parsedTimeout, parsedIsolat
   parsedIsolation = NormalizeIsolationMode[$IsolationModeArg];
   If[parsedIsolation === $Failed,
     Print["Invalid isolation mode: ", $IsolationModeArg];
-    Print["Valid values: inprocess, process"];
+    Print["Valid values: inprocess, process, auto"];
     Exit[2]
   ];
-  $SafeExecuteMode = parsedIsolation;
+  $RequestedIsolationMode = parsedIsolation;
+  $SafeExecuteMode = If[$RequestedIsolationMode === "Auto", "InProcess", $RequestedIsolationMode];
 ];
 
 $RequestedTier = $SelectedTier;
@@ -109,7 +111,7 @@ Print["Selected tier: ", $SelectedTier];
 If[$RequestedTier =!= $SelectedTier, Print["Requested alias: ", $RequestedTier]];
 If[$SelectedCase =!= All, Print["Selected case: ", $SelectedCase]];
 If[NumericQ[$TimeoutOverride], Print["Timeout override: ", $TimeoutOverride, "s"]];
-Print["Isolation mode: ", $SafeExecuteMode];
+Print["Isolation mode: ", If[$RequestedIsolationMode === "Auto", "Auto (tier-routed)", $RequestedIsolationMode]];
 If[$HistoryTag =!= None, Print["History tag:   ", $HistoryTag]];
 If[$HistoryTag =!= None &&
    MemberQ[{$HistoryRationale, $HistoryChanges, $HistoryInterpretation}, None],
@@ -129,13 +131,22 @@ $CasesToRun = If[$SelectedCase =!= All,
 ];
 
 GetTier[key_] := SelectFirst[Keys[$BenchmarkTiers], MemberQ[$BenchmarkTiers[#], key] &, "unknown"];
+ResolveCaseIsolationMode[tier_String] :=
+  If[
+    $RequestedIsolationMode === "Auto",
+    If[MemberQ[{"large", "vlarge"}, tier], "Process", "InProcess"],
+    $RequestedIsolationMode
+  ];
 
 (* --- Benchmark a single case with a single solver --- *)
 
 BenchmarkOneSolver[key_, tier_String, solverName_String, d2e_Association, timeout_?NumericQ] :=
   Module[{result, meta, residual = Missing["N/A"], equationResidual = Missing["N/A"],
       convergence, stopReason = Missing["N/A"], convergenceResidual = Missing["N/A"],
-      iterations = Missing["N/A"]},
+      iterations = Missing["N/A"], solveTime = Missing["N/A"],
+      solveMemory = Missing["N/A"], executionMode = Missing["N/A"],
+      rawResult = Missing["NotAvailable"], resultKind = Missing["NotAvailable"],
+      feasibility = Missing["NotAvailable"], solverMessage = Missing["NotAvailable"]},
     meta = GraphMetadata[d2e];
     Print["  Solver: ", solverName, " (timeout: ", timeout, "s)"];
 
@@ -149,20 +160,39 @@ BenchmarkOneSolver[key_, tier_String, solverName_String, d2e_Association, timeou
       _,
         <|"Time" -> 0, "Memory" -> 0, "Status" -> "SKIPPED", "Result" -> "Unknown solver"|>
     ];
+    solveTime =
+      If[
+        NumericQ[Lookup[result, "InnerSolveTime", Missing["N/A"]]],
+        Lookup[result, "InnerSolveTime", Missing["N/A"]],
+        Lookup[result, "Time", Missing["N/A"]]
+      ];
+    solveMemory =
+      If[
+        NumericQ[Lookup[result, "ChildMaxMemoryUsed", Missing["N/A"]]],
+        Lookup[result, "ChildMaxMemoryUsed", Missing["N/A"]],
+        Lookup[result, "Memory", Missing["N/A"]]
+      ];
+    executionMode = Lookup[result, "ExecutionMode", If[$SafeExecuteMode === "Process", "Process", "InProcess"]];
+    rawResult = Lookup[result, "Result", Missing["NotAvailable"]];
+    If[AssociationQ[rawResult],
+      resultKind = Lookup[rawResult, "ResultKind", Missing["NotAvailable"]];
+      feasibility = Lookup[rawResult, "Feasibility", Missing["NotAvailable"]];
+      solverMessage = Lookup[rawResult, "Message", Missing["NotAvailable"]];
+    ];
 
     (* Compute residual for successful solves *)
-    If[result["Status"] === "OK" && AssociationQ[result["Result"]],
-      residual = Lookup[result["Result"], "KirchhoffResidual", Missing["N/A"]];
-      convergence = Lookup[result["Result"], "Convergence", Missing["N/A"]];
+    If[result["Status"] === "OK" && AssociationQ[rawResult],
+      residual = Lookup[rawResult, "KirchhoffResidual", Missing["N/A"]];
+      convergence = Lookup[rawResult, "Convergence", Missing["N/A"]];
       If[AssociationQ[convergence],
         stopReason = Lookup[convergence, "StopReason", Missing["N/A"]];
         convergenceResidual = Lookup[convergence, "FinalResidual", Missing["N/A"]];
         iterations = Lookup[convergence, "Iterations", Missing["N/A"]];
       ];
       equationResidual = Switch[solverName,
-        "CriticalCongestion", ComputeResidual[Join[d2e, result["Result"]], "AssoCritical"],
-        "NonLinearSolver", ComputeResidual[Join[d2e, result["Result"]], "AssoNonCritical"],
-        "Monotone", ComputeResidual[Join[d2e, result["Result"]], "AssoMonotone"],
+        "CriticalCongestion", ComputeResidual[Join[d2e, rawResult], "AssoCritical"],
+        "NonLinearSolver", ComputeResidual[Join[d2e, rawResult], "AssoNonCritical"],
+        "Monotone", ComputeResidual[Join[d2e, rawResult], "AssoMonotone"],
         _, Missing["N/A"]
       ]
     ];
@@ -171,11 +201,11 @@ BenchmarkOneSolver[key_, tier_String, solverName_String, d2e_Association, timeou
     Module[{verification = "N/A"},
       If[result["Status"] === "OK" && solverName === "CriticalCongestion",
         verification = VerifySolution[key,
-          Lookup[result["Result"], "AssoCritical", Null]];
+          Lookup[rawResult, "AssoCritical", Null]];
       ];
       Print["    Status: ", result["Status"],
-            " | Time: ", FormatTime[result["Time"]], "s",
-            " | Memory: ", FormatMemoryMB[result["Memory"]], " MB",
+            " | Time: ", FormatTime[solveTime], "s",
+            " | Memory: ", FormatMemoryMB[solveMemory], " MB",
             If[verification =!= "N/A", " | Ref: " <> verification, ""]];
     ];
 
@@ -188,10 +218,17 @@ BenchmarkOneSolver[key_, tier_String, solverName_String, d2e_Association, timeou
       "NumEntries" -> meta["NumEntries"],
       "NumExits" -> meta["NumExits"],
       "HasSwitching" -> meta["HasSwitching"],
+      "ExecutionMode" -> executionMode,
+      "WallTime" -> Lookup[result, "WallTime", Lookup[result, "Time", Missing["N/A"]]],
+      "InnerSolveTime" -> Lookup[result, "InnerSolveTime", Missing["N/A"]],
+      "ChildMaxMemoryUsed" -> Lookup[result, "ChildMaxMemoryUsed", Missing["N/A"]],
       "D2ETime" -> Missing["Included"],
-      "SolveTime" -> result["Time"],
-      "SolveMemory" -> result["Memory"],
+      "SolveTime" -> solveTime,
+      "SolveMemory" -> solveMemory,
       "Status" -> result["Status"],
+      "ResultKind" -> resultKind,
+      "Feasibility" -> feasibility,
+      "Message" -> solverMessage,
       "Residual" -> residual,
       "EquationResidual" -> equationResidual,
       "StopReason" -> stopReason,
@@ -216,12 +253,15 @@ CaseStatusSummary[caseRows_List] :=
 (* --- Benchmark a single case across all applicable solvers --- *)
 
 BenchmarkCase[key_] :=
-  Module[{tier, timeout, data, d2eResult, d2e, results = {}, params},
+  Module[{tier, timeout, data, d2eResult, d2e, results = {}, params, d2eTime, caseIsolationMode},
     tier = GetTier[key];
     timeout = If[NumericQ[$TimeoutOverride], $TimeoutOverride, Lookup[$TierTimeouts, tier, 300]];
     params = GetParams[key];
+    caseIsolationMode = ResolveCaseIsolationMode[tier];
+    $SafeExecuteMode = caseIsolationMode;
 
     Print["\n--- Case: ", key, " (tier: ", tier, ") ---"];
+    Print["  Isolation: ", caseIsolationMode];
 
     (* Load data *)
     data = Quiet @ Check[GetExampleData[key], $Failed];
@@ -239,12 +279,18 @@ BenchmarkCase[key_] :=
     (* Convert to equations (timed separately) *)
     Print["  Running DataToEquations..."];
     d2eResult = SafeExecute[DataToEquations[data], timeout];
+    d2eTime =
+      If[
+        NumericQ[Lookup[d2eResult, "InnerSolveTime", Missing["N/A"]]],
+        Lookup[d2eResult, "InnerSolveTime", Missing["N/A"]],
+        Lookup[d2eResult, "Time", Missing["N/A"]]
+      ];
     Print["    D2E Status: ", d2eResult["Status"],
-          " | Time: ", FormatTime[d2eResult["Time"]], "s"];
+          " | Time: ", FormatTime[d2eTime], "s"];
 
     If[d2eResult["Status"] =!= "OK",
       Return[{<|"Key" -> ToString[key], "Tier" -> tier, "Solver" -> "DataToEquations",
-               "D2ETime" -> d2eResult["Time"], "Status" -> d2eResult["Status"],
+               "D2ETime" -> d2eTime, "Status" -> d2eResult["Status"],
                "Timestamp" -> DateString[]|>}]
     ];
 
@@ -261,7 +307,7 @@ BenchmarkCase[key_] :=
       BenchmarkOneSolver[key, tier, "Monotone", d2e, timeout]];
 
     (* Store D2E time in all results *)
-    results = Map[Append[#, "D2ETime" -> d2eResult["Time"]] &, results];
+    results = Map[Append[#, "D2ETime" -> d2eTime] &, results];
 
     results
   ];


### PR DESCRIPTION
## Summary
This PR hardens `MonotoneSolver` against silent mathematical failures and upgrades benchmark execution to be resilient against deep kernel hangs. It adds strict HJB residual gating, heuristic-to-ODE fallback routing with warm-starts, and tier-aware process isolation with child-side telemetry.

## Mathematical Hardening (`MonotoneSolver`)
- Added reconstruction flow needed for equation accountability before packaging:
  - edge-flow recovery + utility reconstruction (`u`) for Monotone solutions
- Added strict mathematical gate for Monotone outputs:
  - `NonLinearResidual` now participates in success/failure classification
  - solutions with Kirchhoff-feasible flow but high HJB residual are demoted to `NonConverged` / `Infeasible` with `Message="ResidualExceedsTolerance"`
- Refactored quadratic shortcut into candidate envelope routing:
  - returns `Outcome = Accepted | Rejected | Unavailable`
  - includes shortcut telemetry (`QuadraticShortcut*` fields)
  - only accepted candidates short-circuit the solve
- Added bounded ODE warm-start fallback from rejected quadratic candidates:
  - seed from rejected quadratic flow with floor (`Max[j, 1e-6]`)
  - avoids `t=0` singular starts and enables stable fallback attempts on stiff cases

## Benchmark Infrastructure (`BenchmarkSuite`)
- Added `isolation=auto` CLI mode:
  - `small/core` -> `InProcess`
  - `large/vlarge` -> `Process`
- Upgraded `SafeExecuteIsolated` WXF payloads to return child-side telemetry:
  - `InnerSolveTime`
  - `ChildMaxMemoryUsed`
- Benchmark rows now include execution metadata:
  - `ExecutionMode`, `WallTime`, `InnerSolveTime`, `ChildMaxMemoryUsed`
- Exporter now surfaces solver truth fields at top-level per row:
  - `ResultKind`, `Feasibility`, `Message`
  - safely default to `null` when execution is `TIMEOUT`/`FAILED`

## Final Validation
Command run:
- `wolframscript -file Scripts/BenchmarkSuite.wls all isolation=auto timeout=10`

Final run summary (93 rows):
- `OK = 53`
- `TIMEOUT = 36`
- `FAILED = 4`

Truth-field distribution in `Results/benchmark_latest.json`:
- `ResultKind`: `Success = 43`, `NonConverged = 10`, `null = 40`
- `Feasibility`: `Feasible = 43`, `Infeasible = 10`, `null = 40`
- `Message`: `None = 43`, `ResidualExceedsTolerance = 10`, `null = 40`

This gives a benchmark artifact that is both execution-safe and mathematically auditable.
