### PR TITLE
fix(critical): recover exit pass-through and heterogeneous-exit preprocessing fixes

### DIFF
--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -97,6 +97,29 @@ IsSwitchingCostConsistent[switchingCosts_] :=
     And @@ Simplify[ConsistentSwitchingCosts[switchingCosts] /@ switchingCosts
         ]
 
+GraphDistanceHeuristicSafeQ[Eqs_Association, tol_:10^-10] :=
+    Module[{exitCosts, exitCostSpread, switchingValues, nonzeroSwitchingQ},
+        exitCosts = Last /@ Lookup[Eqs, "Exit Vertices and Terminal Costs", {}];
+        exitCostSpread =
+            Which[
+                Length[exitCosts] <= 1, 0.,
+                VectorQ[exitCosts, NumericQ], N @ Max[Abs[N @ exitCosts - First[N @ exitCosts]]],
+                True, Infinity
+            ];
+        switchingValues = Values @ Lookup[Eqs, "SwitchingCosts", <||>];
+        nonzeroSwitchingQ =
+            AnyTrue[
+                switchingValues,
+                Function[val,
+                    Which[
+                        NumericQ[val], !PossibleZeroQ[val],
+                        True, True
+                    ]
+                ]
+            ];
+        exitCostSpread <= tol && !nonzeroSwitchingQ
+    ];
+
 (* --- Graph helper functions --- *)
 
 TransitionsAt[G_, k_] :=
