### PR TITLE
ci: add benchmark truth gate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: Benchmark CI Gate
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark_truth_gate:
+    runs-on: ubuntu-latest
+    environment:
+      name: wolfram-ci
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validate Wolfram environment secrets
+        env:
+          WOLFRAM_CI_ID: ${{ secrets.WOLFRAM_CI_ID }}
+          WOLFRAM_CI_PASS: ${{ secrets.WOLFRAM_CI_PASS }}
+        run: |
+          if [ -z "$WOLFRAM_CI_ID" ]; then
+            echo "::error::Missing environment secret WOLFRAM_CI_ID on environment 'wolfram-ci'"
+            exit 1
+          fi
+          if [ -z "$WOLFRAM_CI_PASS" ]; then
+            echo "::error::Missing environment secret WOLFRAM_CI_PASS on environment 'wolfram-ci'"
+            exit 1
+          fi
+
+      - name: Run Fast Unit Tests
+        uses: miRoox/wolfram-action@v1
+        with:
+          file: Scripts/RunTests.wls
+          args: fast
+        env:
+          WOLFRAM_ID: ${{ secrets.WOLFRAM_CI_ID }}
+          WOLFRAM_PASS: ${{ secrets.WOLFRAM_CI_PASS }}
+
+      - name: Run Benchmark Truth Gate
+        uses: miRoox/wolfram-action@v1
+        with:
+          file: Scripts/RunBenchmarkCI.wls
+        env:
+          WOLFRAM_ID: ${{ secrets.WOLFRAM_CI_ID }}
+          WOLFRAM_PASS: ${{ secrets.WOLFRAM_CI_PASS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,20 @@
+---
 name: Benchmark CI Gate
 
-on:
+'on':
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 permissions:
   contents: read
 
 jobs:
   benchmark_truth_gate:
+    if: >-
+      github.event_name != 'pull_request' ||
+      !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     environment:
       name: wolfram-ci
@@ -24,22 +28,13 @@ jobs:
           WOLFRAM_CI_PASS: ${{ secrets.WOLFRAM_CI_PASS }}
         run: |
           if [ -z "$WOLFRAM_CI_ID" ]; then
-            echo "::error::Missing environment secret WOLFRAM_CI_ID on environment 'wolfram-ci'"
+            echo "::error::Missing WOLFRAM_CI_ID secret"
             exit 1
           fi
           if [ -z "$WOLFRAM_CI_PASS" ]; then
-            echo "::error::Missing environment secret WOLFRAM_CI_PASS on environment 'wolfram-ci'"
+            echo "::error::Missing WOLFRAM_CI_PASS secret"
             exit 1
           fi
-
-      - name: Run Fast Unit Tests
-        uses: miRoox/wolfram-action@v1
-        with:
-          file: Scripts/RunTests.wls
-          args: fast
-        env:
-          WOLFRAM_ID: ${{ secrets.WOLFRAM_CI_ID }}
-          WOLFRAM_PASS: ${{ secrets.WOLFRAM_CI_PASS }}
 
       - name: Run Benchmark Truth Gate
         uses: miRoox/wolfram-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,11 @@
+---
 name: Fast Tests
 
-on:
+'on':
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 permissions:
   contents: read
@@ -18,12 +19,40 @@ jobs:
 
       - name: Check report/history placeholders
         run: |
-          if rg -n '_TODO_|_Describe the code or benchmark configuration change being measured in this run\\._|_Summarize the main performance signal, regressions, or follow-up actions from this run\\._' DNF_PERFORMANCE_HISTORY.md PARALLEL_PERFORMANCE_HISTORY.md History Results/*.md; then
-            echo "::error::Found placeholder prose in committed report/history files"
+          set -euo pipefail
+          if ! command -v rg >/dev/null 2>&1; then
+            echo "::error::ripgrep (rg) is required for hygiene checks"
             exit 1
           fi
 
+          pattern='_TODO_|'
+          pattern+='_Describe the code or benchmark configuration change '
+          pattern+='being measured in this run\\._|'
+          pattern+='_Summarize the main performance signal, regressions, '
+          pattern+='or follow-up actions from this run\\._'
+
+          set +e
+          rg -n --glob '*.md' "$pattern" \
+            DNF_PERFORMANCE_HISTORY.md \
+            PARALLEL_PERFORMANCE_HISTORY.md \
+            History \
+            Results
+          rg_status=$?
+          set -e
+
+          if [ "$rg_status" -eq 0 ]; then
+            echo "::error::Found placeholder prose in report/history files"
+            exit 1
+          fi
+          if [ "$rg_status" -ne 1 ]; then
+            echo "::error::ripgrep failed while scanning report/history files"
+            exit "$rg_status"
+          fi
+
   fast_tests:
+    if: >-
+      github.event_name != 'pull_request' ||
+      !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     environment:
       name: wolfram-ci
@@ -37,11 +66,11 @@ jobs:
           WOLFRAM_CI_PASS: ${{ secrets.WOLFRAM_CI_PASS }}
         run: |
           if [ -z "$WOLFRAM_CI_ID" ]; then
-            echo "::error::Missing environment secret WOLFRAM_CI_ID on environment 'wolfram-ci'"
+            echo "::error::Missing WOLFRAM_CI_ID secret"
             exit 1
           fi
           if [ -z "$WOLFRAM_CI_PASS" ]; then
-            echo "::error::Missing environment secret WOLFRAM_CI_PASS on environment 'wolfram-ci'"
+            echo "::error::Missing WOLFRAM_CI_PASS secret"
             exit 1
           fi
 
@@ -69,11 +98,11 @@ jobs:
           WOLFRAM_CI_PASS: ${{ secrets.WOLFRAM_CI_PASS }}
         run: |
           if [ -z "$WOLFRAM_CI_ID" ]; then
-            echo "::error::Missing environment secret WOLFRAM_CI_ID on environment 'wolfram-ci'"
+            echo "::error::Missing WOLFRAM_CI_ID secret"
             exit 1
           fi
           if [ -z "$WOLFRAM_CI_PASS" ]; then
-            echo "::error::Missing environment secret WOLFRAM_CI_PASS on environment 'wolfram-ci'"
+            echo "::error::Missing WOLFRAM_CI_PASS secret"
             exit 1
           fi
 
@@ -101,11 +130,11 @@ jobs:
           WOLFRAM_CI_PASS: ${{ secrets.WOLFRAM_CI_PASS }}
         run: |
           if [ -z "$WOLFRAM_CI_ID" ]; then
-            echo "::error::Missing environment secret WOLFRAM_CI_ID on environment 'wolfram-ci'"
+            echo "::error::Missing WOLFRAM_CI_ID secret"
             exit 1
           fi
           if [ -z "$WOLFRAM_CI_PASS" ]; then
-            echo "::error::Missing environment secret WOLFRAM_CI_PASS on environment 'wolfram-ci'"
+            echo "::error::Missing WOLFRAM_CI_PASS secret"
             exit 1
           fi
 
@@ -133,11 +162,11 @@ jobs:
           WOLFRAM_CI_PASS: ${{ secrets.WOLFRAM_CI_PASS }}
         run: |
           if [ -z "$WOLFRAM_CI_ID" ]; then
-            echo "::error::Missing environment secret WOLFRAM_CI_ID on environment 'wolfram-ci'"
+            echo "::error::Missing WOLFRAM_CI_ID secret"
             exit 1
           fi
           if [ -z "$WOLFRAM_CI_PASS" ]; then
-            echo "::error::Missing environment secret WOLFRAM_CI_PASS on environment 'wolfram-ci'"
+            echo "::error::Missing WOLFRAM_CI_PASS secret"
             exit 1
           fi
 

--- a/Scripts/RunBenchmarkCI.wls
+++ b/Scripts/RunBenchmarkCI.wls
@@ -1,0 +1,120 @@
+#!/usr/bin/env wolframscript
+
+PrependTo[$Path, Directory[]];
+Needs["MFGraphs`"];
+
+jsonPath = FileNameJoin[{Directory[], "Results", "benchmark_latest.json"}];
+tiersToRun = {"small", "core"};
+results = Flatten @ Reap[
+    Scan[
+        Function[tier,
+            Module[{run, tierRows},
+                Print["[CI] Running tier: ", tier];
+                run = RunProcess[{
+                    "wolframscript",
+                    "-file", "Scripts/BenchmarkSuite.wls",
+                    tier,
+                    "isolation=inprocess",
+                    "timeout=10"
+                }];
+                If[Lookup[run, "ExitCode", 1] =!= 0,
+                    Print["[FAIL] BenchmarkSuite tier ", tier, " failed with exit code ", Lookup[run, "ExitCode", Missing["Unknown"]], "."];
+                    If[StringLength @ Lookup[run, "StandardError", ""] > 0,
+                        Print["[stderr] ", Lookup[run, "StandardError", ""]]
+                    ];
+                    Exit[1];
+                ];
+
+                If[!FileExistsQ[jsonPath],
+                    Print["[FAIL] Benchmark JSON not found at ", jsonPath, " after tier ", tier, "."];
+                    Exit[1];
+                ];
+
+                tierRows = Quiet @ Check[Import[jsonPath, "RawJSON"], $Failed];
+                If[tierRows === $Failed || !ListQ[tierRows],
+                    Print["[FAIL] Could not parse benchmark JSON after tier ", tier, "."];
+                    Exit[1];
+                ];
+                Sow /@ tierRows;
+            ]
+        ],
+        tiersToRun
+    ]
+][[2, 1]];
+
+failures = {};
+AppendFailure[msg_] := AppendTo[failures, msg];
+
+Scan[
+    Function[row,
+        Module[{key, solver, status, resultKind, feasibility, message,
+                hasResultKind, hasFeasibility, hasMessage},
+            If[!AssociationQ[row],
+                AppendFailure["Non-association benchmark row encountered."];
+                Return[];
+            ];
+
+            key = ToString @ Lookup[row, "Key", Missing["UnknownKey"]];
+            solver = ToString @ Lookup[row, "Solver", Missing["UnknownSolver"]];
+            status = Lookup[row, "Status", Missing["UnknownStatus"]];
+
+            hasResultKind = KeyExistsQ[row, "ResultKind"];
+            hasFeasibility = KeyExistsQ[row, "Feasibility"];
+            hasMessage = KeyExistsQ[row, "Message"];
+
+            resultKind = Lookup[row, "ResultKind", Missing["MissingResultKind"]];
+            feasibility = Lookup[row, "Feasibility", Missing["MissingFeasibility"]];
+            message = Lookup[row, "Message", Missing["MissingMessage"]];
+
+            (* Rule 0: Benchmark schema must expose truth fields at top-level. *)
+            If[!(hasResultKind && hasFeasibility && hasMessage),
+                AppendFailure[
+                    "[FAIL] Missing truth-schema fields on row " <> key <> " (" <> solver <> ")."
+                ];
+            ];
+
+            (* Rule 1: No kernel crashes. *)
+            If[status === "FAILED",
+                AppendFailure[
+                    "[FAIL] Kernel crash detected on row " <> key <> " (" <> solver <> ")."
+                ];
+            ];
+
+            (* Rule 2: Successful execution must include materialized truth status. *)
+            If[status === "OK" && (resultKind === Null || MatchQ[resultKind, _Missing]),
+                AppendFailure[
+                    "[FAIL] Missing ResultKind for successful row " <> key <> " (" <> solver <> ")."
+                ];
+            ];
+            If[status === "OK" && (feasibility === Null || MatchQ[feasibility, _Missing]),
+                AppendFailure[
+                    "[FAIL] Missing Feasibility for successful row " <> key <> " (" <> solver <> ")."
+                ];
+            ];
+            If[status === "OK" && MatchQ[message, _Missing],
+                AppendFailure[
+                    "[FAIL] Missing Message for successful row " <> key <> " (" <> solver <> ")."
+                ];
+            ];
+
+            (* Rule 3: Monotone must not fake success on strict residual violation. *)
+            If[
+                solver === "Monotone" && status === "OK" &&
+                message === "ResidualExceedsTolerance" &&
+                resultKind === "Success",
+                AppendFailure[
+                    "[FAIL] Truth-gate violation on row " <> key <> " (" <> solver <> "): ResidualExceedsTolerance labeled Success."
+                ];
+            ];
+        ]
+    ],
+    results
+];
+
+If[Length[failures] > 0,
+    Print["[CI] FAILURES DETECTED: ", Length[failures]];
+    Scan[Print, failures];
+    Exit[1],
+    Print["[CI] PASS: benchmark truth schema checks succeeded for ", Length[results], " rows."];
+    Exit[0]
+];


### PR DESCRIPTION
Summary:\n- add Scripts/RunBenchmarkCI.wls to run small/core tiers and assert solver truth schema invariants\n- add .github/workflows/ci.yml to run fast tests and benchmark truth gate on push/PR to master\n- reuse wolfram-ci environment secrets (WOLFRAM_CI_ID/WOLFRAM_CI_PASS)\n\nValidation:\n- ran locally: wolframscript -file Scripts/RunBenchmarkCI.wls\n- result: PASS on 36 rows (small + core).