### PR TITLE
Fix scoping bug, dead variable, flaky test, and convention mismatches

### DIFF
--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -1930,7 +1930,7 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
          numericBackendUsedQ, numericBackendFallbackReason, numericBackendSolveTime,
          numericBackendStrategy, jFirstBackendUsedQ, jFirstBackendFallbackReason,
          numericCandidate, numericOutcome, forcedRejectQ, numericBackendTimeLimit,
-         symbolicTimeLimit, symbolicTimeoutQ,
+         symbolicTimeLimit,
          telemetry},
         ClearSolveCache[];
         validateQ = TrueQ[OptionValue["ValidateSolution"]];
@@ -1940,7 +1940,6 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
         numericBackendUsedQ = False;
         numericBackendSolveTime = Missing["NotAvailable"];
         numericBackendStrategy = "Symbolic";
-        symbolicTimeoutQ = False;
         jFirstBackendUsedQ = False;
         jFirstBackendFallbackReason = None;
         numericBackendRequestedQ = CriticalNumericBackendRequestedQ[Eqs];
@@ -1977,9 +1976,7 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
             "NumericBackendSolveTime" -> numericBackendSolveTime,
             "NumericBackendStrategy" -> numericBackendStrategy,
             "JFirstBackendUsed" -> jFirstBackendUsedQ,
-            "JFirstBackendFallbackReason" -> jFirstBackendFallbackReason,
-            "SymbolicSolverTimedOut" -> symbolicTimeoutQ,
-            "SymbolicSolverTimeLimit" -> symbolicTimeLimit
+            "JFirstBackendFallbackReason" -> jFirstBackendFallbackReason
         |>;
 
         (* Try the numeric backend first when explicitly forced or globally enabled. *)
@@ -2102,8 +2099,7 @@ CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
             ]
         ];
         js = Lookup[PreEqs, "js", $Failed];
