### PR TITLE
Critical solver: deduplicate result envelope, enable numeric backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,8 +81,8 @@ wolframscript -file Scripts/RunTests.wls all
 - Expected times on a typical Mac (as of March 2025):
   - `fast`: **~27 minutes** (solver-contracts + monotone tests with full solver runs)
   - `slow`: **significantly longer** (includes large-case solvers)
+- Test files are MUnit `.mt` files in `MFGraphs/Tests/`
 - Results go to standard Mathematica test output; no files are saved
-- Use this suite in CI for correctness regression checks
 
 #### Performance benchmarks (tier-based)
 
@@ -127,6 +127,10 @@ wolframscript -file Scripts/BenchmarkSuite.wls --tag "description of change" --r
 
 The package follows a linear pipeline: **network data → equations → solver**.
 
+**Unified entrypoint** — `SolveMFG[data, Method -> m]` accepts raw data or compiled equations and dispatches to the appropriate solver. With `Method -> "Automatic"`, it cascades: CriticalCongestion → Monotone → NonLinear, falling back on infeasibility or failure. Returns a standardized result envelope plus `"MethodUsed"` and `"MethodTrace"` keys.
+
+**Individual solvers** can also be called directly:
+
 ```
 Data (Association)
   ↓
@@ -141,15 +145,20 @@ NonLinearSolver[criticalResult]  or  MonotoneSolverFromData[data]
 
 **Solver selection**: `CriticalCongestionSolver` automatically dispatches to `DirectCriticalSolver` for networks with no switching costs (much faster); otherwise uses the full symbolic pipeline.
 
+**MonotoneSolver vs MonotoneSolverFromData**: `MonotoneSolverFromData[data]` accepts raw data and calls `DataToEquations` internally. `MonotoneSolver[d2e]` accepts pre-compiled equations. `SolveMFG` uses `MonotoneSolver` when given compiled input, `MonotoneSolverFromData` otherwise.
+
 ### Module load order
 
 Defined in `MFGraphs.wl`:
 1. `Examples/ExamplesData.wl` — 34 built-in test cases via `GetExampleData[key]`
-2. `DNFReduce.wl` — Boolean algebra solver (disjunctive normal form reduction with Solve/Reduce memoization, branch pruning, and post-reduction via `ReduceDisjuncts`/`SubsumptionPrune`)
-3. `DataToEquations.wl` — Core converter: network topology → equations; implements `DataToEquations`, `CriticalCongestionSolver`, `MFGSystemSolver`, `TripleClean`
-4. `NonLinearSolver.wl` — Iterative fixed-point solver (`NonLinearSolver`) using Hamiltonian framework (up to 15 iterations)
-5. `Monotone.wl` — ODE-based gradient flow solver on Kirchhoff matrix using `NDSolve`
-6. `TimeDependentSolver.wl` — Time-dependent MFG solver using backward-forward sweep on discretized time grid
+2. `Examples/TimeDependentExamples.wl` — Time-dependent example data
+3. `DNFReduce.wl` — Boolean algebra solver (disjunctive normal form reduction with Solve/Reduce memoization, branch pruning, and post-reduction via `ReduceDisjuncts`/`SubsumptionPrune`)
+4. `DataToEquations.wl` — Core converter: network topology → equations; implements `DataToEquations`, `CriticalCongestionSolver`, `MFGSystemSolver`, `TripleClean`
+5. `NonLinearSolver.wl` — Iterative fixed-point solver (`NonLinearSolver`) using Hamiltonian framework (up to 15 iterations)
+6. `Monotone.wl` — ODE-based gradient flow solver on Kirchhoff matrix using `NDSolve`
+7. `TimeDependentSolver.wl` — Time-dependent MFG solver using backward-forward sweep on discretized time grid
+
+After submodule loading, `MFGraphs.wl` defines `SolveMFG` — the unified entrypoint (see Pipeline overview).
 
 ### Symbol contexts
 
@@ -183,23 +192,23 @@ System decomposition (triple `{EE, NN, OR}`):
 
 `NonLinearSolver` expects the output of `CriticalCongestionSolver` (reads `"AssoCritical"` key). Benchmark suite follows: `DataToEquations → CriticalCongestionSolver → NonLinearSolver`.
 
-**Legacy format** (default):
-- `CriticalCongestionSolver`: returns `"AssoCritical"` (zero-flow equilibrium) + `"Status"` (`"Feasible"` or `"Infeasible"`)
-- `NonLinearSolver`: returns `"AssoNonCritical"` (general congestion solution) + `"Status"`
-- `MonotoneSolverFromData`: returns bare solution, `Null`, or message association
+All stationary solvers now return a **standardized result envelope** by default:
 
-**Standard format** (add `"ReturnShape" -> "Standard"`):
 ```mathematica
