### PR TITLE
feat(api): unify solver interface routing

### DIFF
--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -52,6 +52,19 @@ when Length[list] >= $MFGraphsParallelThreshold (and kernels are already running
 or Length[list] >= $MFGraphsParallelLaunchThreshold (when kernels must be launched).
 This avoids paying ~3s kernel launch overhead for small workloads.";
 
+SolveMFG::usage =
+"SolveMFG[input, Method -> m] dispatches to the selected stationary solver and returns
+its standardized result association.
+
+Supported methods:
+  \"Automatic\" (placeholder in phase 1, routes to CriticalCongestion)
+  \"CriticalCongestion\"
+  \"NonLinear\"
+  \"Monotone\"
+
+input can be either raw data (association accepted by DataToEquations) or an already
+compiled equation association.";
+
 $MFGraphsParallelLaunchThreshold::usage =
 "$MFGraphsParallelLaunchThreshold is the minimum list length required to justify
 launching parallel subkernels. Only applies when $KernelCount === 0. Default is 50.";
@@ -205,5 +218,66 @@ Get["MFGraphs`DataToEquations`"];
 Get["MFGraphs`NonLinearSolver`"];
 Get["MFGraphs`Monotone`"];
 Get["MFGraphs`TimeDependentSolver`"];
+
+Options[SolveMFG] = {
+    Method -> "Automatic"
+};
+
+SolveMFGUnknownMethodResult[method_] :=
+    <|
+        "Solver" -> "SolveMFG",
+        "ResultKind" -> "Failure",
+        "Feasibility" -> Missing["NotApplicable"],
+        "Message" -> "UnknownMethod",
+        "Method" -> method,
+        "Solution" -> Missing["NotAvailable"],
+        "Convergence" -> Missing["NotApplicable"]
+    |>;
+
+SolveMFGCompiledInputQ[input_Association] :=
+    KeyExistsQ[input, "EqGeneral"] &&
+    KeyExistsQ[input, "js"] &&
+    KeyExistsQ[input, "jts"];
+
+SolveMFG[input_Association, opts:OptionsPattern[]] :=
+    Module[{method, normalizedMethod, d2e},
+        method = OptionValue[Method];
+        normalizedMethod = ToString[method];
+
+        Switch[normalizedMethod,
+            "Monotone" | "MonotoneSolver",
+                If[
+                    SolveMFGCompiledInputQ[input],
+                    MonotoneSolver[
+                        input,
+                        Sequence @@ FilterRules[{opts}, Options[MonotoneSolver]]
+                    ],
+                    MonotoneSolverFromData[
+                        input,
+                        Sequence @@ FilterRules[{opts}, Options[MonotoneSolverFromData]]
+                    ]
+                ]
+            ,
+            "CriticalCongestion" | "CriticalCongestionSolver" | "Automatic",
+                d2e = If[SolveMFGCompiledInputQ[input], input, DataToEquations[input]];
+                CriticalCongestionSolver[
+                    d2e,
+                    Sequence @@ FilterRules[{opts}, Options[CriticalCongestionSolver]]
+                ]
+            ,
+            "NonLinear" | "NonLinearSolver",
+                d2e = If[SolveMFGCompiledInputQ[input], input, DataToEquations[input]];
+                NonLinearSolver[
+                    d2e,
+                    Sequence @@ FilterRules[{opts}, Options[NonLinearSolver]]
+                ]
+            ,
+            _,
+                SolveMFGUnknownMethodResult[method]
+        ]
+    ];
+
+SolveMFG[_, opts:OptionsPattern[]] :=
+    SolveMFGUnknownMethodResult[OptionValue[Method]];
 
 EndPackage[];

--- a/MFGraphs/Tests/package-loading.mt
+++ b/MFGraphs/Tests/package-loading.mt
@@ -5,6 +5,7 @@
 Test[
     NameQ["MFGraphs`DataToEquations"] && NameQ["MFGraphs`CriticalCongestionSolver"] &&
     NameQ["MFGraphs`NonLinearSolver"] && NameQ["MFGraphs`MonotoneSolverFromData"] &&
+    NameQ["MFGraphs`SolveMFG"] &&
     NameQ["MFGraphs`GetExampleData"] && NameQ["MFGraphs`DNFReduce"] &&
     NameQ["MFGraphs`GetKirchhoffLinearSystem"] && NameQ["MFGraphs`V"] &&
     NameQ["MFGraphs`alpha"] && NameQ["MFGraphs`g"] &&

--- a/MFGraphs/Tests/solve-mfg.mt
+++ b/MFGraphs/Tests/solve-mfg.mt
@@ -1,0 +1,116 @@
+(* Wolfram Language Test file *)
+(* Thin-routing tests for SolveMFG (phase 1 unified API). *)
+
+Test[
+    Module[{data, result},
+        data = GetExampleData[7] /. {I1 -> 100, U1 -> 0, U2 -> 0};
+        result = Quiet[SolveMFG[data]];
+        Lookup[result, {"Solver", "ResultKind", "Feasibility", "Message"}] ===
+            {"CriticalCongestion", "Success", "Feasible", None}
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG routing: Automatic defaults to critical congestion"
+]
+
+Test[
+    Module[{data, d2e, direct, routed, drift},
+        data = GetExampleData[7] /. {I1 -> 100, U1 -> 0, U2 -> 0};
+        d2e = DataToEquations[data];
+        direct = Quiet[CriticalCongestionSolver[d2e]];
+        routed = Quiet[SolveMFG[d2e, Method -> "CriticalCongestion"]];
+        drift = Max[Abs[direct["ComparableFlowVector"] - routed["ComparableFlowVector"]]];
+        Lookup[direct, {"ResultKind", "Feasibility", "Message"}] ===
+            Lookup[routed, {"ResultKind", "Feasibility", "Message"}] &&
+        NumericQ[drift] && drift <= 10^-8
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG routing: CriticalCongestion method matches direct solver on compiled input"
+]
+
+Test[
+    Module[{data, result},
+        data = GetExampleData[3] /. {I1 -> 2, U1 -> 0};
+        result = Quiet[
+            SolveMFG[
+                data,
+                Method -> "NonLinear",
+                "MaxIterations" -> 20,
+                "Tolerance" -> 10^-8,
+                "PotentialFunction" -> Function[{x, edge}, 0],
+                "CongestionExponentFunction" -> Function[edge, 1],
+                "InteractionFunction" -> Function[{m, edge}, -1/m^2]
+            ]
+        ];
+        Lookup[result, {"Solver", "ResultKind", "Feasibility", "Message"}] ===
+            {"NonLinear", "Success", "Feasible", None}
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG routing: NonLinear method dispatches from raw data"
+]
+
+Test[
+    Module[{data, result},
+        data = GetExampleData[3] /. {I1 -> 80, U1 -> 0};
+        result = Quiet[
+            SolveMFG[
+                data,
+                Method -> "Monotone",
+                "ResidualTolerance" -> 10^-6,
+                "MaxTime" -> 10,
+                "MaxSteps" -> 2000,
+                "PotentialFunction" -> Function[{x, edge}, 0],
+                "CongestionExponentFunction" -> Function[edge, 1],
+                "InteractionFunction" -> Function[{m, edge}, -1/m^2]
+            ]
+        ];
+        Lookup[result, "Solver", None] === "Monotone" &&
+        MemberQ[{"Success", "NonConverged"}, Lookup[result, "ResultKind", None]]
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG routing: Monotone method dispatches from raw data"
+]
+
+Test[
+    Module[{data, d2e, result},
+        data = GetExampleData[3] /. {I1 -> 80, U1 -> 0};
+        d2e = DataToEquations[data];
+        result = Quiet[
+            SolveMFG[
+                d2e,
+                Method -> "Monotone",
+                "ResidualTolerance" -> 10^-6,
+                "MaxTime" -> 10,
+                "MaxSteps" -> 2000,
+                "PotentialFunction" -> Function[{x, edge}, 0],
+                "CongestionExponentFunction" -> Function[edge, 1],
+                "InteractionFunction" -> Function[{m, edge}, -1/m^2]
+            ]
+        ];
+        Lookup[result, "Solver", None] === "Monotone" &&
+        AssociationQ[Lookup[result, "Convergence", Missing["NotAvailable"]]]
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG routing: Monotone method accepts compiled equation associations"
+]
+
+Test[
+    Module[{result},
+        result = SolveMFG[<||>, Method -> "NotAMethod"];
+        Lookup[result, {"Solver", "ResultKind", "Message", "Method"}] ===
+            {"SolveMFG", "Failure", "UnknownMethod", "NotAMethod"}
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG routing: unknown method returns failure envelope"
+]

--- a/Scripts/RunTests.wls
+++ b/Scripts/RunTests.wls
@@ -20,6 +20,7 @@ $TestSuites = <|
         "monotone-monotonicity.mt",
         "monotone-solver.mt",
         "numeric-state.mt",
+        "solve-mfg.mt",
         "solver-contracts.mt",
         "time-dependent-data.mt"
     },


### PR DESCRIPTION
Summary: add SolveMFG as a unified top-level stationary solver entrypoint with thin phase-1 routing only. Supports raw data and compiled equation associations. Existing solver internals and envelopes are unchanged.

Routing phase 1:
- Automatic routes to CriticalCongestion as placeholder behavior.
- CriticalCongestion routes to CriticalCongestionSolver.
- Monotone routes to MonotoneSolverFromData for raw data, or MonotoneSolver for compiled input.
- NonLinear routes to NonLinearSolver.
- Unknown methods return a standardized failure envelope from SolveMFG.

Tests:
- add dedicated MFGraphs/Tests/solve-mfg.mt routing tests
- add package-loading symbol check for SolveMFG export
- include solve-mfg.mt in fast/all test suites

Verification:
- RunTests fast: 66/66 pass
- RunTests all: 77/77 pass

Follow-up: automatic cascading fallback policy intentionally deferred to next PR.