### PR TITLE
test(core): add chain-two-exits regression case

### DIFF
--- a/MFGraphs/Examples/ExamplesData.wl
+++ b/MFGraphs/Examples/ExamplesData.wl
@@ -205,6 +205,24 @@ Begin["`Private`"];
         (*SwitchingCostsData=*){}
         },
 
+    (* Chain with two exits: 1 -> 2 -> 3, entry at 1, exits at 2 and 3 *)
+    "chain with two exits" -> {
+        (*VL=*){1, 2, 3},
+        (*AM=*){{0, 1, 0}, {0, 0, 1}, {0, 0, 0}},
+        (*DataIn=*){{1, I1}},
+        (*FinalCosts=*){{2, U1}, {3, U2}},
+        (*SwitchingCostsData=*){}
+        },
+
+    (* Numeric alias for chain with two exits *)
+    105 -> {
+        (*VL=*){1, 2, 3},
+        (*AM=*){{0, 1, 0}, {0, 0, 1}, {0, 0, 0}},
+        (*DataIn=*){{1, I1}},
+        (*FinalCosts=*){{2, U1}, {3, U2}},
+        (*SwitchingCostsData=*){}
+        },
+
     (* Y 2-in 1-out 3 vertices with switching *)
     15 -> {
         (*VL=*){1, 2, 3},

--- a/MFGraphs/Tests/solver-contracts.mt
+++ b/MFGraphs/Tests/solver-contracts.mt
@@ -14,12 +14,31 @@ Test[
         AssociationQ[result["SignedEdgeFlows"]] &&
         VectorQ[result["ComparableFlowVector"], NumericQ] &&
         NumericQ[result["KirchhoffResidual"]] &&
+        NumericQ[result["BoundaryMassResidual"]] &&
+        KeyExistsQ[result, "UtilityClassResidual"] &&
         IsFeasible[result]
     ]
     ,
     True
     ,
     TestID -> "Standard return shape: critical congestion solver"
+]
+
+Test[
+    Module[{data, d2e, result},
+        data = GetExampleData["chain with two exits"] /. {I1 -> 80, U1 -> 0, U2 -> 10};
+        d2e = DataToEquations[data];
+        result = Quiet[CriticalCongestionSolver[d2e]];
+        Lookup[result, {"Solver", "ResultKind", "Feasibility", "Message"}] ===
+            {"CriticalCongestion", "Success", "Feasible", None} &&
+        Length[Lookup[data, "Exit Vertices and Terminal Costs", {}]] === 2 &&
+        NumericQ[Lookup[result, "BoundaryMassResidual", Missing["NotAvailable"]]] &&
+        Lookup[result, "BoundaryMassResidual", Infinity] <= 10^-10
+    ]
+    ,
+    True
+    ,
+    TestID -> "Critical solver: chain with two exits example is feasible and mass-conservative"
 ]
 
 Test[
@@ -106,6 +125,8 @@ Test[
         AssociationQ[result["SignedEdgeFlows"]] &&
         VectorQ[result["ComparableFlowVector"], NumericQ] &&
         NumericQ[result["KirchhoffResidual"]] &&
+        NumericQ[result["BoundaryMassResidual"]] &&
+        KeyExistsQ[result, "UtilityClassResidual"] &&
         AssociationQ[result["Convergence"]] &&
         NumericQ[result["Convergence"]["SolveTime"]] &&
         IsFeasible[result]
@@ -143,6 +164,8 @@ Test[
         AssociationQ[result["SignedEdgeFlows"]] &&
         VectorQ[result["ComparableFlowVector"], NumericQ] &&
         NumericQ[result["KirchhoffResidual"]] &&
+        KeyExistsQ[result, "BoundaryMassResidual"] &&
+        KeyExistsQ[result, "UtilityClassResidual"] &&
         AssociationQ[result["Convergence"]] &&
         NumericQ[result["Convergence"]["FinalResidual"]] &&
         IntegerQ[result["ReducedStateDimension"]] &&

--- a/Scripts/BenchmarkHelpers.wls
+++ b/Scripts/BenchmarkHelpers.wls
@@ -300,6 +300,8 @@ $CaseParams = <|
   18 -> {I1 -> 80, U1 -> 0, S1 -> 2, S2 -> 1},
   104 -> {I1 -> 80, I2 -> 40},
   "triangle with two exits" -> {I1 -> 80, U1 -> 0, U2 -> 10},
+  "chain with two exits" -> {I1 -> 80, U1 -> 0, U2 -> 10},
+  105 -> {I1 -> 80, U1 -> 0, U2 -> 10},
   "HRF Scenario 1" -> {I1 -> 100, I2 -> 100, U1 -> 0, U2 -> 0},
   "Jamaratv9" -> {I1 -> 100, I2 -> 50, U1 -> 0, U2 -> 0, U3 -> 0},
   "Paper example" -> {I1 -> 80, I2 -> 40, S1 -> 2, S2 -> 1, S3 -> 3, S4 -> 1},
@@ -324,7 +326,7 @@ GetParams[key_] := Lookup[$CaseParams, key, $DefaultParams];
 
 $BenchmarkTiers = <|
   "small" -> {1, 2, 3, 4, 5, 6, 27},
-  "core" -> {9, 10, 12, 14, 18},
+  "core" -> {9, 10, 12, 14, 18, "chain with two exits"},
   "stress" -> {7, 8, 104, "triangle with two exits"},
   "paper" -> {"HRF Scenario 1"},
   "inconsistent-switching" -> {11, 15, 17, "Paper example"},


### PR DESCRIPTION
## Summary
- add new built-in example: `"chain with two exits"` (and numeric alias `105`) in `ExamplesData.wl`
- include this case in benchmark defaults and core tier in `BenchmarkHelpers.wls`
- add solver-contract test that asserts feasibility/mass conservation for `I1=80, U1=0, U2=10`

## Why
This case captures the boundary-condition behavior for one-entry/two-exit chain topology and keeps the asymmetric-exit-cost scenario visible as a regression target.

## Validation
- Ran: `wolframscript -file Scripts/RunTests.wls fast`
- Result: **1 failing test** (the newly-added chain-two-exits feasibility assertion), which is the expected signal for the open boundary-condition issue.