-        Module[{symbolicTimeLimit, symbolicResult},
-            symbolicTimeLimit = OptionValue["SymbolicTimeLimit"];
+        Module[{symbolicResult},
             symbolicResult = TimeConstrained[
                 Module[{localAssoCritical, localStatus, localValidationFailedQ = False,
                         localResultKind, localMessage},

--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -477,7 +477,7 @@ SolveMFGCompileInput[input_Association, opts_List:{}] :=
 SolveMFGAutomaticDispatch[input_Association, opts_List] :=
     Module[{d2e, result = Missing["NotAvailable"], decision, trace = {}, methodUsed = "Automatic",
             attempts, isCritical, heldOpts},
-        heldOpts = HoldComplete[opts];
+        heldOpts = HoldComplete[{opts}];
         d2e = If[SolveMFGCompiledInputQ[input], input, Quiet @ Check[SolveMFGCompileInput[input, opts], $Failed]];
         If[!AssociationQ[d2e],
             Return[SolveMFGAbortResult["DataToEquationsFailed", methodUsed, trace], Module]

--- a/MFGraphs/Monotone.wl
+++ b/MFGraphs/Monotone.wl
@@ -831,15 +831,15 @@ BuildReducedMonotoneDynamics[reduced_Association, KM_, B_, cc_, useCache_:True] 
 
 MonotoneSolverFromData[Data_, opts:OptionsPattern[]] :=
 	Module[{d2e, potentialFunction, congestionExponentFunction, interactionFunction},
-        potentialFunction = OptionValue["PotentialFunction"];
-        congestionExponentFunction = OptionValue["CongestionExponentFunction"];
-        interactionFunction = OptionValue["InteractionFunction"];
+		potentialFunction = OptionValue["PotentialFunction"];
+		congestionExponentFunction = OptionValue["CongestionExponentFunction"];
+		interactionFunction = OptionValue["InteractionFunction"];
 		d2e = WithHamiltonianFunctions[
-            potentialFunction,
-            congestionExponentFunction,
-            interactionFunction,
-            DataToEquations[Data]
-        ];
+			potentialFunction,
+			congestionExponentFunction,
+			interactionFunction,
+			DataToEquations[Data]
+		];
 		MonotoneSolver[d2e, opts]
 	];
 

--- a/MFGraphs/Tests/solve-mfg.mt
+++ b/MFGraphs/Tests/solve-mfg.mt
@@ -682,8 +682,8 @@ Test[
 
 Test[
     Module[{f},
-        f = NormalizeEdgeFunction[<|e[1, 2] -> 1.5, e[2, 3] -> 2.0|>];
-        {f[e[1, 2]], f[e[2, 3]], f[e[3, 4]]}
+        f = NormalizeEdgeFunction[<|{1, 2} -> 1.5, {2, 3} -> 2.0|>];
+        {f[{1, 2}], f[{2, 3}], f[{3, 4}]}
     ]
     ,
     {1.5, 2.0, 1}

--- a/MFGraphs/Tests/solver-contracts.mt
+++ b/MFGraphs/Tests/solver-contracts.mt
@@ -113,6 +113,8 @@ Test[
             MFGraphs`U3 -> 0
         };
         d2e = MFGraphs`DataToEquations[data];
+        (* Disable numeric backend to guarantee symbolic path is reached *)
+        d2e = Append[d2e, "CriticalNumericBackendMode" -> False];
         result = Quiet[MFGraphs`CriticalCongestionSolver[d2e, "SymbolicTimeLimit" -> 0.01]];
         Lookup[result, {"Solver", "ResultKind", "Feasibility", "Message"}] ===
             {"CriticalCongestion", "Failure", Missing["NotAvailable"], "SymbolicTimeout"} &&
@@ -323,6 +325,45 @@ Test[
     True
     ,
     TestID -> "Monotone reduced state: observable basis stays feasible and bounded by the Kirchhoff nullspace"
+]
+
+(* BuildPrunedSystem unit tests *)
+
+Test[
+    Module[{system, candidate, pruned},
+        system = {
+            {x == 1},
+            {x >= 0},
+            {x > 0 && y == 0, x == 0 && y > 0}
+        };
+        candidate = <|x -> 1, y -> 0|>;
+        pruned = MFGraphs`Private`BuildPrunedSystem[system, candidate];
+        pruned[[1]] === system[[1]] &&
+        pruned[[2]] === system[[2]] &&
+        Length[pruned[[3]]] === 1 &&
+        pruned[[3]] === {x > 0 && y == 0}
+    ]
+    ,
+    True
+    ,
+    TestID -> "BuildPrunedSystem: prunes unsatisfied Or-branches"
+]
+
+Test[
+    Module[{system, candidate, pruned},
+        system = {
+            {x == 1},
+            {x >= 0},
+            {x > 5 && y == 0, x > 10 && y > 0}
+        };
+        candidate = <|x -> 1, y -> 0|>;
+        pruned = MFGraphs`Private`BuildPrunedSystem[system, candidate];
+        pruned[[3]] === system[[3]]
+    ]
+    ,
+    True
+    ,
+    TestID -> "BuildPrunedSystem: falls back to full system when no branches match"
 ]
 
 Test[


### PR DESCRIPTION
## Summary

Post-merge stability fixes for PRs #69 and #70, addressing all 7 findings from code review:

- **Scoping bug** (critical): Inner `Module` in symbolic timeout path redeclared `symbolicTimeLimit` and re-read `OptionValue`, shadowing the outer validated value. `Infinity` handling was dead code. Fixed by removing inner redeclaration.
- **Dead variable**: Removed `symbolicTimeoutQ` -- declared but never mutated; the timeout branch injects telemetry via `Join` directly.
- **Flaky test**: Jamaratv9 timeout test now disables numeric backend (`CriticalNumericBackendMode -> False`) to reliably reach the symbolic path.
- **Test key convention**: Restored `NormalizeEdgeFunction` test to use list keys `{1,2}` matching actual package edge representation.
- **HoldComplete wrapping**: Standardized to `HoldComplete[{opts}]` in both `SolveMFGAutomaticDispatch` and `SolveMFG`.
- **Oracle Bridge coverage**: Added unit tests for `BuildPrunedSystem` (prune + fallback paths).
- **Indentation**: Normalized mixed tabs/spaces in `MonotoneSolverFromData`.

## Test plan

- [ ] `wolframscript -file Scripts/RunTests.wls fast` passes
- [ ] `wolframscript -file Scripts/BenchmarkSuite.wls core timeout=60` passes
- [ ] Verify `CriticalCongestionSolver[d2e, "SymbolicTimeLimit" -> Infinity]` no longer silently ignores Infinity

Generated with [Claude Code](https://claude.com/claude-code)