### PR TITLE
Alpha-aware dispatch, u-equivalence reduction, and epsilon LP tiebreaker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ wolframscript -file Scripts/BenchmarkSuite.wls --tag "description of change" --r
 
 The package follows a linear pipeline: **network data → equations → solver**.
 
-**Unified entrypoint** — `SolveMFG[data, Method -> m]` accepts raw data or compiled equations and dispatches to the appropriate solver. With `Method -> "Automatic"`, it cascades: CriticalCongestion → Monotone → NonLinear, falling back on infeasibility or failure. Returns a standardized result envelope plus `"MethodUsed"` and `"MethodTrace"` keys.
+**Unified entrypoint** — `SolveMFG[data, Method -> m, opts]` accepts raw data or compiled equations and dispatches to the appropriate solver. With `Method -> "Automatic"`, it cascades: CriticalCongestion → Monotone → NonLinear, falling back on infeasibility or failure. When `"CongestionExponentFunction"` specifies alpha != 1 (scalar, Association, or Function), CriticalCongestion is skipped since it only handles alpha=1. Hamiltonian options (`"PotentialFunction"`, `"CongestionExponentFunction"`, `"InteractionFunction"`) and all downstream solver options are declared in `Options[SolveMFG]` and forwarded via `FilterRules`. `"CongestionExponentFunction"` accepts a scalar, `Function[edge, ...]`, or an `Association` mapping edges to exponents (unlisted edges default to 1); all forms are normalized by `NormalizeEdgeFunction`. Returns a standardized result envelope plus `"MethodUsed"` and `"MethodTrace"` keys.
 
 **Individual solvers** can also be called directly:
 

--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -1133,6 +1133,92 @@ DirectCriticalSolver[Eqs_Association] :=
         result
     ]
 
