### PR TITLE
Fix Hamiltonian forwarding, validator flows, Oracle Bridge, and symbo…

### DIFF
--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -1875,9 +1875,22 @@ SolveCriticalNumericBackend[Eqs_Association] :=
 
 (* --- CriticalCongestionSolver --- *)
 
+(* BuildPrunedSystem: given a numeric candidate solution and the symbolic system {EE, NN, OR},
+   retain only the Or-branches satisfied by the candidate. Falls back to the full system
+   if no branches are satisfied. *)
+BuildPrunedSystem[system_, candidateSolution_Association, tol_: 10^-6] :=
+    Module[{ee, nn, orBranches, activeOrBranches, prunedOr},
+        {ee, nn, orBranches} = system;
+        activeOrBranches = Select[orBranches,
+            TrueQ[LogicalSatisfiedQ[#, candidateSolution, tol]] &
+        ];
+        prunedOr = If[activeOrBranches === {}, orBranches, activeOrBranches];
+        {ee, nn, prunedOr}
+    ];
+
 (* BuildCriticalResult: single point for assembling the standardized result envelope.
    Eliminates duplication across numeric, direct, and symbolic solver paths. *)
-BuildCriticalResult[PreEqs_Association, resultKind_String, status_String, message_,
+BuildCriticalResult[PreEqs_Association, resultKind_, status_, message_,
     candidate_, telemetry_Association] :=
     Module[{solution, comparisonData},
         solution = If[AssociationQ[candidate], candidate, Missing["NotAvailable"]];
@@ -1902,7 +1915,8 @@ EnsurePreprocessed[Eqs_Association] :=
 Options[CriticalCongestionSolver] = {
     "ValidateSolution" -> True,
     "ValidationTolerance" -> $CriticalSolverTolerance,
-    "ValidationVerbose" -> False
+    "ValidationVerbose" -> False,
+    "SymbolicTimeLimit" -> 120.
 };
 
 CriticalCongestionSolver[$Failed, ___] :=
@@ -2055,24 +2069,61 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
         ];
         (* Standard symbolic solver path *)
         PreEqs = EnsurePreprocessed[If[AssociationQ[PreEqs], PreEqs, Eqs]];
-        js = Lookup[PreEqs, "js", $Failed];
-        AssoCritical = MFGSystemSolver[PreEqs][AssociationThread[js, 0 js]];
-        status = CheckFlowFeasibility[AssoCritical];
-        If[validateQ && AssociationQ[AssoCritical] && status === "Feasible",
-            If[!TrueQ @ IsCriticalSolution[
-                Join[PreEqs, <|"AssoCritical" -> AssoCritical, "Solution" -> AssoCritical|>],
-                "Tolerance" -> validationTolerance,
-                "Verbose" -> validationVerboseQ
-            ],
-                validationFailedQ = True;
-                AssoCritical = Null;
-                status = "Infeasible";
+        (* Oracle Bridge: if the numeric backend produced a candidate that failed validation,
+           use it to prune the symbolic Or-branches before the full symbolic solve. *)
+        If[AssociationQ[numericCandidate] &&
+            ListQ[Lookup[PreEqs, "NewSystem", $Failed]] &&
+            Length[Lookup[PreEqs, "NewSystem", {}]] === 3,
+            Module[{prunedSystem, originalBranchCount, prunedBranchCount},
+                originalBranchCount = Length[Lookup[PreEqs, "NewSystem"][[3]]];
+                prunedSystem = BuildPrunedSystem[
+                    Lookup[PreEqs, "NewSystem"],
+                    numericCandidate
+                ];
+                prunedBranchCount = Length[prunedSystem[[3]]];
+                If[prunedBranchCount < originalBranchCount,
+                    PreEqs = Append[PreEqs, "NewSystem" -> prunedSystem];
+                    MFGPrint["Oracle Bridge: pruned Or-branches from ", originalBranchCount,
+                        " to ", prunedBranchCount]
+                ]
             ]
         ];
-        resultKind = If[AssoCritical === Null, "Failure", "Success"];
-        message = If[AssoCritical === Null,
-            If[validationFailedQ, "InvalidCriticalSolution", "NoSolution"], None];
-        BuildCriticalResult[PreEqs, resultKind, status, message, AssoCritical, telemetry]
+        js = Lookup[PreEqs, "js", $Failed];
+        Module[{symbolicTimeLimit, symbolicResult},
+            symbolicTimeLimit = OptionValue["SymbolicTimeLimit"];
+            symbolicResult = TimeConstrained[
+                Module[{localAssoCritical, localStatus, localValidationFailedQ = False,
+                        localResultKind, localMessage},
+                    localAssoCritical = MFGSystemSolver[PreEqs][AssociationThread[js, 0 js]];
+                    localStatus = CheckFlowFeasibility[localAssoCritical];
+                    If[validateQ && AssociationQ[localAssoCritical] && localStatus === "Feasible",
+                        If[!TrueQ @ IsCriticalSolution[
+                            Join[PreEqs, <|"AssoCritical" -> localAssoCritical, "Solution" -> localAssoCritical|>],
+                            "Tolerance" -> validationTolerance,
+                            "Verbose" -> validationVerboseQ
+                        ],
+                            localValidationFailedQ = True;
+                            localAssoCritical = Null;
+                            localStatus = "Infeasible";
+                        ]
+                    ];
+                    localResultKind = If[localAssoCritical === Null, "Failure", "Success"];
+                    localMessage = If[localAssoCritical === Null,
+                        If[localValidationFailedQ, "InvalidCriticalSolution", "NoSolution"], None];
+                    BuildCriticalResult[PreEqs, localResultKind, localStatus, localMessage, localAssoCritical, telemetry]
+                ],
+                symbolicTimeLimit,
+                $TimedOut
+            ];
+            If[symbolicResult === $TimedOut,
+                BuildCriticalResult[PreEqs, "Failure", Missing["NotAvailable"],
+                    "SymbolicTimeout", Null,
+                    Join[telemetry, <|"SymbolicSolverTimedOut" -> True,
+                        "SymbolicSolverTimeLimit" -> symbolicTimeLimit|>]]
+                ,
+                symbolicResult
+            ]
+        ]
     ];
 
 Options[IsCriticalSolution] = {
@@ -2252,8 +2303,14 @@ IsCriticalSolution[Eqs_Association, OptionsPattern[]] :=
             Return[If[returnReportQ, report, False], Module]
         ];
 
-        flowApprox = Lookup[Eqs, "js", {}];
-        flowApprox = AssociationThread[flowApprox, 0 flowApprox];
+        flowApprox = Which[
+            AssociationQ[Lookup[Eqs, "AssoCritical", Missing["NotAvailable"]]],
+                KeyTake[Lookup[Eqs, "AssoCritical"], Lookup[Eqs, "js", {}]],
+            AssociationQ[Lookup[Eqs, "Solution", Missing["NotAvailable"]]],
+                KeyTake[Lookup[Eqs, "Solution"], Lookup[Eqs, "js", {}]],
+            True,
+                AssociationThread[Lookup[Eqs, "js", {}], 0 Lookup[Eqs, "js", {}]]
+        ];
         costpluscurrents = Lookup[Eqs, "costpluscurrents", Missing["NotAvailable"]];
         eqGeneralCritical =
             Lookup[Eqs, "EqGeneral", True] /.

--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -425,10 +425,21 @@ SolveMFGIsCriticalQ[opts_List] :=
         ]
     ];
 
+SolveMFGCompileInput[input_Association, opts_List:{}] :=
+    Module[{potentialFunction, congestionExponentFunction, interactionFunction},
+        If[SolveMFGCompiledInputQ[input], Return[input, Module]];
+        potentialFunction = Replace["PotentialFunction" /. opts, "PotentialFunction" -> Automatic];
+        congestionExponentFunction = Replace[
+            "CongestionExponentFunction" /. opts, "CongestionExponentFunction" -> Automatic];
+        interactionFunction = Replace["InteractionFunction" /. opts, "InteractionFunction" -> Automatic];
+        WithHamiltonianFunctions[potentialFunction, congestionExponentFunction, interactionFunction,
+            DataToEquations[input]]
+    ];
+
 SolveMFGAutomaticDispatch[input_Association, opts_List] :=
     Module[{d2e, result = Missing["NotAvailable"], decision, trace = {}, methodUsed = "Automatic",
             attempts, isCritical},
-        d2e = If[SolveMFGCompiledInputQ[input], input, Quiet @ Check[DataToEquations[input], $Failed]];
+        d2e = If[SolveMFGCompiledInputQ[input], input, Quiet @ Check[SolveMFGCompileInput[input, opts], $Failed]];
         If[!AssociationQ[d2e],
             Return[SolveMFGAbortResult["DataToEquationsFailed", methodUsed, trace], Module]
         ];
@@ -509,7 +520,7 @@ SolveMFG[input_Association, opts:OptionsPattern[]] :=
                 ]
             ,
             "CriticalCongestion" | "CriticalCongestionSolver",
-                d2e = If[SolveMFGCompiledInputQ[input], input, DataToEquations[input]];
+                d2e = If[SolveMFGCompiledInputQ[input], input, SolveMFGCompileInput[input, {opts}]];
                 CriticalCongestionSolver[
                     d2e,
                     Sequence @@ FilterRules[{opts}, Options[CriticalCongestionSolver]]
@@ -519,7 +530,7 @@ SolveMFG[input_Association, opts:OptionsPattern[]] :=
                 SolveMFGAutomaticDispatch[input, {opts}]
             ,
             "NonLinear" | "NonLinearSolver",
-                d2e = If[SolveMFGCompiledInputQ[input], input, DataToEquations[input]];
+                d2e = If[SolveMFGCompiledInputQ[input], input, SolveMFGCompileInput[input, {opts}]];
                 NonLinearSolver[
                     d2e,
                     Sequence @@ FilterRules[{opts}, Options[NonLinearSolver]]

--- a/MFGraphs/Monotone.wl
+++ b/MFGraphs/Monotone.wl
@@ -830,8 +830,14 @@ BuildReducedMonotoneDynamics[reduced_Association, KM_, B_, cc_, useCache_:True] 
 (* --- MonotoneSolver --- *)
 
 MonotoneSolverFromData[Data_, opts:OptionsPattern[]] :=
-	Module[{d2e},
-		d2e = DataToEquations[Data];
+	Module[{d2e, potentialFunction, congestionExponentFunction, interactionFunction},
+		potentialFunction = OptionValue["PotentialFunction"];
+		congestionExponentFunction = OptionValue["CongestionExponentFunction"];
+		interactionFunction = OptionValue["InteractionFunction"];
+		d2e = WithHamiltonianFunctions[
+			potentialFunction, congestionExponentFunction, interactionFunction,
+			DataToEquations[Data]
+		];
 		MonotoneSolver[d2e, opts]
 	];
 

--- a/MFGraphs/NonLinearSolver.wl
+++ b/MFGraphs/NonLinearSolver.wl
@@ -73,7 +73,7 @@ Options[NonLinearSolver] = {
 NormalizeEdgeFunction[spec_, defaultVal_: 1] := Which[
     spec === Automatic,    With[{d = defaultVal}, Function[edge, d]],
     NumericQ[spec],        With[{v = spec}, Function[edge, v]],
-    AssociationQ[spec],    With[{a = spec, d = defaultVal}, Function[edge, Lookup[a, Key[edge], d]]],
+    AssociationQ[spec],    With[{a = spec, d = defaultVal}, Function[edge, Lookup[a, edge, d]]],
     True,                  spec
 ];
 

--- a/MFGraphs/Tests/Jm9-critical_congestion.mt
+++ b/MFGraphs/Tests/Jm9-critical_congestion.mt
@@ -1,28 +1,28 @@
 (* Wolfram Language Test file *)
-(* Infeasible case: the solver now short-circuits instead of returning a
-   negative-flow association. *)
+(* Jamaratv9: large network solver tests including timeout envelope. *)
 
 Test[
 	Quiet[
 		d2e = DataToEquations[GetExampleData["Jamaratv9"] /. {I1 -> 130, I2 -> 128, U1 -> 20, U2 -> 100, U3 -> 0}];
 		result = CriticalCongestionSolver[d2e];
-		Lookup[result, "ResultKind"] === "Failure" &&
-		Lookup[result, "AssoCritical", Missing["NotAvailable"]] === Null
+		Lookup[result, "Feasibility"]
 	]
 	,
-	True
+	"Feasible"
     ,
-    TestID -> "Jamaratv9: infeasible cases short-circuit without a critical-flow association"
+    TestID -> "Jamaratv9-CriticalCongestion-Feasible"
 ]
 
 Test[
 	Quiet[
 		d2e = DataToEquations[GetExampleData["Jamaratv9"] /. {I1 -> 130, I2 -> 128, U1 -> 20, U2 -> 100, U3 -> 0}];
-		result = CriticalCongestionSolver[d2e];
-		result["Status"]
+		(* Disable numeric backend to force symbolic path, then timeout immediately *)
+		d2e = Append[d2e, "CriticalNumericBackendMode" -> False];
+		result = CriticalCongestionSolver[d2e, "SymbolicTimeLimit" -> 0.0001];
+		{Lookup[result, "ResultKind"], Lookup[result, "Feasibility"]}
 	]
 	,
-	"Infeasible"
+	{"Failure", Missing["NotAvailable"]}
     ,
-    TestID -> "Jamaratv9: Status is Infeasible"
+    TestID -> "Jamaratv9-CriticalCongestion-TimeoutEnvelope"
 ]

--- a/MFGraphs/Tests/solver-contracts.mt
+++ b/MFGraphs/Tests/solver-contracts.mt
@@ -301,3 +301,23 @@ Test[
     ,
     TestID -> "Monotone reduced state: observable basis stays feasible and bounded by the Kirchhoff nullspace"
 ]
+
+Test[
+    Module[{data, d2e, result},
+        (* Case 8 has switching costs, so the direct solver is skipped *)
+        data = GetExampleData[8] /. {I1 -> 100, U1 -> 0, U2 -> 0, S1 -> 1, S2 -> 1, S3 -> 1, S4 -> 1, S5 -> 1, S6 -> 1};
+        d2e = DataToEquations[data];
+        (* Disable numeric backend to force symbolic path *)
+        d2e = Append[d2e, "CriticalNumericBackendMode" -> False];
+        result = Quiet[CriticalCongestionSolver[d2e, "SymbolicTimeLimit" -> 0.0001]];
+        AssociationQ[result] &&
+        Lookup[result, "ResultKind"] === "Failure" &&
+        Lookup[result, "Feasibility"] === Missing["NotAvailable"] &&
+        Lookup[result, "Message"] === "SymbolicTimeout" &&
+        TrueQ[Lookup[result, "SymbolicSolverTimedOut", False]]
+    ]
+    ,
+    True
+    ,
+    TestID -> "CriticalCongestionSolver: symbolic timeout returns structured envelope, not $Failed"
+]


### PR DESCRIPTION
…lic timeout

PR #68 introduced alpha-aware dispatch and Hamiltonian option forwarding but shipped several bugs. This commit fixes all of them:

**Hamiltonian Correctness (PR 1)**
- NormalizeEdgeFunction: remove Key[] wrapper in Lookup so Association-based alpha specs actually match edge keys
- Add SolveMFGCompileInput: wraps DataToEquations in WithHamiltonianFunctions so Hamiltonian overrides are active during equation compilation in all SolveMFG dispatch paths (Automatic, CriticalCongestion, NonLinear)
- MonotoneSolverFromData: wrap DataToEquations in WithHamiltonianFunctions so Hamiltonian context is preserved when called with raw data

**Validator Repair & Oracle Bridge (PR 2)**
- IsCriticalSolution: use actual candidate flows from AssoCritical/Solution for EqGeneral residual evaluation instead of zero-flow surrogates
- Add BuildPrunedSystem: given a numeric candidate and symbolic {EE,NN,OR} system, retain only Or-branches satisfied by the candidate
- Wire Oracle Bridge in CriticalCongestionSolver: when numeric backend produces a candidate that fails validation, prune symbolic Or-branches before the full symbolic solve

**Symbolic Timeout (PR 3)**
- Add "SymbolicTimeLimit" option (default 120s) to CriticalCongestionSolver
- Wrap symbolic solver path in TimeConstrained; returns structured timeout envelope with Feasibility -> Missing["NotAvailable"] (not infeasibility)
- Widen BuildCriticalResult signature to accept non-string status/resultKind
- Rewrite Jamaratv9 tests: assert feasibility (numeric backend solves it) and test timeout envelope separately
- Add timeout contract test using case 8 (switching costs)