-result = NonLinearSolver[d2e, "ReturnShape" -> "Standard"]
-(* Returns normalized envelope: *)
 <| "Solver" -> "NonLinearSolver",
-   "ResultKind" -> "...",
+   "ResultKind" -> "Success"|"Failure"|"Degenerate"|"NonConverged",
    "Feasibility" -> "Feasible"|"Infeasible",
    "Message" -> "...",
    "Solution" -> {...},
-   "AssoNonCritical" -> {...}  (* solver-specific payload *)
+   "ComparableFlowVector" -> {...},
+   "KirchhoffResidual" -> ...,
+   "AssoNonCritical" -> {...}  (* solver-specific payload key *)
 |>
 ```
+
+Solver-specific payload keys: `"AssoCritical"`, `"AssoNonCritical"`, `"AssoMonotone"`.
+
+`SolveMFG` results additionally include `"MethodUsed"` and `"MethodTrace"`.
 
 **Checking solutions**:
 - `IsFeasible[result]` — accepts both legacy `"Status"` and standard `"Feasibility"`
@@ -386,6 +395,31 @@ result2 = CriticalCongestionSolver[d2e2];
 ```
 
 Failure to clear the cache can cause stale memoized results to leak into unrelated problems.
+
+## Code style conventions
+
+- Avoid single-letter `System` symbols (e.g., `K`, `D`, `C`) as variable names — they shadow built-ins. Use descriptive names or suffixes like `KM`.
+- For CLI scripts in `Scripts/`, suppress Wolfram Code Analysis warnings for `Print[]` with inline lint blocks:
+  ```wolfram
+  (* :!CodeAnalysis::BeginBlock:: *)
+  (* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
+  ...
+  (* :!CodeAnalysis::EndBlock:: *)
+  ```
+- `API_REFERENCE.md` is auto-generated — edit `::usage` strings in source, then run `wolframscript -file Scripts/GenerateDocs.wls`
+- `DNF_PERFORMANCE_HISTORY.md` and `PARALLEL_PERFORMANCE_HISTORY.md` are auto-appended by benchmark scripts — do not manually edit
+
+## CI pipeline
+
+GitHub Actions (`.github/workflows/tests.yml`) runs on PRs and pushes to `master`:
+
+| Job | Trigger | What it does |
+|-----|---------|-------------|
+| **report_hygiene** | PRs + pushes | Scans for placeholder prose in report/history files |
+| **fast_tests** | PRs + pushes | `Scripts/RunTests.wls fast` |
+| **slow_tests** | pushes only | `Scripts/RunTests.wls slow` |
+| **benchmark_smoke** | pushes only | `Scripts/BenchmarkSuite.wls small case=1 timeout=10` |
+| **solver_compare_smoke** | pushes only | `Scripts/CompareSolvers.wls smoke` |
 
 ## Git workflow
 

--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -1705,6 +1705,30 @@ SolveCriticalNumericBackend[Eqs_Association] :=
 
 (* --- CriticalCongestionSolver --- *)
 