+(* --- u-variable equivalence reduction (zero-switching-cost preprocessing) --- *)
+
+(* BuildUEquivalenceReduction: when switching costs are zero at a vertex,
+   all u[a,v] for that vertex v are equal.  We treat these equalities as
+   undirected edges in a graph over u-variables and collapse each connected
+   component to a single representative.  If a boundary value is known for
+   any member of the class, we prefer that member as representative so the
+   substitution injects the numeric constant directly. *)
+BuildUEquivalenceReduction[Eqs_Association] :=
+    Module[{us, auxPairs, switchingCosts, byVertex, edges, graph, components,
+        boundaryVars, representative, rules, liftRules, nEliminated},
+        us = Lookup[Eqs, "us", {}];
+        auxPairs = Cases[us, u[a_, b_] :> {a, b}];
+        switchingCosts = Lookup[Eqs, "SwitchingCosts", <||>];
+
+        (* Group auxiliary pairs by destination vertex *)
+        byVertex = GroupBy[auxPairs, Last];
+
+        (* Build undirected equality edges: u[a,v] == u[c,v] when S(a,v,c)=0 *)
+        edges = Flatten @ KeyValueMap[
+            Function[{v, pairs},
+                If[Length[pairs] <= 1, {},
+                    Select[
+                        Flatten[Table[
+                            UndirectedEdge[u @@ pairs[[i]], u @@ pairs[[j]]],
+                            {i, Length[pairs]}, {j, i + 1, Length[pairs]}
+                        ]],
+                        (* Both directions of switching must be zero *)
+                        With[{p1 = List @@ #[[1]], p2 = List @@ #[[2]]},
+                            Lookup[switchingCosts, Key[{p1[[1]], v, p2[[1]]}], Infinity] === 0 &&
+                            Lookup[switchingCosts, Key[{p2[[1]], v, p1[[1]]}], Infinity] === 0
+                        ] &
+                    ]
+                ]
+            ],
+            byVertex
+        ];
+
+        If[edges === {},
+            Return[<|
+                "SubstitutionRules" -> {},
+                "LiftRules" -> {},
+                "ReducedUVars" -> us,
+                "EliminatedCount" -> 0,
+                "ClassCount" -> Length[us],
+                "Classes" -> (List /@ us)
+            |>, Module]
+        ];
+
+        graph = Graph[us, edges];
+        components = ConnectedComponents[graph];
+
+        (* Identify boundary-valued u-variables for representative preference *)
+        boundaryVars = Join[
+            Keys[Lookup[Eqs, "RuleExitValues", <||>]],
+            Keys[Lookup[Eqs, "RuleEntryValues", <||>]]
+        ];
+
+        (* For each class, pick representative: prefer boundary vars, else first *)
+        rules = {};
+        liftRules = {};
+        Do[
+            representative = With[{bnd = Select[class, MemberQ[boundaryVars, #] &]},
+                If[bnd =!= {}, First[bnd], First[class]]
+            ];
+            Do[
+                If[var =!= representative,
+                    AppendTo[rules, var -> representative];
+                    AppendTo[liftRules, var -> representative];
+                ],
+                {var, class}
+            ],
+            {class, components}
+        ];
+
+        nEliminated = Length[rules];
+        <|
+            "SubstitutionRules" -> rules,
+            "LiftRules" -> liftRules,
+            "ReducedUVars" -> Complement[us, Keys[Association[rules]]],
+            "EliminatedCount" -> nEliminated,
+            "ClassCount" -> Length[components],
+            "Classes" -> components
+        |>
+    ];
+
 (* --- Critical numeric backend (internal, guarded) --- *)
 
 $CriticalNumericBackendEnabled = True;
@@ -1645,9 +1731,11 @@ SolveCriticalNumericBackendWithTelemetry[Eqs_Association] :=
     ];
 
 SolveCriticalNumericBackend[Eqs_Association] :=
-    Module[{constraints, equalities, flowVars, allVars,
+    Module[{constraints, equalities, flowVars, allVars, fullUs, fullJs, fullJts,
+        reduction, subRules, reducedUs, reducedVars,
         linearSystem, aMat, bVec, xCandidate, varIndex, flowIndices,
-        linResidual, flowMin, tol = $CriticalSolverTolerance, assoc, lpResult, lpVals, solvedAssoc,
+        linResidual, flowMin, tol = $CriticalSolverTolerance, assoc, lpResult, lpVals,
+        solvedAssoc, fullAssoc,
         nVars, cVec, aIneq, bIneq, aEq, bEq},
         constraints = BuildCriticalLinearConstraints[Eqs];
         If[constraints === $Failed || !AssociationQ[constraints],
@@ -1656,34 +1744,59 @@ SolveCriticalNumericBackend[Eqs_Association] :=
         equalities = Lookup[constraints, "Equalities", {}];
         flowVars = Lookup[constraints, "FlowVariables", {}];
         allVars = Lookup[constraints, "AllVariables", {}];
+        fullUs = Lookup[Eqs, "us", {}];
+        fullJs = Lookup[Eqs, "js", {}];
+        fullJts = Lookup[Eqs, "jts", {}];
         If[equalities === {} || allVars === {},
             Return[$Failed, Module]
         ];
-        varIndex = AssociationThread[allVars, Range[Length[allVars]]];
+
+        (* Apply u-variable equivalence reduction *)
+        reduction = BuildUEquivalenceReduction[Eqs];
+        subRules = Lookup[reduction, "SubstitutionRules", {}];
+        reducedUs = Lookup[reduction, "ReducedUVars", fullUs];
+        If[subRules =!= {},
+            equalities = DeleteDuplicates @ Cases[
+                DeleteCases[equalities /. subRules, True],
+                _Equal
+            ];
+            (* Remove tautologies like x == x that arise from substitution *)
+            equalities = Select[equalities, #[[1]] =!= #[[2]] &];
+            reducedVars = Join[reducedUs, fullJs, fullJts];
+            ,
+            reducedVars = allVars
+        ];
+        If[equalities === {} || reducedVars === {},
+            Return[$Failed, Module]
+        ];
+
+        varIndex = AssociationThread[reducedVars, Range[Length[reducedVars]]];
         flowIndices = Lookup[varIndex, flowVars, Missing["NotAvailable"]];
         If[MemberQ[flowIndices, _Missing] || flowIndices === {},
             Return[$Failed, Module]
         ];
 
-        linearSystem = BuildLinearSystemFromEqualities[equalities, allVars];
+        linearSystem = BuildLinearSystemFromEqualities[equalities, reducedVars];
         If[AssociationQ[linearSystem],
             aMat = linearSystem["A"];
             bVec = linearSystem["b"];
             xCandidate = LinearSolveCandidate[aMat, bVec];
-            If[VectorQ[xCandidate, NumericQ] && Length[xCandidate] === Length[allVars],
+            If[VectorQ[xCandidate, NumericQ] && Length[xCandidate] === Length[reducedVars],
                 linResidual = Quiet @ Check[N @ Norm[aMat . xCandidate - bVec, Infinity], Infinity];
                 flowMin = Min[xCandidate[[flowIndices]]];
                 If[NumericQ[linResidual] && linResidual <= tol && NumericQ[flowMin] && flowMin >= -tol,
-                    assoc = AssociationThread[allVars, xCandidate];
+                    assoc = AssociationThread[reducedVars, xCandidate];
+                    (* Lift eliminated u-vars back from their representatives *)
+                    fullAssoc = Join[assoc, Association[subRules /. assoc]];
                     solvedAssoc = Association @ KeyValueMap[
                         #1 -> If[Abs[#2] <= tol, 0., N[#2]] &,
-                        assoc
+                        fullAssoc
                     ];
                     Return[
                         Join[
-                            KeyTake[solvedAssoc, Lookup[Eqs, "us", {}]],
-                            KeyTake[solvedAssoc, Lookup[Eqs, "js", {}]],
-                            KeyTake[solvedAssoc, Lookup[Eqs, "jts", {}]]
+                            KeyTake[solvedAssoc, fullUs],
+                            KeyTake[solvedAssoc, fullJs],
+                            KeyTake[solvedAssoc, fullJts]
                         ],
                         Module
                     ]
@@ -1693,8 +1806,13 @@ SolveCriticalNumericBackend[Eqs_Association] :=
             Return[$Failed, Module]
         ];
 
-        nVars = Length[allVars];
-        cVec = Developer`ToPackedArray @ ConstantArray[0., nVars];
+        nVars = Length[reducedVars];
+        (* Minimize total flow to break counter-flow degeneracy:
+           flow variables get cost 1, u-variables get cost 0. *)
+        cVec = Developer`ToPackedArray @ N @ ReplacePart[
+            ConstantArray[0., nVars],
+            Thread[flowIndices -> 1.]
+        ];
         aEq = If[Head[aMat] === SparseArray, aMat, SparseArray[aMat]];
         bEq = Developer`ToPackedArray @ N @ (-bVec);
         aIneq = SparseArray[
@@ -1739,15 +1857,17 @@ SolveCriticalNumericBackend[Eqs_Association] :=
             lpVals === $Failed || !VectorQ[lpVals, NumericQ] || Length[lpVals] =!= nVars,
             Return[$Failed, Module]
         ];
-        assoc = AssociationThread[allVars, Developer`ToPackedArray @ N @ lpVals];
+        assoc = AssociationThread[reducedVars, Developer`ToPackedArray @ N @ lpVals];
+        (* Lift eliminated u-vars back from their representatives *)
+        fullAssoc = Join[assoc, Association[subRules /. assoc]];
         solvedAssoc = Association @ KeyValueMap[
             #1 -> If[Abs[#2] <= tol, 0., N[#2]] &,
-            assoc
+            fullAssoc
         ];
         Join[
-            KeyTake[solvedAssoc, Lookup[Eqs, "us", {}]],
-            KeyTake[solvedAssoc, Lookup[Eqs, "js", {}]],
-            KeyTake[solvedAssoc, Lookup[Eqs, "jts", {}]]
+            KeyTake[solvedAssoc, fullUs],
+            KeyTake[solvedAssoc, fullJs],
+            KeyTake[solvedAssoc, fullJts]
         ]
     ];
 

--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -1807,11 +1807,13 @@ SolveCriticalNumericBackend[Eqs_Association] :=
         ];
 
         nVars = Length[reducedVars];
-        (* Minimize total flow to break counter-flow degeneracy:
-           flow variables get cost 1, u-variables get cost 0. *)
+        (* Infinitesimal flow-minimizing objective to break counter-flow
+           degeneracy without distorting the equilibrium.  The equilibrium
+           is fully pinned by the equality constraints; this epsilon
+           tiebreaker only selects the non-cycling vertex of the polytope. *)
         cVec = Developer`ToPackedArray @ N @ ReplacePart[
             ConstantArray[0., nVars],
-            Thread[flowIndices -> 1.]
+            Thread[flowIndices -> 10.^-12]
         ];
         aEq = If[Head[aMat] === SparseArray, aMat, SparseArray[aMat]];
         bEq = Developer`ToPackedArray @ N @ (-bVec);

--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -53,16 +53,25 @@ or Length[list] >= $MFGraphsParallelLaunchThreshold (when kernels must be launch
 This avoids paying ~3s kernel launch overhead for small workloads.";
 
 SolveMFG::usage =
-"SolveMFG[input, Method -> m] dispatches to the selected stationary solver and returns
-its standardized result association.
+"SolveMFG[input, Method -> m, opts] dispatches to the selected stationary solver and \
+returns its standardized result association.
 
 Supported methods:
-  \"Automatic\" (placeholder in phase 1, routes to CriticalCongestion)
+  \"Automatic\" — cascades CriticalCongestion -> Monotone -> NonLinear, falling back on \
+infeasibility or failure. When \"CongestionExponentFunction\" specifies alpha != 1, \
+CriticalCongestion is skipped (it only handles alpha=1).
   \"CriticalCongestion\"
   \"NonLinear\"
   \"Monotone\"
 
-input can be either raw data (association accepted by DataToEquations) or an already
+Hamiltonian options (forwarded to NonLinear and Monotone solvers):
+  \"PotentialFunction\" (default Automatic)
+  \"CongestionExponentFunction\" (default Automatic, meaning alpha=1). Accepts a scalar, \
+a Function[edge, ...], or an Association mapping edges to exponents (unlisted edges \
+default to 1).
+  \"InteractionFunction\" (default Automatic)
+
+input can be either raw data (association accepted by DataToEquations) or an already \
 compiled equation association.";
 
 $MFGraphsParallelLaunchThreshold::usage =
@@ -329,9 +338,15 @@ Get["MFGraphs`NonLinearSolver`"];
 Get["MFGraphs`Monotone`"];
 Get["MFGraphs`TimeDependentSolver`"];
 
-Options[SolveMFG] = {
-    Method -> "Automatic"
-};
+Options[SolveMFG] = DeleteDuplicatesBy[
+    Join[
+        {Method -> "Automatic"},
+        Options[NonLinearSolver],
+        Options[MonotoneSolverFromData],
+        Options[CriticalCongestionSolver]
+    ],
+    First
+];
 
 SolveMFGUnknownMethodResult[method_] :=
     <|
@@ -398,41 +413,61 @@ SolveMFGAbortResult[message_, methodUsed_, trace_List] :=
         "Convergence" -> Missing["NotApplicable"]
     |>;
 
+SolveMFGIsCriticalQ[opts_List] :=
+    Module[{alphaOpt},
+        alphaOpt = "CongestionExponentFunction" /. opts;
+        If[alphaOpt === "CongestionExponentFunction", alphaOpt = Automatic];
+        Which[
+            alphaOpt === Automatic, True,
+            NumericQ[alphaOpt], alphaOpt == 1,
+            AssociationQ[alphaOpt], AllTrue[Values[alphaOpt], # == 1 &],
+            True, False
+        ]
+    ];
+
 SolveMFGAutomaticDispatch[input_Association, opts_List] :=
-    Module[{d2e, result = Missing["NotAvailable"], decision, trace = {}, methodUsed = "Automatic", attempts},
+    Module[{d2e, result = Missing["NotAvailable"], decision, trace = {}, methodUsed = "Automatic",
+            attempts, isCritical},
         d2e = If[SolveMFGCompiledInputQ[input], input, Quiet @ Check[DataToEquations[input], $Failed]];
         If[!AssociationQ[d2e],
             Return[SolveMFGAbortResult["DataToEquationsFailed", methodUsed, trace], Module]
         ];
-        attempts = {
-            <|
-                "Method" -> "CriticalCongestion",
-                "Run" -> Function[
-                    CriticalCongestionSolver[
-                        d2e,
-                        Sequence @@ FilterRules[opts, Options[CriticalCongestionSolver]]
+        isCritical = SolveMFGIsCriticalQ[opts];
+        attempts = Join[
+            (* alpha=1: try CriticalCongestion first; alpha!=1: skip it *)
+            If[isCritical,
+                {<|
+                    "Method" -> "CriticalCongestion",
+                    "Run" -> Function[
+                        CriticalCongestionSolver[
+                            d2e,
+                            Sequence @@ FilterRules[opts, Options[CriticalCongestionSolver]]
+                        ]
                     ]
-                ]
-            |>,
-            <|
-                "Method" -> "Monotone",
-                "Run" -> Function[
-                    MonotoneSolver[
-                        d2e,
-                        Sequence @@ FilterRules[opts, Options[MonotoneSolver]]
+                |>},
+                {}
+            ],
+            {
+                <|
+                    "Method" -> "Monotone",
+                    "Run" -> Function[
+                        MonotoneSolver[
+                            d2e,
+                            Sequence @@ FilterRules[opts, Options[MonotoneSolver]]
+                        ]
                     ]
-                ]
-            |>,
-            <|
-                "Method" -> "NonLinear",
-                "Run" -> Function[
-                    NonLinearSolver[
-                        d2e,
-                        Sequence @@ FilterRules[opts, Options[NonLinearSolver]]
+                |>,
+                <|
+                    "Method" -> "NonLinear",
+                    "Run" -> Function[
+                        NonLinearSolver[
+                            d2e,
+                            Sequence @@ FilterRules[opts, Options[NonLinearSolver]]
+                        ]
                     ]
-                ]
-            |>
-        };
+                |>
+            }
+        ];
         Do[
             result = attempt["Run"][];
             decision = SolveMFGClassifyOutcome[result];

--- a/MFGraphs/NonLinearSolver.wl
+++ b/MFGraphs/NonLinearSolver.wl
@@ -37,8 +37,14 @@ alpha::usage =
 g::usage =
 "g[m, edge] is the edge-dependent interaction term as a function of density m. The default is -1/m^2.";
 
+NormalizeEdgeFunction::usage =
+"NormalizeEdgeFunction[spec, defaultVal] normalizes a user-provided per-edge specification \
+(scalar, Association, Function, or Automatic) into a guaranteed Function[edge, ...]. \
+Unlisted edges in an Association default to defaultVal (default 1).";
+
 WithHamiltonianFunctions::usage =
-"WithHamiltonianFunctions[vFun, alphaFun, gFun, expr] temporarily overrides the public MFGraphs Hamiltonian ingredients V, alpha, and g while evaluating expr. Any argument may be Automatic to keep the current definition.";
+"WithHamiltonianFunctions[vFun, alphaFun, gFun, expr] temporarily overrides the public MFGraphs Hamiltonian ingredients V, alpha, and g while evaluating expr. Any argument may be Automatic to keep the current definition. \
+alphaFun is normalized via NormalizeEdgeFunction so that scalar, Association, and Function specs all work.";
 
 U::usage =
 "U[x, edge, Eqs, sol] computes the value function at position x on the given edge."
@@ -64,12 +70,19 @@ Options[NonLinearSolver] = {
     "InteractionFunction" -> Automatic
 };
 
+NormalizeEdgeFunction[spec_, defaultVal_: 1] := Which[
+    spec === Automatic,    With[{d = defaultVal}, Function[edge, d]],
+    NumericQ[spec],        With[{v = spec}, Function[edge, v]],
+    AssociationQ[spec],    With[{a = spec, d = defaultVal}, Function[edge, Lookup[a, Key[edge], d]]],
+    True,                  spec
+];
+
 SetAttributes[WithHamiltonianFunctions, HoldRest];
 
 WithHamiltonianFunctions[vFun_:Automatic, alphaFun_:Automatic, gFun_:Automatic, expr_] :=
     Block[{V, alpha, g},
         V     = If[vFun     =!= Automatic, vFun,     Function[{x, edge}, 0]];
-        alpha = If[alphaFun =!= Automatic, alphaFun, 1&];
+        alpha = NormalizeEdgeFunction[alphaFun, 1];
         g     = If[gFun     =!= Automatic, gFun,     Function[{m, edge}, -1/m^2]];
         expr
     ];

--- a/MFGraphs/Tests/solve-mfg.mt
+++ b/MFGraphs/Tests/solve-mfg.mt
@@ -340,3 +340,168 @@ Test[
     ,
     TestID -> "SolveMFG automatic: real-data run returns method trace and method used"
 ]
+
+(* ================================================================ *)
+(* Alpha-aware dispatch tests (issue #23)                           *)
+(* ================================================================ *)
+
+(* Helper: run SolveMFG with mocked solvers, returning {result, criticalCalls}. *)
+solveMFGWithMockedSolvers[alphaSpec_] :=
+    Module[{compiled, result, criticalCalls = 0},
+        compiled = <|"EqGeneral" -> True, "js" -> {}, "jts" -> {}|>;
+        result = Block[{CriticalCongestionSolver, MonotoneSolver, NonLinearSolver},
+            CriticalCongestionSolver[___] :=
+                (
+                    criticalCalls++;
+                    <|
+                        "Solver" -> "CriticalCongestion",
+                        "ResultKind" -> "Success",
+                        "Feasibility" -> "Feasible",
+                        "Message" -> None,
+                        "Solution" -> <||>,
+                        "Convergence" -> Missing["NotApplicable"]
+                    |>
+                );
+            MonotoneSolver[___] =
+                <|
+                    "Solver" -> "Monotone",
+                    "ResultKind" -> "Success",
+                    "Feasibility" -> "Feasible",
+                    "Message" -> None,
+                    "Solution" -> <||>,
+                    "Convergence" -> <||>
+                |>;
+            NonLinearSolver[___] =
+                <|
+                    "Solver" -> "NonLinear",
+                    "ResultKind" -> "Success",
+                    "Feasibility" -> "Feasible",
+                    "Message" -> None,
+                    "Solution" -> <||>,
+                    "Convergence" -> <||>
+                |>;
+            SolveMFG[compiled, Method -> "Automatic",
+                "CongestionExponentFunction" -> alphaSpec]
+        ];
+        {result, criticalCalls}
+    ];
+
+Test[
+    Module[{result, criticalCalls, trace},
+        {result, criticalCalls} = solveMFGWithMockedSolvers[2&];
+        trace = Lookup[result, "MethodTrace", {}];
+        criticalCalls === 0 &&
+        Lookup[result, "MethodUsed", None] === "Monotone" &&
+        Length[trace] === 1 &&
+        Lookup[trace[[1]], "Method", None] === "Monotone"
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG automatic: alpha!=1 skips CriticalCongestion"
+]
+
+Test[
+    Module[{result, criticalCalls},
+        {result, criticalCalls} = solveMFGWithMockedSolvers[<|{1, 2} -> 1.5|>];
+        criticalCalls === 0 &&
+        Lookup[result, "MethodUsed", None] === "Monotone"
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG automatic: Association alpha!=1 skips CriticalCongestion"
+]
+
+Test[
+    Module[{result, criticalCalls},
+        {result, criticalCalls} = solveMFGWithMockedSolvers[<|{1, 2} -> 1, {2, 3} -> 1|>];
+        criticalCalls === 1 &&
+        Lookup[result, "MethodUsed", None] === "CriticalCongestion"
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG automatic: uniform alpha=1 Association still routes to Critical"
+]
+
+Test[
+    Module[{result, criticalCalls},
+        {result, criticalCalls} = solveMFGWithMockedSolvers[1&];
+        (* Function (1&) is not recognized as critical (conservative), so it skips Critical *)
+        criticalCalls === 0 &&
+        Lookup[result, "MethodUsed", None] === "Monotone"
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG automatic: opaque Function alpha conservatively skips Critical"
+]
+
+Test[
+    Module[{data, result},
+        data = GetExampleData[3] /. {I1 -> 2, U1 -> 0};
+        result = Quiet[
+            SolveMFG[
+                data,
+                Method -> "NonLinear",
+                "MaxIterations" -> 20,
+                "Tolerance" -> 10^-8,
+                "CongestionExponentFunction" -> 1.5
+            ]
+        ];
+        Lookup[result, "Solver", None] === "NonLinear" &&
+        MemberQ[{"Success", "NonConverged"}, Lookup[result, "ResultKind", None]]
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG routing: Hamiltonian options forwarded to NonLinear with scalar alpha"
+]
+
+(* NormalizeEdgeFunction unit tests *)
+
+Test[
+    Module[{f},
+        f = NormalizeEdgeFunction[2.5];
+        f[{1, 2}]
+    ]
+    ,
+    2.5
+    ,
+    TestID -> "NormalizeEdgeFunction: scalar input returns constant function"
+]
+
+Test[
+    Module[{f},
+        f = NormalizeEdgeFunction[<|{1, 2} -> 1.5, {2, 3} -> 2.0|>];
+        {f[{1, 2}], f[{2, 3}], f[{3, 4}]}
+    ]
+    ,
+    {1.5, 2.0, 1}
+    ,
+    TestID -> "NormalizeEdgeFunction: Association with default fallback"
+]
+
+Test[
+    Module[{f},
+        f = NormalizeEdgeFunction[Automatic];
+        f[{1, 2}]
+    ]
+    ,
+    1
+    ,
+    TestID -> "NormalizeEdgeFunction: Automatic returns default-valued function"
+]
+
+Test[
+    Module[{f, custom},
+        custom = Function[edge, Length[edge]];
+        f = NormalizeEdgeFunction[custom];
+        f[{1, 2}]
+    ]
+    ,
+    2
+    ,
+    TestID -> "NormalizeEdgeFunction: Function passthrough"
+]

--- a/MFGraphs/TimeDependentSolver.wl
+++ b/MFGraphs/TimeDependentSolver.wl
@@ -39,7 +39,10 @@ Options[TimeDependentSolver] = {
     "MaxOuterIterations" -> 20,
     "Tolerance" -> 10^-6,
     "SpatialSolverIterations" -> 0,
-    "ReturnShape" -> "Legacy"
+    "ReturnShape" -> "Legacy",
+    "PotentialFunction" -> Automatic,
+    "CongestionExponentFunction" -> Automatic,
+    "InteractionFunction" -> Automatic
 };
 
 Begin["`Private`"];
@@ -319,7 +322,8 @@ assembleResult[timeGrid_List, valueField_List, flowField_List,
 (* ============================================================ *)
 
 TimeDependentSolver[data_Association, opts:OptionsPattern[]] :=
-    Module[{d2e, T, Nt, timeGrid,
+    Module[{potentialFunction, congestionExponentFunction, interactionFunction,
+            d2e, T, Nt, timeGrid,
             maxIter, tol, spatialIter, returnShape,
             massField, valueField, flowField, prevFlowField,
             residual = Infinity, converged = False, iteration = 0,
@@ -341,66 +345,75 @@ TimeDependentSolver[data_Association, opts:OptionsPattern[]] :=
         tol = OptionValue["Tolerance"];
         spatialIter = OptionValue["SpatialSolverIterations"];
         returnShape = OptionValue["ReturnShape"];
+        potentialFunction = OptionValue["PotentialFunction"];
+        congestionExponentFunction = OptionValue["CongestionExponentFunction"];
+        interactionFunction = OptionValue["InteractionFunction"];
 
-        (* Time discretization *)
-        T = data["Time Horizon"];
-        Nt = Lookup[data, "Time Steps", 10];
-        timeGrid = N @ Subdivide[0, T, Nt];
+        WithHamiltonianFunctions[
+            potentialFunction,
+            congestionExponentFunction,
+            interactionFunction,
 
-        (* Build spatial structure once *)
-        MFGPrint["Building spatial structure..."];
-        {time, d2e} = AbsoluteTiming @ DataToEquations[data];
-        MFGPrint["DataToEquations took ", time, " seconds."];
+            (* Time discretization *)
+            T = data["Time Horizon"];
+            Nt = Lookup[data, "Time Steps", 10];
+            timeGrid = N @ Subdivide[0, T, Nt];
 
-        js = Lookup[d2e, "js", {}];
+            (* Build spatial structure once *)
+            MFGPrint["Building spatial structure..."];
+            {time, d2e} = AbsoluteTiming @ DataToEquations[data];
+            MFGPrint["DataToEquations took ", time, " seconds."];
 
-        (* Initialize: zero flows at all time steps *)
-        massField = Table[AssociationThread[js, 0 js], {Nt + 1}];
+            js = Lookup[d2e, "js", {}];
 
-        (* Outer backward-forward loop *)
-        Do[
-            MFGPrint["\n=== Outer iteration ", iteration, " / ", maxIter, " ==="];
+            (* Initialize: zero flows at all time steps *)
+            massField = Table[AssociationThread[js, 0 js], {Nt + 1}];
 
-            (* Backward pass: solve for value function *)
-            {time, {valueField, flowField}} = AbsoluteTiming @
-                backwardPass[d2e, data, timeGrid, massField, spatialIter];
-            MFGPrint["Backward pass took ", time, " seconds."];
+            (* Outer backward-forward loop *)
+            Do[
+                MFGPrint["\n=== Outer iteration ", iteration, " / ", maxIter, " ==="];
 
-            (* Convergence check: compare flow fields *)
-            If[iteration > 1,
-                residual = Max @ Table[
-                    If[AssociationQ[flowField[[k]]] && AssociationQ[prevFlowField[[k]]],
-                        Module[{diff = Values[flowField[[k]]] - Values[prevFlowField[[k]]]},
-                            If[AllTrue[diff, NumericQ],
-                                Max[Abs[diff]],
-                                Infinity
-                            ]
+                (* Backward pass: solve for value function *)
+                {time, {valueField, flowField}} = AbsoluteTiming @
+                    backwardPass[d2e, data, timeGrid, massField, spatialIter];
+                MFGPrint["Backward pass took ", time, " seconds."];
+
+                (* Convergence check: compare flow fields *)
+                If[iteration > 1,
+                    residual = Max @ Table[
+                        If[AssociationQ[flowField[[k]]] && AssociationQ[prevFlowField[[k]]],
+                            Module[{diff = Values[flowField[[k]]] - Values[prevFlowField[[k]]]},
+                                If[AllTrue[diff, NumericQ],
+                                    Max[Abs[diff]],
+                                    Infinity
+                                ]
+                            ],
+                            Infinity
                         ],
-                        Infinity
-                    ],
-                    {k, 1, Nt + 1}
-                ];
-                MFGPrint["Flow residual: ", residual];
+                        {k, 1, Nt + 1}
+                    ];
+                    MFGPrint["Flow residual: ", residual];
 
-                If[residual < tol,
-                    converged = True;
-                    MFGPrint["Converged!"];
-                    Break[]
-                ]
+                    If[residual < tol,
+                        converged = True;
+                        MFGPrint["Converged!"];
+                        Break[]
+                    ]
+                ];
+
+                prevFlowField = flowField;
+
+                (* Forward pass: update mass field from flows *)
+                massField = forwardPass[d2e, flowField, timeGrid];
+                MFGPrint["Forward pass complete."],
+
+                {iteration, 1, maxIter}
             ];
 
-            prevFlowField = flowField;
-
-            (* Forward pass: update mass field from flows *)
-            massField = forwardPass[d2e, flowField, timeGrid];
-            MFGPrint["Forward pass complete."],
-
-            {iteration, 1, maxIter}
-        ];
-
-        (* Assemble and return result *)
-        assembleResult[timeGrid, valueField, flowField, massField,
-            iteration, residual, converged, returnShape]
+            (* Assemble and return result *)
+            assembleResult[timeGrid, valueField, flowField, massField,
+                iteration, residual, converged, returnShape]
+        ]
     ]
 
 End[];


### PR DESCRIPTION
## Summary

Closes #23

- **Alpha-aware SolveMFG dispatch**: `SolveMFG` now captures all downstream solver options and skips `CriticalCongestionSolver` when `"CongestionExponentFunction"` specifies alpha != 1 (scalar, Association, or Function). Adds `NormalizeEdgeFunction` to normalize per-edge alpha specs and `SolveMFGIsCriticalQ` for cascade logic.
- **u-variable equivalence reduction**: `BuildUEquivalenceReduction` collapses u-variables linked by zero switching costs into equivalence classes, reducing the LP/linear system dimensionality for the numeric backend.
- **Epsilon LP tiebreaker**: Replaces the unit-cost objective with an infinitesimal flow-minimizing objective (`10^-12` per flow variable) to break counter-flow degeneracy without distorting the equilibrium.
- **TimeDependentSolver Hamiltonian options**: Adds `"PotentialFunction"`, `"CongestionExponentFunction"`, `"InteractionFunction"` options with `WithHamiltonianFunctions` wrapper.

## Test plan

- [x] 9 new tests in `solve-mfg.mt` (alpha dispatch, NormalizeEdgeFunction, end-to-end forwarding)
- [ ] `wolframscript -file Scripts/RunTests.wls fast` — no regressions
- [ ] `wolframscript -file Scripts/BenchmarkSuite.wls core timeout=60` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)