@@ -152,6 +175,10 @@ ResolveOrByGraphDistance[Eqs_Association, triple:{_, _, _}] :=
     Module[{graph, exitVerts, distToExit, orTerms, resolved = {},
             unresolved = {}, newEE, newOR},
         If[triple[[3]] === True, Return[triple, Module]];
+        If[!GraphDistanceHeuristicSafeQ[Eqs],
+            MFGPrint["ResolveOrByGraphDistance: skipped (heterogeneous exit/switching costs)."];
+            Return[triple, Module]
+        ];
         graph = Lookup[Eqs, "auxiliaryGraph", None];
         exitVerts = Lookup[Eqs, "auxExitVertices", {}];
         If[graph === None || exitVerts === {},
@@ -1254,7 +1281,8 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
         If[AllTrue[Values[Lookup[Eqs, "SwitchingCosts", <|_ -> 1|>]], # === 0 &] &&
             Lookup[Eqs, "auxiliaryGraph", None] =!= None &&
             AllTrue[Flatten[Lookup[Eqs, "Entrance Vertices and Flows", {}]], NumericQ] &&
-            AllTrue[Flatten[Lookup[Eqs, "Exit Vertices and Terminal Costs", {}]], NumericQ],
+            AllTrue[Flatten[Lookup[Eqs, "Exit Vertices and Terminal Costs", {}]], NumericQ] &&
+            GraphDistanceHeuristicSafeQ[Eqs],
             MFGPrint["Attempting direct critical solver (zero switching costs)..."];
             {time, AssoCritical} = AbsoluteTiming[DirectCriticalSolver[Eqs]];
             If[AssociationQ[AssoCritical] && AssoCritical =!= $Failed,

--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -406,6 +406,7 @@ DataToEquations[Data_Association] :=
          BalanceSplittingFlows, NoDeadStarts, RuleBalanceGatheringFlows, BalanceGatheringFlows,
          EqBalanceGatheringFlows, EqEntryIn, RuleEntryValues, RuleEntryOut, RuleExitFlowsIn,
          RuleExitValues, EqValueAuxiliaryEdges, IneqSwitchingByVertex, AltOptCond,
+         blockedIncomingPairs, activeAuxTriples,
          Nlhs, ModuleVars, ModuleVarsNames, Nrhs, costpluscurrents, EqGeneral,
          inAuxEntryPairs, outAuxEntryPairs, inAuxExitPairs, outAuxExitPairs, 
         pairs, halfPairs, consistentCosts},
@@ -513,6 +514,11 @@ DataToEquations[Data_Association] :=
             ];
         RuleExitFlowsIn = Association[(j @@ # -> 0)& /@ inAuxExitPairs
             ];
+        blockedIncomingPairs = DeleteDuplicates @ Join[outAuxEntryPairs, inAuxExitPairs];
+        activeAuxTriples = Select[
+            auxTriples,
+            !MemberQ[blockedIncomingPairs, #[[{1, 2}]]] &
+        ];
         (* Exit values at exit vertices *)
         RuleExitValues = AssociationThread[u @@@ (Reverse /@ outAuxExitPairs
             ), Last /@ exitVerticesCosts];
@@ -522,10 +528,14 @@ DataToEquations[Data_Association] :=
              @@@ inAuxEntryPairs];
         EqValueAuxiliaryEdges = And @@ ((u @@ # == u @@ Reverse[#])& 
             /@ Join[inAuxEntryPairs, outAuxExitPairs]);
-        IneqSwitchingByVertex = IneqSwitch[u, SwitchingCosts] @@@ TransitionsAt[
-            auxiliaryGraph, #]& /@ verticesList;
+        IneqSwitchingByVertex =
+            IneqSwitch[u, SwitchingCosts] @@@
+                Select[
+                    TransitionsAt[auxiliaryGraph, #],
+                    !MemberQ[blockedIncomingPairs, #[[{1, 2}]]] &
+                ] & /@ verticesList;
         IneqSwitchingByVertex = And @@@ IneqSwitchingByVertex;
-        AltOptCond = And @@ AltSwitch[j, u, SwitchingCosts] @@@ auxTriples
+        AltOptCond = And @@ AltSwitch[j, u, SwitchingCosts] @@@ activeAuxTriples
             ;
         Nlhs = Flatten[u @@ # - u @@ Reverse @ # + SignedFlows[#]& /@
              halfPairs];
@@ -674,13 +684,24 @@ MFGPreprocessing[Eqs_] :=
            i.e. equalities. Skip expensive Simplify and extract directly. *)
         If[AllTrue[Values[Lookup[Eqs, "SwitchingCosts", <||>]], # === 0 &],
             {time, IneqSwitchingByVertex} = AbsoluteTiming[
-                Module[{items = IneqSwitchingByVertex /. InitRules, ineqs, eqs},
+                Module[{items = IneqSwitchingByVertex /. InitRules, ineqs, pairs,
+                        reciprocalPairs, eqs, canonicalPair, reciprocalKeys,
+                        remainingIneqs, combinedConditions},
                     ineqs = Flatten[If[Head[#] === And, List @@ #, {#}]& /@ items];
-                    eqs = DeleteDuplicatesBy[
-                        Cases[ineqs, LessEqual[a_, b_] :> (a == b)],
-                        Sort @* (List @@ #&)
+                    pairs = Cases[ineqs, LessEqual[a_, b_] :> {a, b}];
+                    reciprocalPairs = Select[pairs, MemberQ[pairs, Reverse[#]] &];
+                    canonicalPair[pair_] := SortBy[pair, ToString[InputForm[#]] &];
+                    eqs = DeleteDuplicatesBy[Equal @@@ reciprocalPairs, canonicalPair @* (List @@ # &)];
+                    reciprocalKeys = DeleteDuplicates[canonicalPair /@ reciprocalPairs];
+                    remainingIneqs = Select[
+                        ineqs,
+                        Not @ MatchQ[
+                            #,
+                            LessEqual[a_, b_] /; MemberQ[reciprocalKeys, canonicalPair[{a, b}]]
+                        ] &
                     ];
-                    If[eqs === {}, True, And @@ eqs]
+                    combinedConditions = Join[eqs, remainingIneqs];
+                    If[combinedConditions === {}, True, And @@ combinedConditions]
                 ]
             ];
             MFGPrint["Switching costs (zero): extracted equalities in ",
@@ -1671,7 +1692,8 @@ IsCriticalSolution[Eqs_Association, OptionsPattern[]] :=
 
 MFGSystemSolver[Eqs_][approxJs_] :=
     Module[{NewSystem, InitRules, pickOne, vars, System, Ncpc, costpluscurrents,
-         us, js, jts, jjtsR, usR, time, temp, ineqsByTransition},
+         us, js, jts, jjtsR, usR, time, temp, ineqsByTransition,
+         ineqsWithoutTransition = {}},
         ClearSolveCache[];
         us = Lookup[Eqs, "us", $Failed];
         js = Lookup[Eqs, "js", $Failed];
@@ -1700,13 +1722,25 @@ MFGSystemSolver[Eqs_][approxJs_] :=
             ];
         If[NewSystem[[2]] === True,
             ineqsByTransition = ConstantArray[True, Length[jts]];
+            ineqsWithoutTransition = {};
             time = 0.
             ,
             {time, ineqsByTransition} =
                 AbsoluteTiming[
-                    Module[{ineqList, index},
+                    Module[{ineqList, index, scopedIneqs, transitionPattern},
                         ineqList = If[Head[NewSystem[[2]]] === And,
                             List @@ NewSystem[[2]], {NewSystem[[2]]}];
+                        transitionPattern = If[jts === {}, None, Alternatives @@ jts];
+                        ineqsWithoutTransition =
+                            If[transitionPattern === None,
+                                ineqList,
+                                Select[ineqList, FreeQ[#, transitionPattern] &]
+                            ];
+                        scopedIneqs =
+                            If[ineqsWithoutTransition === {},
+                                ineqList,
+                                Complement[ineqList, ineqsWithoutTransition]
+                            ];
                         index = Association[# -> {} & /@ jts];
                         Do[
                             Do[
@@ -1714,7 +1748,7 @@ MFGSystemSolver[Eqs_][approxJs_] :=
                                     index[jt] = Append[index[jt], ineq]],
                                 {jt, jts}
                             ],
-                            {ineq, ineqList}
+                            {ineq, scopedIneqs}
                         ];
                         (If[# === {}, True, And @@ #]&) /@ Values[index]
                     ]
@@ -1732,11 +1766,18 @@ MFGSystemSolver[Eqs_][approxJs_] :=
         {time, ineqsByTransition} = AbsoluteTiming[DeduplicateByComplexity[
             MFGParallelMap[Simplify,
                 Select[ineqsByTransition, # =!= True &]]]];
+        {time, ineqsWithoutTransition} =
+            AbsoluteTiming[
+                DeduplicateByComplexity[
+                    MFGParallelMap[Simplify,
+                        Select[ineqsWithoutTransition, # =!= True &]]
+                ]
+            ];
         (* Restore True entries for any that were already resolved *)
         NotebookDelete[temp];
         MFGPrint["MFGSS: Simplifying inequalities by transition flow took ",
              time, " seconds. "];
-        NewSystem[[2]] = (And @@ ineqsByTransition);
+        NewSystem[[2]] = (And @@ Join[ineqsByTransition, ineqsWithoutTransition]);
         NewSystem = SystemToTriple[And @@ NewSystem];
         {NewSystem, InitRules} = TripleClean[{NewSystem, InitRules}];
 

--- a/MFGraphs/Tests/exit-pass-through-nonzero.mt
+++ b/MFGraphs/Tests/exit-pass-through-nonzero.mt
@@ -1,0 +1,49 @@
+(* Wolfram Language Test file *)
+
+Test[
+    Module[{vertices, adjacency, graph, auxiliaryGraph, auxVertices, auxTriples,
+            switchingCosts, data, d2e, result, asso, j23, j2ex2, j3ex3},
+        vertices = {1, 2, 3};
+        adjacency = {{0, 1, 0}, {1, 0, 1}, {0, 1, 0}};
+        graph = AdjacencyGraph[vertices, adjacency, DirectedEdges -> False];
+        auxiliaryGraph = EdgeAdd[
+            graph,
+            {
+                UndirectedEdge[en1, 1],
+                UndirectedEdge[2, ex2],
+                UndirectedEdge[3, ex3]
+            }
+        ];
+        auxVertices = VertexList[auxiliaryGraph];
+        auxTriples = Flatten[
+            Insert[#, 2] & /@ Permutations[AdjacencyList[auxiliaryGraph, #], {2}] & /@ auxVertices,
+            1
+        ];
+        (* Force the nonzero-switching preprocessing path while keeping a consistent metric. *)
+        switchingCosts = Append[#, 1] & /@ auxTriples;
+
+        data = <|
+            "Vertices List" -> vertices,
+            "Adjacency Matrix" -> adjacency,
+            "Entrance Vertices and Flows" -> {{1, 12}},
+            "Exit Vertices and Terminal Costs" -> {{2, 10}, {3, 0}},
+            "Switching Costs" -> switchingCosts
+        |>;
+        d2e = DataToEquations[data];
+        result = CriticalCongestionSolver[d2e];
+        asso = Lookup[result, "AssoCritical", <||>];
+        j23 = Lookup[asso, MFGraphs`Private`j[2, 3], Missing[]];
+        j2ex2 = Lookup[asso, MFGraphs`Private`j[2, ex2], Missing[]];
+        j3ex3 = Lookup[asso, MFGraphs`Private`j[3, ex3], Missing[]];
+
+        Lookup[result, "ResultKind"] === "Success" &&
+        Lookup[result, "Status"] === "Feasible" &&
+        AssociationQ[asso] &&
+        NumericQ[j23] && NumericQ[j2ex2] && NumericQ[j3ex3] &&
+        j23 > 0 &&
+        Chop[j23 + j2ex2 - 12] === 0 &&
+        Chop[j3ex3 - j23] === 0
+    ],
+    True,
+    TestID -> "Exit pass-through: nonzero switching costs keep model feasible and preserve flow through v3 path"
+]

--- a/MFGraphs/Tests/exit-pass-through.mt
+++ b/MFGraphs/Tests/exit-pass-through.mt
@@ -1,0 +1,47 @@
+(* Wolfram Language Test file *)
+
+Test[
+    Module[{data, d2e, result, asso},
+        data = <|
+            "Vertices List" -> {1, 2, 3},
+            "Adjacency Matrix" -> {{0, 1, 0}, {1, 0, 1}, {0, 1, 0}},
+            "Entrance Vertices and Flows" -> {{1, 4}},
+            "Exit Vertices and Terminal Costs" -> {{2, 10}, {3, 0}},
+            "Switching Costs" -> {}
+        |>;
+        d2e = DataToEquations[data];
+        result = CriticalCongestionSolver[d2e];
+        asso = Lookup[result, "AssoCritical", <||>];
+        Lookup[result, "ResultKind"] === "Success" &&
+        Lookup[result, "Status"] === "Feasible" &&
+        AssociationQ[asso] &&
+        Lookup[asso, MFGraphs`Private`j[2, 3], Missing[]] === 4 &&
+        Lookup[asso, MFGraphs`Private`j[2, ex2], Missing[]] === 0 &&
+        Lookup[asso, MFGraphs`Private`j[3, ex3], Missing[]] === 4
+    ],
+    True,
+    TestID -> "Exit pass-through: iota=4 routes all mass to the cheaper exit at v3"
+]
+
+Test[
+    Module[{data, d2e, result, asso},
+        data = <|
+            "Vertices List" -> {1, 2, 3},
+            "Adjacency Matrix" -> {{0, 1, 0}, {1, 0, 1}, {0, 1, 0}},
+            "Entrance Vertices and Flows" -> {{1, 12}},
+            "Exit Vertices and Terminal Costs" -> {{2, 10}, {3, 0}},
+            "Switching Costs" -> {}
+        |>;
+        d2e = DataToEquations[data];
+        result = CriticalCongestionSolver[d2e];
+        asso = Lookup[result, "AssoCritical", <||>];
+        Lookup[result, "ResultKind"] === "Success" &&
+        Lookup[result, "Status"] === "Feasible" &&
+        AssociationQ[asso] &&
+        Lookup[asso, MFGraphs`Private`j[2, 3], Missing[]] === 10 &&
+        Lookup[asso, MFGraphs`Private`j[2, ex2], Missing[]] === 2 &&
+        Lookup[asso, MFGraphs`Private`j[3, ex3], Missing[]] === 10
+    ],
+    True,
+    TestID -> "Exit pass-through: iota=12 saturates v3 path and sends remainder to v2 exit"
+]

--- a/Scripts/RunTests.wls
+++ b/Scripts/RunTests.wls
@@ -17,6 +17,7 @@ $TestSuites = <|
         "012-critical_congestion.mt",
         "critical-numeric-backend.mt",
         "exit-pass-through.mt",
+        "exit-pass-through-nonzero.mt",
         "infeasible-status.mt",
         "monotone-monotonicity.mt",
         "monotone-solver.mt",

--- a/Scripts/RunTests.wls
+++ b/Scripts/RunTests.wls
@@ -16,6 +16,7 @@ $TestSuites = <|
         "007-critical_congestion_ok.mt",
         "012-critical_congestion.mt",
         "critical-numeric-backend.mt",
+        "exit-pass-through.mt",
         "infeasible-status.mt",
         "monotone-monotonicity.mt",
         "monotone-solver.mt",


### PR DESCRIPTION
## Summary
Recovered three previously unreachable commits and reapplied them cleanly on top of `master`:

- `fix(preprocessing): guard distance pruning for heterogeneous exit costs`
- `fix(model): ignore phantom switching states and preserve one-way inequalities`
- `test(critical): cover nonzero switching exit pass-through path`

### Included changes
- updates `DataToEquations.wl` to avoid unsafe distance-based pruning when exit costs are heterogeneous
- filters phantom switching states and preserves one-way inequalities in preprocessing/solver partitioning
- adds regression tests:
  - `MFGraphs/Tests/exit-pass-through.mt`
  - `MFGraphs/Tests/exit-pass-through-nonzero.mt`
- wires these tests into `Scripts/RunTests.wls` fast suite

## Why
This addresses the chain two-exit asymmetric-cost behavior (`I1=80, U1=0, U2=10`) so the critical solver remains feasible instead of returning `NoSolution`.

## Validation
- `exit-pass-through.mt`: 2 passed, 0 failed
- `exit-pass-through-nonzero.mt`: 1 passed, 0 failed
- direct check (`chain with two exits`, `I1=80, U1=0, U2=10`) now returns:
  - `{CriticalCongestion, Success, Feasible, None}`
