### PR TITLE
feat(critical): guarded numeric backend with symbolic fallback

### DIFF
--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -1104,7 +1104,7 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
          validateQ, validationTolerance, validationVerboseQ, validationFailedQ,
          numericBackendRequestedQ, numericBackendEligibleQ,
          numericBackendUsedQ, numericBackendFallbackReason, numericBackendSolveTime,
-         numericCandidate, forcedRejectQ},
+         numericCandidate, forcedRejectQ, numericBackendTimeLimit},
         ClearSolveCache[];
         validateQ = TrueQ[OptionValue["ValidateSolution"]];
         validationTolerance = OptionValue["ValidationTolerance"];
@@ -1120,12 +1120,36 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
             True, "NumericSolveFailed"
         ];
         forcedRejectQ = TrueQ[Lookup[Eqs, "ForceNumericBackendValidationFailure", False]];
+        numericBackendTimeLimit = Lookup[Eqs, "CriticalNumericBackendTimeLimit", 30.];
+        numericBackendTimeLimit = Which[
+            numericBackendTimeLimit === Infinity || numericBackendTimeLimit === DirectedInfinity[1],
+                Infinity,
+            NumericQ[numericBackendTimeLimit] && numericBackendTimeLimit > 0,
+                N[numericBackendTimeLimit],
+            True,
+                30.
+        ];
 
         (* Try the numeric backend first when explicitly forced or globally enabled. *)
         If[numericBackendRequestedQ && numericBackendEligibleQ,
             MFGPrint["Attempting critical numeric backend..."];
             {numericBackendSolveTime, numericCandidate} =
-                AbsoluteTiming[SolveCriticalNumericBackend[Eqs]];
+                AbsoluteTiming[
+                    TimeConstrained[
+                        SolveCriticalNumericBackend[Eqs],
+                        numericBackendTimeLimit,
+                        $TimedOut
+                    ]
+                ];
+            If[numericCandidate === $TimedOut,
+                numericBackendFallbackReason = "NumericBackendTimeout";
+                MFGPrint[
+                    "Numeric backend timed out after ",
+                    numericBackendTimeLimit,
+                    " seconds; falling back to symbolic path."
+                ];
+                numericCandidate = $Failed;
+            ];
             If[AssociationQ[numericCandidate] && numericCandidate =!= $Failed,
                 status = CheckFlowFeasibility[numericCandidate];
                 If[status === "Feasible",
@@ -1197,7 +1221,9 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
                     ],
                     numericBackendFallbackReason = "FlowFeasibilityFailed"
                 ],
-                numericBackendFallbackReason = "NumericSolveFailed"
+                If[numericBackendFallbackReason =!= "NumericBackendTimeout",
+                    numericBackendFallbackReason = "NumericSolveFailed"
+                ]
             ]
         ];
 

--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -1068,19 +1068,31 @@ SolveCriticalNumericBackend[Eqs_Association] :=
                 cVec,
                 {aIneq, bIneq},
                 {aEq, bEq},
-                Method -> "Simplex",
                 Tolerance -> 10^-6
             ],
             $Failed
         ];
