### PR TITLE
feat(api): automatic SolveMFG cascade with method trace

### DIFF
--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -239,6 +239,111 @@ SolveMFGCompiledInputQ[input_Association] :=
     KeyExistsQ[input, "js"] &&
     KeyExistsQ[input, "jts"];
 
+$SolveMFGRequiredEnvelopeKeys = {"Solver", "ResultKind", "Feasibility", "Message"};
+
+SolveMFGClassifyOutcome[result_] :=
+    Module[{resultKind, feasibility, message},
+        If[!AssociationQ[result], Return["Abort"]];
+        If[!And @@ (KeyExistsQ[result, #] & /@ $SolveMFGRequiredEnvelopeKeys), Return["Abort"]];
+        resultKind = Lookup[result, "ResultKind", Missing["NotAvailable"]];
+        feasibility = Lookup[result, "Feasibility", Missing["NotAvailable"]];
+        message = Lookup[result, "Message", Missing["NotAvailable"]];
+        Which[
+            resultKind === "Success" && feasibility === "Feasible", "Done",
+            resultKind === "Degenerate" && message === "DegenerateCase", "Done",
+            feasibility === "Infeasible" || MemberQ[{"Failure", "NonConverged"}, resultKind], "Fallback",
+            True, "Abort"
+        ]
+    ];
+
+SolveMFGBuildTraceEntry[method_, result_, decision_] :=
+    Module[{solver, resultKind, feasibility, message},
+        solver = If[AssociationQ[result], Lookup[result, "Solver", "InvalidSolver"], "InvalidSolver"];
+        resultKind = If[AssociationQ[result], Lookup[result, "ResultKind", Missing["NotAvailable"]], Missing["NotAvailable"]];
+        feasibility = If[AssociationQ[result], Lookup[result, "Feasibility", Missing["NotAvailable"]], Missing["NotAvailable"]];
+        message = If[AssociationQ[result], Lookup[result, "Message", Missing["NotAvailable"]], "InvalidSolverReturnShape"];
+        <|
+            "Method" -> method,
+            "Solver" -> solver,
+            "ResultKind" -> resultKind,
+            "Feasibility" -> feasibility,
+            "Message" -> message,
+            "Decision" -> decision
+        |>
+    ];
+
+SolveMFGFinalizeWithTrace[result_Association, methodUsed_, trace_List] :=
+    Join[result, <|"MethodUsed" -> methodUsed, "MethodTrace" -> trace|>];
+
+SolveMFGAbortResult[message_, methodUsed_, trace_List] :=
+    <|
+        "Solver" -> "SolveMFG",
+        "ResultKind" -> "Failure",
+        "Feasibility" -> Missing["NotApplicable"],
+        "Message" -> message,
+        "Method" -> "Automatic",
+        "MethodUsed" -> methodUsed,
+        "MethodTrace" -> trace,
+        "Solution" -> Missing["NotAvailable"],
+        "Convergence" -> Missing["NotApplicable"]
+    |>;
+
+SolveMFGAutomaticDispatch[input_Association, opts_List] :=
+    Module[{d2e, result = Missing["NotAvailable"], decision, trace = {}, methodUsed = "Automatic", attempts},
+        d2e = If[SolveMFGCompiledInputQ[input], input, Quiet @ Check[DataToEquations[input], $Failed]];
+        If[!AssociationQ[d2e],
+            Return[SolveMFGAbortResult["DataToEquationsFailed", methodUsed, trace], Module]
+        ];
+        attempts = {
+            <|
+                "Method" -> "CriticalCongestion",
+                "Run" -> Function[
+                    CriticalCongestionSolver[
+                        d2e,
+                        Sequence @@ FilterRules[opts, Options[CriticalCongestionSolver]]
+                    ]
+                ]
+            |>,
+            <|
+                "Method" -> "Monotone",
+                "Run" -> Function[
+                    MonotoneSolver[
+                        d2e,
+                        Sequence @@ FilterRules[opts, Options[MonotoneSolver]]
+                    ]
+                ]
+            |>,
+            <|
+                "Method" -> "NonLinear",
+                "Run" -> Function[
+                    NonLinearSolver[
+                        d2e,
+                        Sequence @@ FilterRules[opts, Options[NonLinearSolver]]
+                    ]
+                ]
+            |>
+        };
+        Do[
+            result = attempt["Run"][];
+            decision = SolveMFGClassifyOutcome[result];
+            methodUsed = attempt["Method"];
+            trace = Append[trace, SolveMFGBuildTraceEntry[methodUsed, result, decision]];
+            Switch[decision,
+                "Done",
+                    Return[SolveMFGFinalizeWithTrace[result, methodUsed, trace], Module],
+                "Fallback",
+                    Null,
+                _,
+                    Return[SolveMFGAbortResult["InvalidSolverReturnShape", methodUsed, trace], Module]
+            ],
+            {attempt, attempts}
+        ];
+        If[AssociationQ[result],
+            SolveMFGFinalizeWithTrace[result, methodUsed, trace],
+            SolveMFGAbortResult["InvalidSolverReturnShape", methodUsed, trace]
+        ]
+    ];
+
 SolveMFG[input_Association, opts:OptionsPattern[]] :=
     Module[{method, normalizedMethod, d2e},
         method = OptionValue[Method];
@@ -258,12 +363,15 @@ SolveMFG[input_Association, opts:OptionsPattern[]] :=
                     ]
                 ]
             ,
-            "CriticalCongestion" | "CriticalCongestionSolver" | "Automatic",
+            "CriticalCongestion" | "CriticalCongestionSolver",
                 d2e = If[SolveMFGCompiledInputQ[input], input, DataToEquations[input]];
                 CriticalCongestionSolver[
                     d2e,
                     Sequence @@ FilterRules[{opts}, Options[CriticalCongestionSolver]]
                 ]
+            ,
+            "Automatic",
+                SolveMFGAutomaticDispatch[input, {opts}]
             ,
             "NonLinear" | "NonLinearSolver",
                 d2e = If[SolveMFGCompiledInputQ[input], input, DataToEquations[input]];

--- a/MFGraphs/NonLinearSolver.wl
+++ b/MFGraphs/NonLinearSolver.wl
@@ -104,7 +104,7 @@ NonLinearSolver[Eqs_, OptionsPattern[]] :=
              MaxIter = OptionValue["MaxIterations"], tol = OptionValue["Tolerance"],
              status, resultKind, message, solution, comparisonData, convergenceData,
              flowDelta = Missing["NotAvailable"], iterations, stopReason, solveTime,
-             seedMethod, timingResult, residualHistory = {}},
+             seedMethod, timingResult, residualHistory = {}, demotedDueToFeasibilityQ},
                 {solveTime, timingResult} = AbsoluteTiming[
                     If[ KeyExistsQ[PreEqs, "AssoNonCritical"],
                         AssoNonCritical = PreEqs["AssoNonCritical"];
@@ -193,7 +193,14 @@ NonLinearSolver[Eqs_, OptionsPattern[]] :=
                         MemberQ[{"ToleranceMet", "FixedPointReached"}, stopReason], "Success",
                         True, "NonConverged"
                     ];
-                message = If[resultKind === "Success", None, stopReason];
+                demotedDueToFeasibilityQ = resultKind === "Success" && status =!= "Feasible";
+                If[demotedDueToFeasibilityQ, resultKind = "NonConverged"];
+                message =
+                    Which[
+                        resultKind === "Success", None,
+                        demotedDueToFeasibilityQ, "FlowFeasibilityFailed",
+                        True, stopReason
+                    ];
                 solution = If[AssociationQ[AssoNonCritical], AssoNonCritical, Missing["NotAvailable"]];
                 comparisonData = BuildSolverComparisonData[PreEqs, solution];
                 convergenceData = <|

--- a/MFGraphs/Tests/solve-mfg.mt
+++ b/MFGraphs/Tests/solve-mfg.mt
@@ -114,3 +114,229 @@ Test[
     ,
     TestID -> "SolveMFG routing: unknown method returns failure envelope"
 ]
+
+(* Automatic cascade tests (issue #23): trace + strict fallback/abort behavior. *)
+
+Test[
+    Module[{compiled, result, trace},
+        compiled = <|"EqGeneral" -> True, "js" -> {}, "jts" -> {}|>;
+        result = Block[{CriticalCongestionSolver, MonotoneSolver, NonLinearSolver},
+            CriticalCongestionSolver[___] =
+                <|
+                    "Solver" -> "CriticalCongestion",
+                    "ResultKind" -> "Failure",
+                    "Feasibility" -> "Infeasible",
+                    "Message" -> "NoSolution",
+                    "Solution" -> Missing["NotAvailable"],
+                    "Convergence" -> Missing["NotApplicable"]
+                |>;
+            MonotoneSolver[___] =
+                <|
+                    "Solver" -> "Monotone",
+                    "ResultKind" -> "Success",
+                    "Feasibility" -> "Feasible",
+                    "Message" -> None,
+                    "Solution" -> <||>,
+                    "Convergence" -> <||>
+                |>;
+            NonLinearSolver[___] =
+                <|
+                    "Solver" -> "NonLinear",
+                    "ResultKind" -> "Success",
+                    "Feasibility" -> "Feasible",
+                    "Message" -> None,
+                    "Solution" -> <||>,
+                    "Convergence" -> <||>
+                |>;
+            SolveMFG[compiled, Method -> "Automatic"]
+        ];
+        trace = Lookup[result, "MethodTrace", {}];
+        Lookup[result, {"Solver", "MethodUsed", "ResultKind", "Feasibility", "Message"}] ===
+            {"Monotone", "Monotone", "Success", "Feasible", None} &&
+        Length[trace] === 2 &&
+        Lookup[trace[[1]], "Decision", None] === "Fallback" &&
+        Lookup[trace[[2]], "Decision", None] === "Done"
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG automatic: recoverable critical failure cascades to monotone"
+]
+
+Test[
+    Module[{compiled, result, trace},
+        compiled = <|"EqGeneral" -> True, "js" -> {}, "jts" -> {}|>;
+        result = Block[{CriticalCongestionSolver, MonotoneSolver, NonLinearSolver},
+            CriticalCongestionSolver[___] =
+                <|
+                    "Solver" -> "CriticalCongestion",
+                    "ResultKind" -> "Success",
+                    "Feasibility" -> "Infeasible",
+                    "Message" -> None,
+                    "Solution" -> <||>,
+                    "Convergence" -> <||>
+                |>;
+            MonotoneSolver[___] =
+                <|
+                    "Solver" -> "Monotone",
+                    "ResultKind" -> "Success",
+                    "Feasibility" -> "Feasible",
+                    "Message" -> None,
+                    "Solution" -> <||>,
+                    "Convergence" -> <||>
+                |>;
+            NonLinearSolver[___] =
+                <|
+                    "Solver" -> "NonLinear",
+                    "ResultKind" -> "Success",
+                    "Feasibility" -> "Feasible",
+                    "Message" -> None,
+                    "Solution" -> <||>,
+                    "Convergence" -> <||>
+                |>;
+            SolveMFG[compiled, Method -> "Automatic"]
+        ];
+        trace = Lookup[result, "MethodTrace", {}];
+        Lookup[result, {"Solver", "MethodUsed", "ResultKind", "Feasibility"}] ===
+            {"Monotone", "Monotone", "Success", "Feasible"} &&
+        Length[trace] === 2 &&
+        Lookup[trace[[1]], "ResultKind", None] === "Success" &&
+        Lookup[trace[[1]], "Feasibility", None] === "Infeasible" &&
+        Lookup[trace[[1]], "Decision", None] === "Fallback"
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG automatic: infeasible false-success critical result falls back"
+]
+
+Test[
+    Module[{compiled, result, trace},
+        compiled = <|"EqGeneral" -> True, "js" -> {}, "jts" -> {}|>;
+        result = Block[{CriticalCongestionSolver, MonotoneSolver, NonLinearSolver},
+            CriticalCongestionSolver[___] =
+                <|
+                    "Solver" -> "CriticalCongestion",
+                    "ResultKind" -> "Failure",
+                    "Feasibility" -> "Infeasible",
+                    "Message" -> "NoSolution",
+                    "Solution" -> Missing["NotAvailable"],
+                    "Convergence" -> Missing["NotApplicable"]
+                |>;
+            MonotoneSolver[___] =
+                <|
+                    "Solver" -> "Monotone",
+                    "ResultKind" -> "NonConverged",
+                    "Feasibility" -> "Infeasible",
+                    "Message" -> "ResidualExceedsTolerance",
+                    "Solution" -> Missing["NotAvailable"],
+                    "Convergence" -> <|"StopReason" -> "MaxTimeReached"|>
+                |>;
+            NonLinearSolver[___] =
+                <|
+                    "Solver" -> "NonLinear",
+                    "ResultKind" -> "Success",
+                    "Feasibility" -> "Feasible",
+                    "Message" -> None,
+                    "Solution" -> <||>,
+                    "Convergence" -> <||>
+                |>;
+            SolveMFG[compiled, Method -> "Automatic"]
+        ];
+        trace = Lookup[result, "MethodTrace", {}];
+        Lookup[result, {"Solver", "MethodUsed", "ResultKind", "Feasibility", "Message"}] ===
+            {"NonLinear", "NonLinear", "Success", "Feasible", None} &&
+        Length[trace] === 3 &&
+        Lookup[trace[[1]], "Decision", None] === "Fallback" &&
+        Lookup[trace[[2]], "Decision", None] === "Fallback" &&
+        Lookup[trace[[3]], "Decision", None] === "Done"
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG automatic: cascades through nonlinear on dual recoverable failures"
+]
+
+Test[
+    Module[{compiled, result, trace},
+        compiled = <|"EqGeneral" -> True, "js" -> {}, "jts" -> {}|>;
+        result = Block[{CriticalCongestionSolver},
+            CriticalCongestionSolver[___] = $Failed;
+            SolveMFG[compiled, Method -> "Automatic"]
+        ];
+        trace = Lookup[result, "MethodTrace", {}];
+        Lookup[result, {"Solver", "ResultKind", "Message", "MethodUsed"}] ===
+            {"SolveMFG", "Failure", "InvalidSolverReturnShape", "CriticalCongestion"} &&
+        Length[trace] === 1 &&
+        Lookup[trace[[1]], "Decision", None] === "Abort"
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG automatic: malformed solver return triggers strict abort"
+]
+
+Test[
+    Module[{compiled, result, trace, nonLinearCalls = 0},
+        compiled = <|"EqGeneral" -> True, "js" -> {}, "jts" -> {}|>;
+        result = Block[{CriticalCongestionSolver, MonotoneSolver, NonLinearSolver},
+            CriticalCongestionSolver[___] =
+                <|
+                    "Solver" -> "CriticalCongestion",
+                    "ResultKind" -> "Failure",
+                    "Feasibility" -> "Infeasible",
+                    "Message" -> "NoSolution",
+                    "Solution" -> Missing["NotAvailable"],
+                    "Convergence" -> Missing["NotApplicable"]
+                |>;
+            MonotoneSolver[___] =
+                <|
+                    "Solver" -> "Monotone",
+                    "ResultKind" -> "Degenerate",
+                    "Feasibility" -> Missing["NotApplicable"],
+                    "Message" -> "DegenerateCase",
+                    "Solution" -> Missing["NotAvailable"],
+                    "Convergence" -> <|"StopReason" -> "DegenerateCase"|>
+                |>;
+            NonLinearSolver[___] :=
+                (
+                    nonLinearCalls++;
+                    <|
+                        "Solver" -> "NonLinear",
+                        "ResultKind" -> "Success",
+                        "Feasibility" -> "Feasible",
+                        "Message" -> None,
+                        "Solution" -> <||>,
+                        "Convergence" -> <||>
+                    |>
+                );
+            SolveMFG[compiled, Method -> "Automatic"]
+        ];
+        trace = Lookup[result, "MethodTrace", {}];
+        Lookup[result, {"Solver", "MethodUsed", "ResultKind", "Message"}] ===
+            {"Monotone", "Monotone", "Degenerate", "DegenerateCase"} &&
+        nonLinearCalls === 0 &&
+        Length[trace] === 2 &&
+        Lookup[trace[[2]], "Decision", None] === "Done"
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG automatic: monotone degenerate case is terminal"
+]
+
+Test[
+    Module[{data, result, trace, methodUsed},
+        data = GetExampleData[7] /. {I1 -> 100, U1 -> 0, U2 -> 0};
+        result = Quiet[SolveMFG[data, Method -> "Automatic"]];
+        trace = Lookup[result, "MethodTrace", {}];
+        methodUsed = Lookup[result, "MethodUsed", Missing["NotAvailable"]];
+        Lookup[result, {"ResultKind", "Feasibility"}] === {"Success", "Feasible"} &&
+        ListQ[trace] && Length[trace] >= 1 &&
+        StringQ[methodUsed]
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG automatic: real-data run returns method trace and method used"
+]


### PR DESCRIPTION
Summary: Implements the Phase 2 automatic routing policy for `SolveMFG` and fixes a local convergence reporting bug.

Key Changes:
- `NonLinearSolver` now correctly demotes to `FlowFeasibilityFailed` if bounds are violated, preventing false `ToleranceMet` signals.
- `SolveMFG` with `Method -> "Automatic"` now executes a strict fallback cascade: `CriticalCongestion -> Monotone -> NonLinear`.
- Implements one-time `DataToEquations` compilation for the entire automatic pipeline to eliminate redundant matrix assemblies.
- Introduces `MethodUsed` and `MethodTrace` exclusively for automatic mode to provide complete diagnostic transparency.
- Added 6 `Block`-stubbed deterministic tests in `solve-mfg.mt` to verify fallback rules (including degenerate terminals and false-positive rejections).

Tests:
- `wolframscript -file Scripts/RunTests.wls fast`
- `wolframscript -file Scripts/RunTests.wls all`

Result: 83/83 passing.