+(* BuildCriticalResult: single point for assembling the standardized result envelope.
+   Eliminates duplication across numeric, direct, and symbolic solver paths. *)
+BuildCriticalResult[PreEqs_Association, resultKind_String, status_String, message_,
+    candidate_, telemetry_Association] :=
+    Module[{solution, comparisonData},
+        solution = If[AssociationQ[candidate], candidate, Missing["NotAvailable"]];
+        comparisonData = BuildSolverComparisonData[PreEqs, solution];
+        Join[PreEqs, MakeSolverResult["CriticalCongestion", resultKind,
+            status, message, solution,
+            Join[comparisonData, <|"AssoCritical" -> candidate, "Status" -> status|>, telemetry]
+        ]]
+    ];
+
+(* EnsurePreprocessed: lazily run MFGPreprocessing if InitRules are not already present. *)
+EnsurePreprocessed[Eqs_Association] :=
+    Module[{time, PreEqs},
+        If[KeyExistsQ[Eqs, "InitRules"],
+            Eqs,
+            {time, PreEqs} = AbsoluteTiming @ MFGPreprocessing[Eqs];
+            MFGPrint["Preprocessing (for downstream solvers) took ", time, " seconds."];
+            PreEqs
+        ]
+    ];
+
 Options[CriticalCongestionSolver] = {
     "ValidateSolution" -> True,
     "ValidationTolerance" -> $CriticalSolverTolerance,
@@ -1715,13 +1739,14 @@ CriticalCongestionSolver[$Failed, ___] :=
     $Failed
 
 CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
-    Module[{PreEqs, js, AssoCritical, time, temp, status,
-         resultKind, message, solution, comparisonData,
+    Module[{PreEqs, js, AssoCritical, time, status,
+         resultKind, message,
          validateQ, validationTolerance, validationVerboseQ, validationFailedQ,
          numericBackendRequestedQ, numericBackendEligibleQ,
          numericBackendUsedQ, numericBackendFallbackReason, numericBackendSolveTime,
          numericBackendStrategy, jFirstBackendUsedQ, jFirstBackendFallbackReason,
-         numericCandidate, numericOutcome, forcedRejectQ, numericBackendTimeLimit},
+         numericCandidate, numericOutcome, forcedRejectQ, numericBackendTimeLimit,
+         telemetry},
         ClearSolveCache[];
         validateQ = TrueQ[OptionValue["ValidateSolution"]];
         validationTolerance = OptionValue["ValidationTolerance"];
@@ -1749,6 +1774,16 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
             True,
                 30.
         ];
+
+        (* Helper: build telemetry association from current state *)
+        telemetry := <|
+            "NumericBackendUsed" -> numericBackendUsedQ,
+            "NumericBackendFallbackReason" -> numericBackendFallbackReason,
+            "NumericBackendSolveTime" -> numericBackendSolveTime,
+            "NumericBackendStrategy" -> numericBackendStrategy,
+            "JFirstBackendUsed" -> jFirstBackendUsedQ,
+            "JFirstBackendFallbackReason" -> jFirstBackendFallbackReason
+        |>;
 
         (* Try the numeric backend first when explicitly forced or globally enabled. *)
         If[numericBackendRequestedQ && numericBackendEligibleQ,
@@ -1786,11 +1821,8 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
                 status = CheckFlowFeasibility[numericCandidate];
                 If[status === "Feasible",
                     numericBackendUsedQ = True;
-                    If[KeyExistsQ[Eqs, "InitRules"],
-                        PreEqs = Eqs,
-                        {time, PreEqs} = AbsoluteTiming @ MFGPreprocessing[Eqs];
-                        MFGPrint["Preprocessing (for downstream solvers) took ", time, " seconds."]
-                    ];
+                    numericBackendFallbackReason = None;
+                    PreEqs = EnsurePreprocessed[Eqs];
                     If[validateQ,
                         If[forcedRejectQ || !TrueQ @ IsCriticalSolution[
                             Join[PreEqs, <|"AssoCritical" -> numericCandidate, "Solution" -> numericCandidate|>],
@@ -1809,63 +1841,9 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
                             numericBackendFallbackReason =
                                 If[forcedRejectQ, "ForcedValidationFailure", "CriticalValidationFailed"]
                             ,
-                            solution = numericCandidate;
-                            comparisonData = BuildSolverComparisonData[PreEqs, solution];
-                            Return[
-                                Join[
-                                    PreEqs,
-                                    MakeSolverResult[
-                                        "CriticalCongestion",
-                                        "Success",
-                                        status,
-                                        None,
-                                        solution,
-                                        Join[
-                                            comparisonData,
-                                            <|
-                                                "AssoCritical" -> numericCandidate,
-                                                "Status" -> status,
-                                                "NumericBackendUsed" -> True,
-                                                "NumericBackendFallbackReason" -> None,
-                                                "NumericBackendSolveTime" -> numericBackendSolveTime,
-                                                "NumericBackendStrategy" -> numericBackendStrategy,
-                                                "JFirstBackendUsed" -> jFirstBackendUsedQ,
-                                                "JFirstBackendFallbackReason" -> jFirstBackendFallbackReason
-                                            |>
-                                        ]
-                                    ]
-                                ],
-                                Module
-                            ]
+                            Return[BuildCriticalResult[PreEqs, "Success", status, None, numericCandidate, telemetry], Module]
                         ],
-                        solution = numericCandidate;
-                        comparisonData = BuildSolverComparisonData[PreEqs, solution];
-                        Return[
-                            Join[
-                                PreEqs,
-                                MakeSolverResult[
-                                    "CriticalCongestion",
-                                    "Success",
-                                    status,
-                                    None,
-                                    solution,
-                                    Join[
-                                        comparisonData,
-                                        <|
-                                            "AssoCritical" -> numericCandidate,
-                                            "Status" -> status,
-                                            "NumericBackendUsed" -> True,
-                                            "NumericBackendFallbackReason" -> None,
-                                            "NumericBackendSolveTime" -> numericBackendSolveTime,
-                                            "NumericBackendStrategy" -> numericBackendStrategy,
-                                            "JFirstBackendUsed" -> jFirstBackendUsedQ,
-                                            "JFirstBackendFallbackReason" -> jFirstBackendFallbackReason
-                                        |>
-                                    ]
-                                ]
-                            ],
-                            Module
-                        ]
+                        Return[BuildCriticalResult[PreEqs, "Success", status, None, numericCandidate, telemetry], Module]
                     ],
                     numericBackendFallbackReason = "FlowFeasibilityFailed"
                 ],
@@ -1886,14 +1864,7 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
                 MFGPrint["Direct critical solver completed in ", time, " seconds."];
                 status = CheckFlowFeasibility[AssoCritical];
                 If[status === "Feasible",
-                    (* Run MFGPreprocessing so downstream solvers (NonLinearSolver)
-                       have the symbolic InitRules, NewSystem, costpluscurrents that
-                       MFGSystemSolver expects to specialize per-iteration. *)
-                    If[KeyExistsQ[Eqs, "InitRules"],
-                        PreEqs = Eqs,
-                        {time, PreEqs} = AbsoluteTiming @ MFGPreprocessing[Eqs];
-                        MFGPrint["Preprocessing (for downstream solvers) took ", time, " seconds."]
-                    ];
+                    PreEqs = EnsurePreprocessed[Eqs];
                     If[validateQ,
                         If[!TrueQ @ IsCriticalSolution[
                             Join[PreEqs, <|"AssoCritical" -> AssoCritical, "Solution" -> AssoCritical|>],
@@ -1902,47 +1873,9 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
                         ],
                             MFGPrint["Direct solver validation failed, falling back to symbolic solver."]
                             ,
-                            solution = AssoCritical;
-                            comparisonData = BuildSolverComparisonData[PreEqs, solution];
-                            Return[
-                                Join[PreEqs, MakeSolverResult["CriticalCongestion", "Success",
-                                    status, None, solution,
-                                    Join[
-                                        comparisonData,
-                                        <|
-                                            "AssoCritical" -> AssoCritical,
-                                            "Status" -> status,
-                                            "NumericBackendUsed" -> numericBackendUsedQ,
-                                            "NumericBackendFallbackReason" -> numericBackendFallbackReason,
-                                            "NumericBackendSolveTime" -> numericBackendSolveTime,
-                                            "NumericBackendStrategy" -> numericBackendStrategy,
-                                            "JFirstBackendUsed" -> jFirstBackendUsedQ,
-                                            "JFirstBackendFallbackReason" -> jFirstBackendFallbackReason
-                                        |>
-                                    ]]],
-                                Module
-                            ]
+                            Return[BuildCriticalResult[PreEqs, "Success", status, None, AssoCritical, telemetry], Module]
                         ],
-                        solution = AssoCritical;
-                        comparisonData = BuildSolverComparisonData[PreEqs, solution];
-                        Return[
-                            Join[PreEqs, MakeSolverResult["CriticalCongestion", "Success",
-                                status, None, solution,
-                                Join[
-                                    comparisonData,
-                                    <|
-                                        "AssoCritical" -> AssoCritical,
-                                        "Status" -> status,
-                                        "NumericBackendUsed" -> numericBackendUsedQ,
-                                        "NumericBackendFallbackReason" -> numericBackendFallbackReason,
-                                        "NumericBackendSolveTime" -> numericBackendSolveTime,
-                                        "NumericBackendStrategy" -> numericBackendStrategy,
-                                        "JFirstBackendUsed" -> jFirstBackendUsedQ,
-                                        "JFirstBackendFallbackReason" -> jFirstBackendFallbackReason
-                                    |>
-                                ]]],
-                            Module
-                        ]
+                        Return[BuildCriticalResult[PreEqs, "Success", status, None, AssoCritical, telemetry], Module]
                     ],
                     MFGPrint["Direct solver produced infeasible result, falling back to symbolic solver."]
                 ],
@@ -1950,20 +1883,9 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
             ]
         ];
         (* Standard symbolic solver path *)
-        If[!(AssociationQ[PreEqs] && KeyExistsQ[PreEqs, "InitRules"]),
-            If[KeyExistsQ[Eqs, "InitRules"],
-                PreEqs = Eqs
-                ,
-                temp = MFGPrintTemporary["Preprocessing..."];
-                {time, PreEqs} = AbsoluteTiming @ MFGPreprocessing[Eqs];
-                NotebookDelete[temp];
-                MFGPrint["Preprocessing took ", time, " seconds to terminate."
-                    ];
-            ]
-        ];
+        PreEqs = EnsurePreprocessed[If[AssociationQ[PreEqs], PreEqs, Eqs]];
         js = Lookup[PreEqs, "js", $Failed];
-        AssoCritical = MFGSystemSolver[PreEqs][AssociationThread[js,
-            0 js]];
+        AssoCritical = MFGSystemSolver[PreEqs][AssociationThread[js, 0 js]];
         status = CheckFlowFeasibility[AssoCritical];
         If[validateQ && AssociationQ[AssoCritical] && status === "Feasible",
             If[!TrueQ @ IsCriticalSolution[
@@ -1976,40 +1898,10 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
                 status = "Infeasible";
             ]
         ];
-        resultKind =
-            If[AssoCritical === Null,
-                "Failure"
-                ,
-                "Success"
-            ];
-        message =
-            If[AssoCritical === Null,
-                If[validationFailedQ, "InvalidCriticalSolution", "NoSolution"]
-                ,
-                None
-            ];
-        solution =
-            If[AssociationQ[AssoCritical],
-                AssoCritical
-                ,
-                Missing["NotAvailable"]
-            ];
-        comparisonData = BuildSolverComparisonData[PreEqs, solution];
-        Join[PreEqs, MakeSolverResult["CriticalCongestion", resultKind,
-             status, message, solution,
-             Join[
-                 comparisonData,
-                 <|
-                    "AssoCritical" -> AssoCritical,
-                    "Status" -> status,
-                    "NumericBackendUsed" -> numericBackendUsedQ,
-                    "NumericBackendFallbackReason" -> numericBackendFallbackReason,
-                    "NumericBackendSolveTime" -> numericBackendSolveTime,
-                    "NumericBackendStrategy" -> numericBackendStrategy,
-                    "JFirstBackendUsed" -> jFirstBackendUsedQ,
-                    "JFirstBackendFallbackReason" -> jFirstBackendFallbackReason
-                 |>
-             ]]]
+        resultKind = If[AssoCritical === Null, "Failure", "Success"];
+        message = If[AssoCritical === Null,
+            If[validationFailedQ, "InvalidCriticalSolution", "NoSolution"], None];
+        BuildCriticalResult[PreEqs, resultKind, status, message, AssoCritical, telemetry]
     ];
 
 Options[IsCriticalSolution] = {

--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -1087,7 +1087,7 @@ DirectCriticalSolver[Eqs_Association] :=
 
 (* --- Critical numeric backend (internal, guarded) --- *)
 
-$CriticalNumericBackendEnabled = False;
+$CriticalNumericBackendEnabled = True;
 
 CriticalNumericBackendRequestedQ[Eqs_Association] :=
     Module[{mode},

--- a/MFGraphs/Tests/007-critical_congestion.mt
+++ b/MFGraphs/Tests/007-critical_congestion.mt
@@ -2,7 +2,9 @@
 Test[
 	MFGEquations = DataToEquations[GetExampleData[7] /. {I1 -> 100, U1 -> 0, U2 -> 0}];
     Association[
-        Normal[CriticalCongestionSolver[MFGEquations]["AssoCritical"]] /.
+        Normal[CriticalCongestionSolver[
+            Join[MFGEquations, <|"CriticalNumericBackendMode" -> False|>]
+        ]["AssoCritical"]] /.
             {MFGraphs`Private`u -> u, MFGraphs`Private`j -> j}
     ]
 	,

--- a/MFGraphs/Tests/007-critical_congestion_ok.mt
+++ b/MFGraphs/Tests/007-critical_congestion_ok.mt
@@ -2,7 +2,9 @@
 Test[
 	MFGEquations = DataToEquations[GetExampleData[7] /. {I1 -> 11, U1 -> 0, U2 -> 10}];
     Association[
-        Normal[CriticalCongestionSolver[MFGEquations]["AssoCritical"]] /.
+        Normal[CriticalCongestionSolver[
+            Join[MFGEquations, <|"CriticalNumericBackendMode" -> False|>]
+        ]["AssoCritical"]] /.
             {MFGraphs`Private`u -> u, MFGraphs`Private`j -> j}
     ]
 	,

--- a/MFGraphs/Tests/012-critical_congestion.mt
+++ b/MFGraphs/Tests/012-critical_congestion.mt
@@ -2,7 +2,9 @@
 Test[
 	MFGEquations = DataToEquations[GetExampleData[12] /. {I1 -> 2, U1 -> 0}];
     Association[
-        Normal[CriticalCongestionSolver[MFGEquations]["AssoCritical"]] /.
+        Normal[CriticalCongestionSolver[
+            Join[MFGEquations, <|"CriticalNumericBackendMode" -> False|>]
+        ]["AssoCritical"]] /.
             {MFGraphs`Private`u -> u, MFGraphs`Private`j -> j}
     ]
 	,


### PR DESCRIPTION
## Summary

- **Extract `BuildCriticalResult` helper** — replaces 4 copy-pasted ~25-line result envelope blocks in `CriticalCongestionSolver` with single-line calls. Introduces `EnsurePreprocessed` to consolidate 3 identical preprocessing guards. Net reduction: ~70 lines.
- **Fix latent telemetry bug** — `numericBackendFallbackReason` was never reset to `None` on the numeric success path (old code hardcoded `None` in inline associations, masking the variable). Now explicitly cleared when the numeric backend succeeds.
- **Enable numeric backend by default** — flip `$CriticalNumericBackendEnabled` from `False` to `True`. Eligible networks (zero switching costs, fully numeric inputs, valid `NumericState`) now use the LP-based solver automatically, with 30s timeout and graceful fallback to symbolic. Three legacy exact-match tests pinned to symbolic path via `"CriticalNumericBackendMode" -> False`.
- **Update CLAUDE.md** — document `SolveMFG` unified API, fix module load order, update return format to standardized envelope, add code style conventions and CI pipeline table.

## Test plan

- [x] All 9 MUnit test suites pass (package-loading, 007-critical_congestion, 007-critical_congestion_ok, 012-critical_congestion, infeasible-status, numeric-state, critical-numeric-backend, solve-mfg, solver-contracts)
- [ ] CI `fast_tests` green
- [ ] Spot-check performance on `core` tier benchmarks to confirm numeric backend speedup on eligible cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)