-        If[lpResult === $Failed,
-            Return[$Failed, Module]
-        ];
-        lpVals = Which[
+        lpVals = If[
             VectorQ[lpResult, NumericQ] && Length[lpResult] === nVars,
-                Developer`ToPackedArray @ N @ lpResult,
-            True,
+            Developer`ToPackedArray @ N @ lpResult,
+            $Failed
+        ];
+        If[lpVals === $Failed,
+            lpResult = Quiet @ Check[
+                LinearOptimization[
+                    cVec,
+                    {aIneq, bIneq},
+                    {aEq, bEq},
+                    Method -> "Simplex",
+                    Tolerance -> 10^-6
+                ],
                 $Failed
+            ];
+            lpVals = If[
+                VectorQ[lpResult, NumericQ] && Length[lpResult] === nVars,
+                Developer`ToPackedArray @ N @ lpResult,
+                $Failed
+            ];
         ];
         If[
             lpVals === $Failed || !VectorQ[lpVals, NumericQ] || Length[lpVals] =!= nVars,

--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -1006,7 +1006,8 @@ LinearSolveCandidate[aMat_SparseArray, bVec_List] :=
 SolveCriticalNumericBackend[Eqs_Association] :=
     Module[{constraints, equalities, inequalities, flowVars, allVars,
         linearSystem, aMat, bVec, xCandidate, varIndex, flowIndices,
-        linResidual, flowMin, tol = 10^-8, assoc, lpResult, lpVals, solvedAssoc},
+        linResidual, flowMin, tol = 10^-8, assoc, lpResult, lpVals, solvedAssoc,
+        nVars, cVec, aIneq, bIneq, aEq, bEq},
         constraints = BuildCriticalLinearConstraints[Eqs];
         If[constraints === $Failed || !AssociationQ[constraints],
             Return[$Failed, Module]
@@ -1018,6 +1019,11 @@ SolveCriticalNumericBackend[Eqs_Association] :=
         If[equalities === {} || allVars === {},
             Return[$Failed, Module]
         ];
+        varIndex = AssociationThread[allVars, Range[Length[allVars]]];
+        flowIndices = Lookup[varIndex, flowVars, Missing["NotAvailable"]];
+        If[MemberQ[flowIndices, _Missing] || flowIndices === {},
+            Return[$Failed, Module]
+        ];
 
         linearSystem = BuildLinearSystemFromEqualities[equalities, allVars];
         If[AssociationQ[linearSystem],
@@ -1025,36 +1031,46 @@ SolveCriticalNumericBackend[Eqs_Association] :=
             bVec = linearSystem["b"];
             xCandidate = LinearSolveCandidate[aMat, bVec];
             If[VectorQ[xCandidate, NumericQ] && Length[xCandidate] === Length[allVars],
-                varIndex = AssociationThread[allVars, Range[Length[allVars]]];
-                flowIndices = Lookup[varIndex, flowVars, Missing["NotAvailable"]];
-                If[!MemberQ[flowIndices, _Missing] && flowIndices =!= {},
-                    linResidual = Quiet @ Check[N @ Norm[aMat . xCandidate - bVec, Infinity], Infinity];
-                    flowMin = Min[xCandidate[[flowIndices]]];
-                    If[NumericQ[linResidual] && linResidual <= tol && NumericQ[flowMin] && flowMin >= -tol,
-                        assoc = AssociationThread[allVars, xCandidate];
-                        solvedAssoc = Association @ KeyValueMap[
-                            #1 -> If[Abs[#2] <= tol, 0., N[#2]] &,
-                            assoc
-                        ];
-                        Return[
-                            Join[
-                                KeyTake[solvedAssoc, Lookup[Eqs, "us", {}]],
-                                KeyTake[solvedAssoc, Lookup[Eqs, "js", {}]],
-                                KeyTake[solvedAssoc, Lookup[Eqs, "jts", {}]]
-                            ],
-                            Module
-                        ]
+                linResidual = Quiet @ Check[N @ Norm[aMat . xCandidate - bVec, Infinity], Infinity];
+                flowMin = Min[xCandidate[[flowIndices]]];
+                If[NumericQ[linResidual] && linResidual <= tol && NumericQ[flowMin] && flowMin >= -tol,
+                    assoc = AssociationThread[allVars, xCandidate];
+                    solvedAssoc = Association @ KeyValueMap[
+                        #1 -> If[Abs[#2] <= tol, 0., N[#2]] &,
+                        assoc
+                    ];
+                    Return[
+                        Join[
+                            KeyTake[solvedAssoc, Lookup[Eqs, "us", {}]],
+                            KeyTake[solvedAssoc, Lookup[Eqs, "js", {}]],
+                            KeyTake[solvedAssoc, Lookup[Eqs, "jts", {}]]
+                        ],
+                        Module
                     ]
                 ]
             ]
+            ,
+            Return[$Failed, Module]
         ];
 
+        nVars = Length[allVars];
+        cVec = Developer`ToPackedArray @ ConstantArray[0., nVars];
+        aEq = If[Head[aMat] === SparseArray, aMat, SparseArray[aMat]];
+        bEq = Developer`ToPackedArray @ N @ (-bVec);
+        aIneq = SparseArray[
+            Thread[
+                Transpose[{Range[Length[flowIndices]], flowIndices}] -> 1.
+            ],
+            {Length[flowIndices], nVars}
+        ];
+        bIneq = Developer`ToPackedArray @ ConstantArray[0., Length[flowIndices]];
         lpResult = Quiet @ Check[
             LinearOptimization[
-                0,
-                And @@ Join[equalities, inequalities],
-                allVars,
-                Reals
+                cVec,
+                {aIneq, bIneq},
+                {aEq, bEq},
+                Method -> "Simplex",
+                Tolerance -> 10^-6
             ],
             $Failed
         ];
@@ -1062,17 +1078,13 @@ SolveCriticalNumericBackend[Eqs_Association] :=
             Return[$Failed, Module]
         ];
         lpVals = Which[
-            VectorQ[lpResult, NumericQ] && Length[lpResult] === Length[allVars],
+            VectorQ[lpResult, NumericQ] && Length[lpResult] === nVars,
                 Developer`ToPackedArray @ N @ lpResult,
-            AssociationQ[lpResult],
-                Lookup[lpResult, allVars, Missing["NotAvailable"]],
-            ListQ[lpResult] && VectorQ[lpResult, MatchQ[#, _Rule] &],
-                allVars /. lpResult,
             True,
                 $Failed
         ];
         If[
-            lpVals === $Failed || !VectorQ[lpVals, NumericQ] || Length[lpVals] =!= Length[allVars],
+            lpVals === $Failed || !VectorQ[lpVals, NumericQ] || Length[lpVals] =!= nVars,
             Return[$Failed, Module]
         ];
         assoc = AssociationThread[allVars, Developer`ToPackedArray @ N @ lpVals];

--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -1373,30 +1373,55 @@ Options[IsCriticalSolution] = {
 };
 
 NumericRelationSatisfiedQ[expr_, tol_?NumericQ] :=
-    Module[{delta},
+    Module[{delta, pair, held},
+        held = HoldComplete[expr];
         Which[
-            MatchQ[expr, HoldPattern[Equal[l_, r_]]],
-                delta = Quiet @ Check[N[expr[[1]] - expr[[2]]], $Failed];
+            MatchQ[held, HoldComplete[Equal[_, _]] | HoldComplete[Inactive[Equal][_, _]]],
+                pair = Replace[held, {
+                    HoldComplete[Equal[l_, r_]] :> {l, r},
+                    HoldComplete[Inactive[Equal][l_, r_]] :> {l, r}
+                }];
+                delta = Quiet @ Check[N[pair[[1]] - pair[[2]]], $Failed];
                 NumericQ[delta] && Abs[delta] <= tol
             ,
-            MatchQ[expr, HoldPattern[LessEqual[l_, r_]]],
-                delta = Quiet @ Check[N[expr[[1]] - expr[[2]]], $Failed];
+            MatchQ[held, HoldComplete[LessEqual[_, _]] | HoldComplete[Inactive[LessEqual][_, _]]],
+                pair = Replace[held, {
+                    HoldComplete[LessEqual[l_, r_]] :> {l, r},
+                    HoldComplete[Inactive[LessEqual][l_, r_]] :> {l, r}
+                }];
+                delta = Quiet @ Check[N[pair[[1]] - pair[[2]]], $Failed];
                 NumericQ[delta] && delta <= tol
             ,
-            MatchQ[expr, HoldPattern[GreaterEqual[l_, r_]]],
-                delta = Quiet @ Check[N[expr[[2]] - expr[[1]]], $Failed];
+            MatchQ[held, HoldComplete[GreaterEqual[_, _]] | HoldComplete[Inactive[GreaterEqual][_, _]]],
+                pair = Replace[held, {
+                    HoldComplete[GreaterEqual[l_, r_]] :> {l, r},
+                    HoldComplete[Inactive[GreaterEqual][l_, r_]] :> {l, r}
+                }];
+                delta = Quiet @ Check[N[pair[[2]] - pair[[1]]], $Failed];
                 NumericQ[delta] && delta <= tol
             ,
-            MatchQ[expr, HoldPattern[Less[l_, r_]]],
-                delta = Quiet @ Check[N[expr[[1]] - expr[[2]]], $Failed];
+            MatchQ[held, HoldComplete[Less[_, _]] | HoldComplete[Inactive[Less][_, _]]],
+                pair = Replace[held, {
+                    HoldComplete[Less[l_, r_]] :> {l, r},
+                    HoldComplete[Inactive[Less][l_, r_]] :> {l, r}
+                }];
+                delta = Quiet @ Check[N[pair[[1]] - pair[[2]]], $Failed];
                 NumericQ[delta] && delta < -tol
             ,
-            MatchQ[expr, HoldPattern[Greater[l_, r_]]],
-                delta = Quiet @ Check[N[expr[[2]] - expr[[1]]], $Failed];
+            MatchQ[held, HoldComplete[Greater[_, _]] | HoldComplete[Inactive[Greater][_, _]]],
+                pair = Replace[held, {
+                    HoldComplete[Greater[l_, r_]] :> {l, r},
+                    HoldComplete[Inactive[Greater][l_, r_]] :> {l, r}
+                }];
+                delta = Quiet @ Check[N[pair[[2]] - pair[[1]]], $Failed];
                 NumericQ[delta] && delta < -tol
             ,
-            MatchQ[expr, HoldPattern[Unequal[l_, r_]]],
-                delta = Quiet @ Check[N[expr[[1]] - expr[[2]]], $Failed];
+            MatchQ[held, HoldComplete[Unequal[_, _]] | HoldComplete[Inactive[Unequal][_, _]]],
+                pair = Replace[held, {
+                    HoldComplete[Unequal[l_, r_]] :> {l, r},
+                    HoldComplete[Inactive[Unequal][l_, r_]] :> {l, r}
+                }];
+                delta = Quiet @ Check[N[pair[[1]] - pair[[2]]], $Failed];
                 NumericQ[delta] && Abs[delta] > tol
             ,
             True,
@@ -1405,14 +1430,29 @@ NumericRelationSatisfiedQ[expr_, tol_?NumericQ] :=
     ];
 
 LogicalSatisfiedQ[expr_, rules_Association, tol_?NumericQ] :=
-    Module[{evaluated},
+    Module[{heldExpr, evaluated},
         Which[
             expr === True, True,
             expr === False, False,
             True,
+                heldExpr =
+                    expr /. HoldPattern[(h:Equal | LessEqual | GreaterEqual | Less | Greater | Unequal)[lhs_, rhs_]] :>
+                        Inactive[h][lhs, rhs];
                 evaluated = Quiet @ Check[
-                    expr /. rules /. relation_ /; MatchQ[relation, _Equal | _LessEqual | _GreaterEqual | _Less | _Greater | _Unequal] :>
-                        NumericRelationSatisfiedQ[relation, tol],
+                    heldExpr /. rules /. {
+                        HoldPattern[Inactive[Equal][lhs_, rhs_]] :>
+                            NumericRelationSatisfiedQ[Inactive[Equal][lhs, rhs], tol],
+                        HoldPattern[Inactive[LessEqual][lhs_, rhs_]] :>
+                            NumericRelationSatisfiedQ[Inactive[LessEqual][lhs, rhs], tol],
+                        HoldPattern[Inactive[GreaterEqual][lhs_, rhs_]] :>
+                            NumericRelationSatisfiedQ[Inactive[GreaterEqual][lhs, rhs], tol],
+                        HoldPattern[Inactive[Less][lhs_, rhs_]] :>
+                            NumericRelationSatisfiedQ[Inactive[Less][lhs, rhs], tol],
+                        HoldPattern[Inactive[Greater][lhs_, rhs_]] :>
+                            NumericRelationSatisfiedQ[Inactive[Greater][lhs, rhs], tol],
+                        HoldPattern[Inactive[Unequal][lhs_, rhs_]] :>
+                            NumericRelationSatisfiedQ[Inactive[Unequal][lhs, rhs], tol]
+                    },
                     $Failed
                 ];
                 If[evaluated === $Failed,
@@ -1538,8 +1578,9 @@ IsCriticalSolution[Eqs_Association, OptionsPattern[]] :=
         allBlocksPass = And @@ Values[blockResults];
 
         eqResidualPairs =
-            Cases[eqGeneralCritical /. solution,
-                HoldPattern[Equal[lhs_, rhs_]] :> {lhs, rhs},
+            Cases[
+                (eqGeneralCritical /. HoldPattern[Equal[lhs_, rhs_]] :> Inactive[Equal][lhs, rhs]) /. solution,
+                HoldPattern[Inactive[Equal][lhs_, rhs_]] :> {lhs, rhs},
                 Infinity
             ];
         eqResidualDeltas =

--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -1004,7 +1004,7 @@ LinearSolveCandidate[aMat_SparseArray, bVec_List] :=
     ];
 
 SolveCriticalNumericBackend[Eqs_Association] :=
-    Module[{constraints, equalities, inequalities, flowVars, allVars,
+    Module[{constraints, equalities, flowVars, allVars,
         linearSystem, aMat, bVec, xCandidate, varIndex, flowIndices,
         linResidual, flowMin, tol = 10^-8, assoc, lpResult, lpVals, solvedAssoc,
         nVars, cVec, aIneq, bIneq, aEq, bEq},
@@ -1013,7 +1013,6 @@ SolveCriticalNumericBackend[Eqs_Association] :=
             Return[$Failed, Module]
         ];
         equalities = Lookup[constraints, "Equalities", {}];
-        inequalities = Lookup[constraints, "Inequalities", {}];
         flowVars = Lookup[constraints, "FlowVariables", {}];
         allVars = Lookup[constraints, "AllVariables", {}];
         If[equalities === {} || allVars === {},

--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -817,6 +817,276 @@ DirectCriticalSolver[Eqs_Association] :=
         result
     ]
 
+(* --- Critical numeric backend (internal, guarded) --- *)
+
+$CriticalNumericBackendEnabled = False;
+
+CriticalNumericBackendRequestedQ[Eqs_Association] :=
+    Module[{mode},
+        mode = Lookup[Eqs, "CriticalNumericBackendMode", Automatic];
+        Which[
+            mode === True || mode === "Force", True,
+            mode === False || mode === "Disabled", False,
+            mode === Automatic || mode === "Auto", TrueQ[$CriticalNumericBackendEnabled],
+            True, False
+        ]
+    ];
+
+CriticalNumericBackendEligibleQ[Eqs_Association] :=
+    Module[{numericState, switchingVals, entryVals, exitVals, km, b, vars},
+        numericState = Lookup[Eqs, "NumericState", Missing["NotAvailable"]];
+        switchingVals = Values[Lookup[Eqs, "SwitchingCosts", <||>]];
+        entryVals = Flatten[Lookup[Eqs, "Entrance Vertices and Flows", {}]];
+        exitVals = Flatten[Lookup[Eqs, "Exit Vertices and Terminal Costs", {}]];
+        km = Lookup[numericState, "KirchhoffKM", Missing["NotAvailable"]];
+        b = Lookup[numericState, "KirchhoffB", Missing["NotAvailable"]];
+        vars = Lookup[numericState, "KirchhoffVariables", {}];
+        AssociationQ[numericState] &&
+        AllTrue[switchingVals, # === 0 &] &&
+        Lookup[Eqs, "auxiliaryGraph", None] =!= None &&
+        AllTrue[entryVals, NumericQ] &&
+        AllTrue[exitVals, NumericQ] &&
+        Head[km] === SparseArray &&
+        VectorQ[b, NumericQ] &&
+        ListQ[vars] &&
+        vars =!= {}
+    ];
+
+BuildCriticalLinearConstraints[Eqs_Association] :=
+    Module[{graph, exitVerts, us, js, jts, auxPairs, distToExit, zeroRules, pair,
+        RuleEntryOut, RuleExitFlowsIn, RuleEntryValues, RuleExitValues,
+        RuleBalanceGatheringFlows, EqGeneral, EqEntryIn,
+        EqBalanceSplittingFlows, EqValueAuxiliaryEdges,
+        eqList, flowVars, allVars, ineqList},
+        graph = Lookup[Eqs, "auxiliaryGraph", None];
+        exitVerts = Lookup[Eqs, "auxExitVertices", {}];
+        us = Lookup[Eqs, "us", {}];
+        js = Lookup[Eqs, "js", {}];
+        jts = Lookup[Eqs, "jts", {}];
+        auxPairs = Cases[us, u[a_, b_] :> {a, b}];
+        RuleEntryOut = Lookup[Eqs, "RuleEntryOut", {}];
+        RuleExitFlowsIn = Lookup[Eqs, "RuleExitFlowsIn", {}];
+        RuleEntryValues = Lookup[Eqs, "RuleEntryValues", <||>];
+        RuleExitValues = Lookup[Eqs, "RuleExitValues", <||>];
+        RuleBalanceGatheringFlows = Lookup[Eqs, "RuleBalanceGatheringFlows", <||>];
+        EqGeneral = Lookup[Eqs, "EqGeneral", True];
+        EqEntryIn = Lookup[Eqs, "EqEntryIn", True];
+        EqBalanceSplittingFlows = Lookup[Eqs, "EqBalanceSplittingFlows", True];
+        EqValueAuxiliaryEdges = Lookup[Eqs, "EqValueAuxiliaryEdges", True];
+
+        distToExit = Lookup[
+            Lookup[Eqs, "NumericState", <||>],
+            "DistanceToExit",
+            <||>
+        ];
+        If[!AssociationQ[distToExit] || distToExit === <||>,
+            If[Head[graph] =!= Graph || exitVerts === {},
+                Return[$Failed, Module]
+            ];
+            distToExit = Association @ Table[
+                v -> Min[GraphDistance[graph, v, #] & /@ exitVerts],
+                {v, VertexList[graph]}
+            ];
+        ];
+
+        zeroRules = Association[];
+        Do[
+            pair = auxPairs[[k]];
+            If[
+                Lookup[distToExit, pair[[1]], Infinity] <
+                    Lookup[distToExit, pair[[2]], Infinity],
+                zeroRules[j @@ pair] = 0
+            ],
+            {k, Length[auxPairs]}
+        ];
+
+        eqList = Flatten[{
+            List @@ (EqGeneral /. Thread[
+                Keys[Lookup[Eqs, "costpluscurrents", <||>]] -> 0
+            ]),
+            If[Head[EqEntryIn] === And, List @@ EqEntryIn, If[EqEntryIn === True, {}, {EqEntryIn}]],
+            If[Head[EqBalanceSplittingFlows] === And,
+                List @@ EqBalanceSplittingFlows,
+                If[EqBalanceSplittingFlows === True, {}, {EqBalanceSplittingFlows}]
+            ],
+            If[Head[EqValueAuxiliaryEdges] === And,
+                List @@ EqValueAuxiliaryEdges,
+                If[EqValueAuxiliaryEdges === True, {}, {EqValueAuxiliaryEdges}]
+            ],
+            KeyValueMap[Equal, RuleExitValues],
+            KeyValueMap[Equal, RuleEntryValues],
+            Equal @@@ Normal[RuleEntryOut],
+            Equal @@@ Normal[RuleExitFlowsIn],
+            Equal @@@ Normal[RuleBalanceGatheringFlows],
+            (Equal[#, 0] & /@ Keys[zeroRules]),
+            Module[{byVertex = GroupBy[auxPairs, Last]},
+                Flatten @ KeyValueMap[
+                    Function[{v, pairs},
+                        If[
+                            Length[pairs] > 1,
+                            (u @@ # == u @@ pairs[[1]]) & /@ Rest[pairs],
+                            {}
+                        ]
+                    ],
+                    byVertex
+                ]
+            ]
+        }];
+        eqList = Cases[DeleteCases[eqList, True], _Equal];
+
+        flowVars = Join[js, jts];
+        allVars = Join[us, js, jts];
+        ineqList = (# >= 0) & /@ flowVars;
+        <|
+            "Equalities" -> eqList,
+            "Inequalities" -> ineqList,
+            "FlowVariables" -> flowVars,
+            "AllVariables" -> allVars
+        |>
+    ];
+
+BuildLinearSystemFromEqualities[equalities_List, vars_List] :=
+    Module[{exprs, placeholders, subExprs, coeffData, bVec, aMat},
+        If[equalities === {} || vars === {},
+            Return[$Failed, Module]
+        ];
+        exprs = equalities /. Equal[l_, r_] :> (l - r);
+        placeholders = Table[Unique["lv"], {Length[vars]}];
+        subExprs = exprs /. Thread[vars -> placeholders];
+        coeffData = Quiet @ Check[
+            CoefficientArrays[subExprs, placeholders],
+            $Failed
+        ];
+        If[coeffData === $Failed || Length[coeffData] < 2,
+            Return[$Failed, Module]
+        ];
+        bVec = Quiet @ Check[
+            Developer`ToPackedArray @ N @ (-Normal[coeffData[[1]]]),
+            $Failed
+        ];
+        aMat = Quiet @ Check[
+            SparseArray[coeffData[[2]]],
+            $Failed
+        ];
+        If[
+            bVec === $Failed || aMat === $Failed || !VectorQ[bVec, NumericQ],
+            $Failed,
+            <|"A" -> aMat, "b" -> bVec|>
+        ]
+    ];
+
+LinearSolveCandidate[aMat_SparseArray, bVec_List] :=
+    Module[{dims, ls, x, ata, atb},
+        dims = Dimensions[aMat];
+        If[Length[dims] =!= 2 || dims[[2]] == 0,
+            Return[$Failed, Module]
+        ];
+        If[dims[[1]] === dims[[2]],
+            ls = Quiet @ Check[LinearSolve[N @ aMat], $Failed];
+            If[ls === $Failed,
+                Return[$Failed, Module]
+            ];
+            x = Quiet @ Check[N @ ls[N @ bVec], $Failed];
+            If[VectorQ[x, NumericQ], Developer`ToPackedArray @ x, $Failed]
+            ,
+            ata = Quiet @ Check[N @ (Transpose[aMat].aMat), $Failed];
+            atb = Quiet @ Check[N @ (Transpose[aMat].bVec), $Failed];
+            If[ata === $Failed || atb === $Failed,
+                Return[$Failed, Module]
+            ];
+            ls = Quiet @ Check[LinearSolve[ata], $Failed];
+            If[ls === $Failed,
+                Return[$Failed, Module]
+            ];
+            x = Quiet @ Check[N @ ls[atb], $Failed];
+            If[VectorQ[x, NumericQ], Developer`ToPackedArray @ x, $Failed]
+        ]
+    ];
+
+SolveCriticalNumericBackend[Eqs_Association] :=
+    Module[{constraints, equalities, inequalities, flowVars, allVars,
+        linearSystem, aMat, bVec, xCandidate, varIndex, flowIndices,
+        linResidual, flowMin, tol = 10^-8, assoc, lpResult, lpVals, solvedAssoc},
+        constraints = BuildCriticalLinearConstraints[Eqs];
+        If[constraints === $Failed || !AssociationQ[constraints],
+            Return[$Failed, Module]
+        ];
+        equalities = Lookup[constraints, "Equalities", {}];
+        inequalities = Lookup[constraints, "Inequalities", {}];
+        flowVars = Lookup[constraints, "FlowVariables", {}];
+        allVars = Lookup[constraints, "AllVariables", {}];
+        If[equalities === {} || allVars === {},
+            Return[$Failed, Module]
+        ];
+
+        linearSystem = BuildLinearSystemFromEqualities[equalities, allVars];
+        If[AssociationQ[linearSystem],
+            aMat = linearSystem["A"];
+            bVec = linearSystem["b"];
+            xCandidate = LinearSolveCandidate[aMat, bVec];
+            If[VectorQ[xCandidate, NumericQ] && Length[xCandidate] === Length[allVars],
+                varIndex = AssociationThread[allVars, Range[Length[allVars]]];
+                flowIndices = Lookup[varIndex, flowVars, Missing["NotAvailable"]];
+                If[!MemberQ[flowIndices, _Missing] && flowIndices =!= {},
+                    linResidual = Quiet @ Check[N @ Norm[aMat . xCandidate - bVec, Infinity], Infinity];
+                    flowMin = Min[xCandidate[[flowIndices]]];
+                    If[NumericQ[linResidual] && linResidual <= tol && NumericQ[flowMin] && flowMin >= -tol,
+                        assoc = AssociationThread[allVars, xCandidate];
+                        solvedAssoc = Association @ KeyValueMap[
+                            #1 -> If[Abs[#2] <= tol, 0., N[#2]] &,
+                            assoc
+                        ];
+                        Return[
+                            Join[
+                                KeyTake[solvedAssoc, Lookup[Eqs, "us", {}]],
+                                KeyTake[solvedAssoc, Lookup[Eqs, "js", {}]],
+                                KeyTake[solvedAssoc, Lookup[Eqs, "jts", {}]]
+                            ],
+                            Module
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        lpResult = Quiet @ Check[
+            LinearOptimization[
+                0,
+                And @@ Join[equalities, inequalities],
+                allVars,
+                Reals
+            ],
+            $Failed
+        ];
+        If[lpResult === $Failed,
+            Return[$Failed, Module]
+        ];
+        lpVals = Which[
+            VectorQ[lpResult, NumericQ] && Length[lpResult] === Length[allVars],
+                Developer`ToPackedArray @ N @ lpResult,
+            AssociationQ[lpResult],
+                Lookup[lpResult, allVars, Missing["NotAvailable"]],
+            ListQ[lpResult] && VectorQ[lpResult, MatchQ[#, _Rule] &],
+                allVars /. lpResult,
+            True,
+                $Failed
+        ];
+        If[
+            lpVals === $Failed || !VectorQ[lpVals, NumericQ] || Length[lpVals] =!= Length[allVars],
+            Return[$Failed, Module]
+        ];
+        assoc = AssociationThread[allVars, Developer`ToPackedArray @ N @ lpVals];
+        solvedAssoc = Association @ KeyValueMap[
+            #1 -> If[Abs[#2] <= tol, 0., N[#2]] &,
+            assoc
+        ];
+        Join[
+            KeyTake[solvedAssoc, Lookup[Eqs, "us", {}]],
+            KeyTake[solvedAssoc, Lookup[Eqs, "js", {}]],
+            KeyTake[solvedAssoc, Lookup[Eqs, "jts", {}]]
+        ]
+    ];
+
 (* --- CriticalCongestionSolver --- *)
 
 Options[CriticalCongestionSolver] = {
@@ -831,12 +1101,106 @@ CriticalCongestionSolver[$Failed, ___] :=
 CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
     Module[{PreEqs, js, AssoCritical, time, temp, status,
          resultKind, message, solution, comparisonData,
-         validateQ, validationTolerance, validationVerboseQ, validationFailedQ},
+         validateQ, validationTolerance, validationVerboseQ, validationFailedQ,
+         numericBackendRequestedQ, numericBackendEligibleQ,
+         numericBackendUsedQ, numericBackendFallbackReason, numericBackendSolveTime,
+         numericCandidate, forcedRejectQ},
         ClearSolveCache[];
         validateQ = TrueQ[OptionValue["ValidateSolution"]];
         validationTolerance = OptionValue["ValidationTolerance"];
         validationVerboseQ = TrueQ[OptionValue["ValidationVerbose"]];
         validationFailedQ = False;
+        numericBackendUsedQ = False;
+        numericBackendSolveTime = Missing["NotAvailable"];
+        numericBackendRequestedQ = CriticalNumericBackendRequestedQ[Eqs];
+        numericBackendEligibleQ = CriticalNumericBackendEligibleQ[Eqs];
+        numericBackendFallbackReason = Which[
+            !numericBackendRequestedQ, "DisabledByGuard",
+            !numericBackendEligibleQ, "IneligibleInput",
+            True, "NumericSolveFailed"
+        ];
+        forcedRejectQ = TrueQ[Lookup[Eqs, "ForceNumericBackendValidationFailure", False]];
+
+        (* Try the numeric backend first when explicitly forced or globally enabled. *)
+        If[numericBackendRequestedQ && numericBackendEligibleQ,
+            MFGPrint["Attempting critical numeric backend..."];
+            {numericBackendSolveTime, numericCandidate} =
+                AbsoluteTiming[SolveCriticalNumericBackend[Eqs]];
+            If[AssociationQ[numericCandidate] && numericCandidate =!= $Failed,
+                status = CheckFlowFeasibility[numericCandidate];
+                If[status === "Feasible",
+                    If[KeyExistsQ[Eqs, "InitRules"],
+                        PreEqs = Eqs,
+                        {time, PreEqs} = AbsoluteTiming @ MFGPreprocessing[Eqs];
+                        MFGPrint["Preprocessing (for downstream solvers) took ", time, " seconds."]
+                    ];
+                    If[validateQ,
+                        If[forcedRejectQ || !TrueQ @ IsCriticalSolution[
+                            Join[PreEqs, <|"AssoCritical" -> numericCandidate, "Solution" -> numericCandidate|>],
+                            "Tolerance" -> validationTolerance,
+                            "Verbose" -> validationVerboseQ
+                        ],
+                            numericBackendFallbackReason =
+                                If[forcedRejectQ, "ForcedValidationFailure", "CriticalValidationFailed"]
+                            ,
+                            solution = numericCandidate;
+                            comparisonData = BuildSolverComparisonData[PreEqs, solution];
+                            Return[
+                                Join[
+                                    PreEqs,
+                                    MakeSolverResult[
+                                        "CriticalCongestion",
+                                        "Success",
+                                        status,
+                                        None,
+                                        solution,
+                                        Join[
+                                            comparisonData,
+                                            <|
+                                                "AssoCritical" -> numericCandidate,
+                                                "Status" -> status,
+                                                "NumericBackendUsed" -> True,
+                                                "NumericBackendFallbackReason" -> None,
+                                                "NumericBackendSolveTime" -> numericBackendSolveTime
+                                            |>
+                                        ]
+                                    ]
+                                ],
+                                Module
+                            ]
+                        ],
+                        solution = numericCandidate;
+                        comparisonData = BuildSolverComparisonData[PreEqs, solution];
+                        Return[
+                            Join[
+                                PreEqs,
+                                MakeSolverResult[
+                                    "CriticalCongestion",
+                                    "Success",
+                                    status,
+                                    None,
+                                    solution,
+                                    Join[
+                                        comparisonData,
+                                        <|
+                                            "AssoCritical" -> numericCandidate,
+                                            "Status" -> status,
+                                            "NumericBackendUsed" -> True,
+                                            "NumericBackendFallbackReason" -> None,
+                                            "NumericBackendSolveTime" -> numericBackendSolveTime
+                                        |>
+                                    ]
+                                ]
+                            ],
+                            Module
+                        ]
+                    ],
+                    numericBackendFallbackReason = "FlowFeasibilityFailed"
+                ],
+                numericBackendFallbackReason = "NumericSolveFailed"
+            ]
+        ];
+
         (* Try direct solver for zero-switching-cost, fully numeric networks *)
         If[AllTrue[Values[Lookup[Eqs, "SwitchingCosts", <|_ -> 1|>]], # === 0 &] &&
             Lookup[Eqs, "auxiliaryGraph", None] =!= None &&
@@ -869,8 +1233,16 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
                             Return[
                                 Join[PreEqs, MakeSolverResult["CriticalCongestion", "Success",
                                     status, None, solution,
-                                    Join[comparisonData, <|"AssoCritical" -> AssoCritical,
-                                        "Status" -> status|>]]],
+                                    Join[
+                                        comparisonData,
+                                        <|
+                                            "AssoCritical" -> AssoCritical,
+                                            "Status" -> status,
+                                            "NumericBackendUsed" -> numericBackendUsedQ,
+                                            "NumericBackendFallbackReason" -> numericBackendFallbackReason,
+                                            "NumericBackendSolveTime" -> numericBackendSolveTime
+                                        |>
+                                    ]]],
                                 Module
                             ]
                         ],
@@ -879,8 +1251,16 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
                         Return[
                             Join[PreEqs, MakeSolverResult["CriticalCongestion", "Success",
                                 status, None, solution,
-                                Join[comparisonData, <|"AssoCritical" -> AssoCritical,
-                                    "Status" -> status|>]]],
+                                Join[
+                                    comparisonData,
+                                    <|
+                                        "AssoCritical" -> AssoCritical,
+                                        "Status" -> status,
+                                        "NumericBackendUsed" -> numericBackendUsedQ,
+                                        "NumericBackendFallbackReason" -> numericBackendFallbackReason,
+                                        "NumericBackendSolveTime" -> numericBackendSolveTime
+                                    |>
+                                ]]],
                             Module
                         ]
                     ],
@@ -890,14 +1270,16 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
             ]
         ];
         (* Standard symbolic solver path *)
-        If[KeyExistsQ[Eqs, "InitRules"],
-            PreEqs = Eqs
-            ,
-            temp = MFGPrintTemporary["Preprocessing..."];
-            {time, PreEqs} = AbsoluteTiming @ MFGPreprocessing[Eqs];
-            NotebookDelete[temp];
-            MFGPrint["Preprocessing took ", time, " seconds to terminate."
-                ];
+        If[!(AssociationQ[PreEqs] && KeyExistsQ[PreEqs, "InitRules"]),
+            If[KeyExistsQ[Eqs, "InitRules"],
+                PreEqs = Eqs
+                ,
+                temp = MFGPrintTemporary["Preprocessing..."];
+                {time, PreEqs} = AbsoluteTiming @ MFGPreprocessing[Eqs];
+                NotebookDelete[temp];
+                MFGPrint["Preprocessing took ", time, " seconds to terminate."
+                    ];
+            ]
         ];
         js = Lookup[PreEqs, "js", $Failed];
         AssoCritical = MFGSystemSolver[PreEqs][AssociationThread[js,
@@ -934,8 +1316,17 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
             ];
         comparisonData = BuildSolverComparisonData[PreEqs, solution];
         Join[PreEqs, MakeSolverResult["CriticalCongestion", resultKind,
-             status, message, solution, Join[comparisonData, <|"AssoCritical" -> AssoCritical, "Status"
-             -> status|>]]]
+             status, message, solution,
+             Join[
+                 comparisonData,
+                 <|
+                    "AssoCritical" -> AssoCritical,
+                    "Status" -> status,
+                    "NumericBackendUsed" -> numericBackendUsedQ,
+                    "NumericBackendFallbackReason" -> numericBackendFallbackReason,
+                    "NumericBackendSolveTime" -> numericBackendSolveTime
+                 |>
+             ]]]
     ];
 
 Options[IsCriticalSolution] = {

--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -85,7 +85,8 @@ SelectFlowAssociation[assoc_Association] :=
 
 BuildSolverComparisonData[Eqs_Association, solution_] :=
     Module[{missing, flowAssoc, edgeList, edgePairs, signedFlowRules, signedExprs,
-         signedVals, B, KM, jj, jjVals, residual},
+         signedVals, B, KM, jj, jjVals, residual, numericState, encodedFlowVec,
+         fastSignedVals, fastResidual, usedFastSignedQ, usedFastResidualQ},
         missing = Missing["NotAvailable"];
         edgeList = Lookup[Eqs, "edgeList", {}];
         If[!AssociationQ[solution],
@@ -101,26 +102,65 @@ BuildSolverComparisonData[Eqs_Association, solution_] :=
             ]
         ];
         flowAssoc = SelectFlowAssociation[solution];
-        edgePairs = List @@@ edgeList;
-        signedFlowRules = Lookup[Eqs, "SignedFlows", <||>];
-        signedExprs =
-            (If[KeyExistsQ[signedFlowRules, #], signedFlowRules[#], missing] & /@ edgePairs) /.
-                Join[
-                    Lookup[Eqs, "RuleBalanceGatheringFlows", <||>],
-                    Lookup[Eqs, "RuleExitFlowsIn", <||>],
-                    Lookup[Eqs, "RuleEntryOut", <||>]
-                ];
-        signedVals = Quiet @ Check[signedExprs /. flowAssoc, missing];
-        If[!ListQ[signedVals] || !VectorQ[signedVals, NumericQ],
-            signedVals = missing
-        ];
-        {B, KM, jj} = MFGraphs`GetKirchhoffLinearSystem[Eqs];
-        jjVals = Lookup[flowAssoc, jj, missing];
-        residual =
-            If[ListQ[jjVals] && VectorQ[jjVals, NumericQ],
-                N @ Norm[KM . jjVals - B, Infinity],
+        numericState = Lookup[Eqs, "NumericState", Missing["NotAvailable"]];
+        usedFastSignedQ = False;
+        usedFastResidualQ = False;
+        signedVals = missing;
+        residual = missing;
+
+        If[AssociationQ[numericState],
+            encodedFlowVec = Quiet @ Check[
+                EncodeFlowAssociation[numericState, flowAssoc],
                 missing
             ];
+            If[ListQ[encodedFlowVec] && VectorQ[encodedFlowVec, NumericQ],
+                fastSignedVals = Quiet @ Check[
+                    ComputeSignedEdgeFlowsFast[numericState, encodedFlowVec],
+                    missing
+                ];
+                If[
+                    ListQ[fastSignedVals] &&
+                    VectorQ[fastSignedVals, NumericQ] &&
+                    Length[fastSignedVals] === Length[edgeList],
+                    signedVals = fastSignedVals;
+                    usedFastSignedQ = True
+                ];
+                fastResidual = Quiet @ Check[
+                    ComputeKirchhoffResidualFast[numericState, encodedFlowVec],
+                    missing
+                ];
+                If[NumericQ[fastResidual],
+                    residual = fastResidual;
+                    usedFastResidualQ = True
+                ]
+            ]
+        ];
+
+        If[!usedFastSignedQ,
+            edgePairs = List @@@ edgeList;
+            signedFlowRules = Lookup[Eqs, "SignedFlows", <||>];
+            signedExprs =
+                (If[KeyExistsQ[signedFlowRules, #], signedFlowRules[#], missing] & /@ edgePairs) /.
+                    Join[
+                        Lookup[Eqs, "RuleBalanceGatheringFlows", <||>],
+                        Lookup[Eqs, "RuleExitFlowsIn", <||>],
+                        Lookup[Eqs, "RuleEntryOut", <||>]
+                    ];
+            signedVals = Quiet @ Check[signedExprs /. flowAssoc, missing];
+            If[!ListQ[signedVals] || !VectorQ[signedVals, NumericQ],
+                signedVals = missing
+            ]
+        ];
+
+        If[!usedFastResidualQ,
+            {B, KM, jj} = MFGraphs`GetKirchhoffLinearSystem[Eqs];
+            jjVals = Lookup[flowAssoc, jj, missing];
+            residual =
+                If[ListQ[jjVals] && VectorQ[jjVals, NumericQ],
+                    N @ Norm[KM . jjVals - B, Infinity],
+                    missing
+                ]
+        ];
         <|
             "ComparableEdges" -> edgeList,
             "FlowAssociation" -> flowAssoc,

--- a/MFGraphs/Tests/critical-numeric-backend.mt
+++ b/MFGraphs/Tests/critical-numeric-backend.mt
@@ -1,0 +1,86 @@
+(* Wolfram Language Test file *)
+(* Critical numeric backend integration and fallback behavior. *)
+
+Test[
+    Module[{data, d2e, symbolic, numeric, drift},
+        data = GetExampleData[7] /. {I1 -> 100, U1 -> 0, U2 -> 0};
+        d2e = DataToEquations[data];
+        symbolic = Quiet[
+            CriticalCongestionSolver[
+                Join[d2e, <|"CriticalNumericBackendMode" -> False|>]
+            ]
+        ];
+        numeric = Quiet[
+            CriticalCongestionSolver[
+                Join[d2e, <|"CriticalNumericBackendMode" -> "Force"|>]
+            ]
+        ];
+        drift = Max[Abs[symbolic["ComparableFlowVector"] - numeric["ComparableFlowVector"]]];
+        Lookup[symbolic, {"ResultKind", "Feasibility", "Message"}] ===
+            Lookup[numeric, {"ResultKind", "Feasibility", "Message"}] &&
+        TrueQ[Lookup[numeric, "NumericBackendUsed", False]] &&
+        Lookup[numeric, "NumericBackendFallbackReason", Missing["NotAvailable"]] === None &&
+        NumericQ[Lookup[numeric, "NumericBackendSolveTime", Missing["NotAvailable"]]] &&
+        NumericQ[drift] && drift <= 10^-6 &&
+        IsCriticalSolution[numeric]
+    ],
+    True,
+    TestID -> "Critical numeric backend parity: forced backend matches symbolic result"
+]
+
+Test[
+    Module[{data, d2e, result},
+        data = GetExampleData[7] /. {I1 -> 100, U1 -> 0, U2 -> 0};
+        d2e = DataToEquations[data];
+        result = Quiet[
+            CriticalCongestionSolver[
+                Join[KeyDrop[d2e, "NumericState"], <|"CriticalNumericBackendMode" -> "Force"|>]
+            ]
+        ];
+        !TrueQ[Lookup[result, "NumericBackendUsed", False]] &&
+        Lookup[result, "NumericBackendFallbackReason", Missing["NotAvailable"]] === "IneligibleInput" &&
+        IsCriticalSolution[result]
+    ],
+    True,
+    TestID -> "Critical numeric backend fallback: ineligible input stays symbolic"
+]
+
+Test[
+    Module[{data, d2e, result},
+        data = GetExampleData[7] /. {I1 -> 100, U1 -> 0, U2 -> 0};
+        d2e = DataToEquations[data];
+        result = Quiet[
+            CriticalCongestionSolver[
+                Join[
+                    d2e,
+                    <|
+                        "CriticalNumericBackendMode" -> "Force",
+                        "ForceNumericBackendValidationFailure" -> True
+                    |>
+                ]
+            ]
+        ];
+        !TrueQ[Lookup[result, "NumericBackendUsed", False]] &&
+        Lookup[result, "NumericBackendFallbackReason", Missing["NotAvailable"]] === "ForcedValidationFailure" &&
+        Lookup[result, "ResultKind", Missing["NotAvailable"]] === "Success" &&
+        Lookup[result, "Feasibility", Missing["NotAvailable"]] === "Feasible" &&
+        IsCriticalSolution[result]
+    ],
+    True,
+    TestID -> "Critical numeric backend fallback: forced validation reject demotes numeric candidate"
+]
+
+Test[
+    Module[{data, d2e, result},
+        data = GetExampleData[7] /. {I1 -> 100, U1 -> 0, U2 -> 0};
+        d2e = DataToEquations[data];
+        result = Quiet[CriticalCongestionSolver[d2e]];
+        And @@ (KeyExistsQ[result, #] & /@ {
+            "NumericBackendUsed",
+            "NumericBackendFallbackReason",
+            "NumericBackendSolveTime"
+        })
+    ],
+    True,
+    TestID -> "Critical numeric backend telemetry: keys always present"
+]

--- a/MFGraphs/Tests/critical-numeric-backend.mt
+++ b/MFGraphs/Tests/critical-numeric-backend.mt
@@ -74,6 +74,31 @@ Test[
     Module[{data, d2e, result},
         data = GetExampleData[7] /. {I1 -> 100, U1 -> 0, U2 -> 0};
         d2e = DataToEquations[data];
+        result = Quiet[
+            CriticalCongestionSolver[
+                Join[
+                    d2e,
+                    <|
+                        "CriticalNumericBackendMode" -> "Force",
+                        "CriticalNumericBackendTimeLimit" -> 10^-9
+                    |>
+                ]
+            ]
+        ];
+        !TrueQ[Lookup[result, "NumericBackendUsed", False]] &&
+        Lookup[result, "NumericBackendFallbackReason", Missing["NotAvailable"]] === "NumericBackendTimeout" &&
+        Lookup[result, "ResultKind", Missing["NotAvailable"]] === "Success" &&
+        Lookup[result, "Feasibility", Missing["NotAvailable"]] === "Feasible" &&
+        IsCriticalSolution[result]
+    ],
+    True,
+    TestID -> "Critical numeric backend fallback: timeout fast-fails to symbolic solver"
+]
+
+Test[
+    Module[{data, d2e, result},
+        data = GetExampleData[7] /. {I1 -> 100, U1 -> 0, U2 -> 0};
+        d2e = DataToEquations[data];
         result = Quiet[CriticalCongestionSolver[d2e]];
         And @@ (KeyExistsQ[result, #] & /@ {
             "NumericBackendUsed",

--- a/Scripts/BenchmarkSuite.wls
+++ b/Scripts/BenchmarkSuite.wls
@@ -16,6 +16,7 @@ Print[];
 PrependTo[$Path, Directory[]];
 Needs["MFGraphs`"];
 $MFGraphsVerbose = False;
+$HistoryLength = 0;
 
 (* --- Load helpers --- *)
 Get[FileNameJoin[{Directory[], "Scripts", "BenchmarkHelpers.wls"}]];
@@ -39,7 +40,7 @@ $HistoryInterpretation = None;
 $SelectedTier = "all";
 $SelectedCase = All;
 $TimeoutOverride = Automatic;
-$IsolationModeArg = "inprocess";
+$IsolationModeArg = "auto";
 
 Module[{args = Rest[$ScriptCommandLine], i = 1, arg, parsedTimeout, parsedIsolation},
   While[i <= Length[args],
@@ -304,6 +305,9 @@ BenchmarkCase[key_] :=
     Print["\n--- Case: ", key, " (tier: ", tier, ") ---"];
     Print["  Isolation: ", caseIsolationMode];
 
+    Quiet @ Check[MFGraphs`Private`ClearSolveCache[], Null];
+    Quiet @ Check[ClearSystemCache[], Null];
+
     (* Load data *)
     data = Quiet @ Check[GetExampleData[key], $Failed];
     If[data === $Failed,
@@ -371,6 +375,8 @@ BenchmarkCase[key_] :=
 
     (* Store D2E time in all results *)
     results = Map[Append[#, "D2ETime" -> d2eTime] &, results];
+    Quiet @ Check[MFGraphs`Private`ClearSolveCache[], Null];
+    Quiet @ Check[ClearSystemCache[], Null];
 
     results
   ];
@@ -428,10 +434,10 @@ If[$HistoryTag =!= None,
       If[Length[tierRows2] === 0, Return[""]];
       caseKeys = DeleteDuplicates[#["Key"] & /@ tierRows2];
       tableLines = {"#### Tier: " <> tierName, "",
-        "| Case | D2E (s) | CritSolver (s) | NLSolver inc (s) | NLSolver standalone est (s) | Monotone (s) | Total (s) | Case Status |",
-        "|------|---------|---------------|------------------|----------------------------|--------------|-----------|-------------|"};
+        "| Case | D2E (s) | CritSolver (s) | NLSolver inc (s) | NLSolver standalone est (s) | Monotone inc (s) | Monotone standalone est (s) | Total (s) | Case Status |",
+        "|------|---------|---------------|------------------|----------------------------|------------------|-----------------------------|-----------|-------------|"};
       Do[
-        Module[{caseRows, d2eT, critT, nlT, monoT, totalT, caseStatus, nlEstST},
+        Module[{caseRows, d2eT, critT, nlT, monoT, totalT, caseStatus, nlEstST, monoEstST},
           caseRows = Select[tierRows2, #["Key"] === k &];
           d2eT = SelectFirst[caseRows, True&, <||>]["D2ETime"];
           critT = SelectFirst[Select[caseRows, #["Solver"] === "CriticalCongestion"&], True&, <||>];
@@ -443,6 +449,7 @@ If[$HistoryTag =!= None,
           nlST   = fmtT[If[KeyExistsQ[nlT, "SolveTime"], nlT["SolveTime"], Missing[]]];
           nlEstST = fmtT[If[KeyExistsQ[nlT, "EstimatedStandaloneSolveTime"], nlT["EstimatedStandaloneSolveTime"], Missing[]]];
           monoST = fmtT[If[KeyExistsQ[monoT, "SolveTime"], monoT["SolveTime"], Missing[]]];
+          monoEstST = fmtT[If[KeyExistsQ[monoT, "EstimatedStandaloneSolveTime"], monoT["EstimatedStandaloneSolveTime"], Missing[]]];
           totalN = Plus @@ Select[{
             If[KeyExistsQ[critT, "SolveTime"] && NumericQ[critT["SolveTime"]], critT["SolveTime"], 0],
             If[KeyExistsQ[nlT, "SolveTime"] && NumericQ[nlT["SolveTime"]], nlT["SolveTime"], 0],
@@ -452,7 +459,7 @@ If[$HistoryTag =!= None,
           caseStatus = CaseStatusSummary[caseRows];
           AppendTo[tableLines,
             "| " <> k <> " | " <> d2eT <> " | " <> critST <> " | " <>
-            nlST <> " | " <> nlEstST <> " | " <> monoST <> " | " <> totalT <> " | " <> caseStatus <> " |"]
+            nlST <> " | " <> nlEstST <> " | " <> monoST <> " | " <> monoEstST <> " | " <> totalT <> " | " <> caseStatus <> " |"]
         ],
         {k, caseKeys}
       ];

--- a/Scripts/RunTests.wls
+++ b/Scripts/RunTests.wls
@@ -15,6 +15,7 @@ $TestSuites = <|
         "007-critical_congestion.mt",
         "007-critical_congestion_ok.mt",
         "012-critical_congestion.mt",
+        "critical-numeric-backend.mt",
         "infeasible-status.mt",
         "monotone-monotonicity.mt",
         "monotone-solver.mt",


### PR DESCRIPTION
## Summary
This PR integrates a guarded critical numeric backend with strict safety gates and symbolic fallback.

## Defensive architecture
- numeric path is guarded by $CriticalNumericBackendEnabled = False (default)
- numeric backend runs only for eligible inputs
- acceptance gate requires feasible status and critical validation
- if acceptance fails, solver automatically reruns via existing direct/symbolic path

## Scope
- integrate numeric backend into CriticalCongestionSolver
- add internal telemetry keys without changing required public envelope contract:
  - NumericBackendUsed
  - NumericBackendFallbackReason
  - NumericBackendSolveTime
- preserve existing direct/symbolic behavior as fallback
- add critical numeric backend parity/fallback tests
- benchmark script hygiene updates:
  - default isolation to auto
  - set $HistoryLength = 0
  - clear per-case caches
  - clarify Monotone incremental vs standalone estimate columns

## Validation
- wolframscript -file Scripts/RunTests.wls fast
- wolframscript -file Scripts/RunTests.wls slow
- wolframscript -file Scripts/RunTests.wls