### PR TITLE
fix(benchmark): restore Process-mode isolation for large/vlarge tiers

### DIFF
--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -1956,10 +1956,15 @@ Options[CriticalCongestionSolver] = {
     "SymbolicTimeLimit" -> 120.
 };
 
+CriticalCongestionSolver::noassoc = "Expected an Association for Eqs, but received `1`. Ensure input is pre-processed via DataToEquations.";
+
 CriticalCongestionSolver[$Failed, ___] :=
     $Failed
 
-CriticalCongestionSolver[Eqs_, OptionsPattern[]] :=
+CriticalCongestionSolver[Eqs : Except[_Association | $Failed], OptionsPattern[]] :=
+    (Message[CriticalCongestionSolver::noassoc, Head[Eqs]]; $Failed)
+
+CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
     Module[{PreEqs, js, AssoCritical, time, status,
          resultKind, message,
          validateQ, validationTolerance, validationVerboseQ, validationFailedQ,

--- a/Scripts/BenchmarkHelpers.wls
+++ b/Scripts/BenchmarkHelpers.wls
@@ -69,7 +69,14 @@ SafeExecuteIsolated[expr_, timeout_:300, opts:OptionsPattern[]] :=
     outFile = CreateFile[];
 
     heldExpr = HoldComplete[expr];
-    concretizedExpr = heldExpr /. s_Symbol /; (Context[s] === "Global`" && OwnValues[s] =!= {}) :> Evaluate[s];
+    (* Inline caller-bound symbols into the child script. Two pitfalls this avoids:
+       1. Evaluate[s] inside HoldComplete is inert — must use RuleCondition to force RHS eval.
+       2. Symbols can land outside Global`: Module creates local contexts (e.g. foo$123`),
+          and name collisions with MFGraphs` exports put user variables in MFGraphs`.
+       We inline any non-System symbol that has OwnValues. *)
+    concretizedExpr = heldExpr /. s_Symbol /;
+        (!StringStartsQ[Context[s], "System`"] && OwnValues[s] =!= {}) :>
+      RuleCondition[s /. OwnValues[s], True];
     exprString = StringReplace[
       ToString[concretizedExpr, InputForm],
       {


### PR DESCRIPTION
## Summary

- Fix a catastrophic IPC bug in `SafeExecuteIsolated` that caused every `large`/`vlarge` benchmark case to silently run on undefined symbols and fail at ~120s.
- Add a `CriticalCongestionSolver::noassoc` guard so future IPC regressions surface in microseconds instead of flailing for 120s.

## Root cause

`SafeExecuteIsolated` was supposed to inline caller-bound symbols into the child's script string via a `ReplaceAll` rule. Two compounding bugs made the rule a no-op:

1. **`Evaluate[s]` inert inside `HoldComplete`** — after `/.` replacement, the RHS `Evaluate[d2e]` is stored literally, not evaluated. Fixed with `RuleCondition[s /. OwnValues[s], True]`.
2. **Context filter too narrow** — rule matched only `Context[s] === "Global`"`, but benchmark callers bind `Module`-local variables (context `solverInput$NNN`) and user variables name-collide with `MFGraphs`` exports (e.g. `d2e` resolves to `MFGraphs`d2e`). Broadened to any non-`System` symbol with `OwnValues`.

Consequence: the child kernel received `CriticalCongestionSolver[d2e]` with `d2e` undefined, then flailed inside `DNFReduce`'s internal 120s `TimeConstrained` safety valve. The ~120s uniform wall time across wildly different problems (Grid0303 through Grid1020) was the smoking gun.

## Verification

Ran the 4 representative large-tier cases through the Module-local call pattern (mirrors `BenchmarkOneSolver`):

| Case | exprString bytes | Wall time | Result |
|------|------------------|-----------|--------|
| 13 | ~30 → 25,008 | 120s FAIL → 2.30s | Feasible |
| 19 | ~30 → 21,771 | 120s FAIL → 2.34s | Infeasible (solver-correct) |
| 20 | ~30 → 49,306 | 120s FAIL → 2.25s | Feasible |
| Jamaratv9 | ~30 → 71,459 | 120s FAIL → 2.72s | Feasible |

~45–53× speedup. Case 19's `Infeasible` is the solver correctly determining no feasible solution exists — `Status: OK` confirms clean execution.

## Out of scope (follow-up)

The 120s hardcoded `TimeConstrained` literals remain in `DNFReduce.wl:270/286` and `DataToEquations.wl:1985/2035`. They were masked by this bug. They should be parameterized as options in a separate PR tracking #83.

## Test plan

- [x] `CriticalCongestionSolver::noassoc` fires on String/Symbol/Null input, returns `$Failed`
- [x] Concretization inlines `d2e` (Module-local + `MFGraphs`` context)
- [x] 4 large-tier cases solve correctly in Process mode
- [ ] Reviewer: run `wolframscript -file Scripts/BenchmarkSuite.wls large` end-to-end if desired (~15 min)
- [ ] Reviewer: confirm no regression on small/core tiers (those use `InProcess` and were never affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
