### PR TITLE
Refactor redundancy and stabilize solver-contract test bootstrap

### DIFF
--- a/MFGraphs/Getting started.wl
+++ b/MFGraphs/Getting started.wl
@@ -106,69 +106,19 @@ DescribeOutput[title_String, description_String, expr_] :=
         Spacings -> {0.2, 0.7}
     ];
 
+(* Reuse canonical visualization helpers from Graphics.wl to avoid workbook drift. *)
 AssociationValue[assoc_Association, key_, default_: Missing["NotAvailable"]] :=
-    If[KeyExistsQ[assoc, key], assoc[key], default];
+    MFGraphs`AssociationValue[assoc, key, default];
 
 (* Net flow on each displayed edge, after eliminating dependent current variables. *)
 NetEdgeFlows[d2e_Association, solution_Association, pairs_: Automatic] :=
-    Module[{selectedPairs, rules},
-        selectedPairs = Replace[
-            pairs,
-            Automatic -> (List @@@ Lookup[d2e, "edgeList", {}])
-        ];
-        rules = Join[
-            Lookup[d2e, "RuleBalanceGatheringFlows", <||>],
-            Lookup[d2e, "RuleExitFlowsIn", <||>],
-            Lookup[d2e, "RuleEntryOut", <||>]
-        ];
-        AssociationThread[
-            selectedPairs,
-            N[((Lookup[d2e, "SignedFlows", <||>] /@ selectedPairs) /. rules /. solution)]
-        ]
-    ];
-
-vertexPropertyMap[entryVertices_, exitVertices_, internalVertices_, entryVal_, exitVal_, internalVal_] :=
-    Join[
-        AssociationThread[entryVertices, ConstantArray[entryVal, Length[entryVertices]]],
-        AssociationThread[exitVertices, ConstantArray[exitVal, Length[exitVertices]]],
-        AssociationThread[internalVertices, ConstantArray[internalVal, Length[internalVertices]]]
-    ];
+    MFGraphs`NetEdgeFlows[d2e, solution, pairs];
 
 NetworkVisualData[d2e_Association] :=
-    Module[{graph, layoutGraph, coords, coordArray, extent,
-      entryVertices, exitVertices, internalVertices},
-        graph = Lookup[d2e, "graph", Graph[{}]];
-        layoutGraph = Graph[graph, GraphLayout -> "SpringElectricalEmbedding"];
-        coords = AssociationThread[VertexList[layoutGraph], N @ GraphEmbedding[layoutGraph]];
-        coordArray = Values[coords];
-        extent = If[coordArray === {},
-            1.,
-            Max[(Max /@ Transpose[coordArray]) - (Min /@ Transpose[coordArray])]
-        ];
-        extent = Max[extent, 1.];
-        entryVertices = Lookup[d2e, "entryVertices", {}];
-        exitVertices = Lookup[d2e, "exitVertices", {}];
-        internalVertices = Complement[VertexList[graph], entryVertices, exitVertices];
-        <|
-            "graph" -> graph,
-            "coords" -> coords,
-            "vertexColors" -> vertexPropertyMap[entryVertices, exitVertices, internalVertices,
-                RGBColor[0.22, 0.6, 0.3], RGBColor[0.82, 0.27, 0.2], GrayLevel[0.75]],
-            "vertexSizes" -> vertexPropertyMap[entryVertices, exitVertices, internalVertices,
-                0.34, 0.34, 0.28],
-            "vertexRadii" -> vertexPropertyMap[entryVertices, exitVertices, internalVertices,
-                0.045 extent, 0.045 extent, 0.035 extent]
-        |>
-    ];
+    MFGraphs`NetworkVisualData[d2e];
 
 FlowStyleDirective[flow_?NumericQ, maxFlow_?NumericQ] :=
-    Directive[
-        If[flow >= 0, RGBColor[0.12, 0.45, 0.78], RGBColor[0.82, 0.39, 0.2]],
-        AbsoluteThickness[
-            Rescale[Abs[flow], {0, Max[maxFlow, 10^-9]}, {1.5, 8}]
-        ],
-        Opacity[0.9]
-    ];
+    MFGraphs`FlowStyleDirective[flow, maxFlow];
 
 (* NetworkGraphPlot and SolutionFlowPlot now live in Graphics.wl. *)
 

--- a/MFGraphs/Graphics.wl
+++ b/MFGraphs/Graphics.wl
@@ -20,6 +20,18 @@ SolutionFlowPlot::usage =
 ExitFlowPlot::usage =
 "ExitFlowPlot[exitFlows] produces a bar chart of exit-flow totals from an association mapping exit vertices to numeric flow values. An optional second argument sets the plot title.";
 
+AssociationValue::usage =
+"AssociationValue[assoc, key, default] returns assoc[key] when key exists, otherwise default (Missing[\"NotAvailable\"] by default).";
+
+NetEdgeFlows::usage =
+"NetEdgeFlows[d2e, solution, pairs] returns the net signed flow on each requested edge pair after applying balance and boundary flow rules. pairs defaults to all model edges.";
+
+NetworkVisualData::usage =
+"NetworkVisualData[d2e] builds reusable graph layout and vertex styling metadata used by plotting helpers.";
+
+FlowStyleDirective::usage =
+"FlowStyleDirective[flow, maxFlow] returns an edge style directive (color/thickness/opacity) scaled by flow magnitude and sign.";
+
 Begin["`Private`"];
 
 AssociationValue[assoc_Association, key_, default_: Missing["NotAvailable"]] :=

--- a/MFGraphs/Solvers.wl
+++ b/MFGraphs/Solvers.wl
@@ -1115,26 +1115,28 @@ CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
                     numericBackendUsedQ = True;
                     numericBackendFallbackReason = None;
                     PreEqs = EnsurePreprocessed[Eqs];
-                    If[validateQ,
-                        If[forcedRejectQ || !TrueQ @ IsCriticalSolution[
-                            Join[PreEqs, <|"AssoCritical" -> numericCandidate, "Solution" -> numericCandidate|>],
-                            "Tolerance" -> validationTolerance,
-                            "Verbose" -> validationVerboseQ
-                        ],
-                            numericBackendUsedQ = False;
-                            numericBackendStrategy = "Symbolic";
-                            If[
-                                TrueQ[jFirstBackendUsedQ] &&
-                                (jFirstBackendFallbackReason === None || jFirstBackendFallbackReason === "NotAttempted"),
-                                jFirstBackendFallbackReason =
-                                    If[forcedRejectQ, "ForcedValidationFailure", "CriticalValidationFailed"]
-                            ];
-                            jFirstBackendUsedQ = False;
-                            numericBackendFallbackReason =
+                    If[
+                        validateQ &&
+                        (
+                            forcedRejectQ ||
+                            !TrueQ @ IsCriticalSolution[
+                                Join[PreEqs, <|"AssoCritical" -> numericCandidate, "Solution" -> numericCandidate|>],
+                                "Tolerance" -> validationTolerance,
+                                "Verbose" -> validationVerboseQ
+                            ]
+                        ),
+                        numericBackendUsedQ = False;
+                        numericBackendStrategy = "Symbolic";
+                        If[
+                            TrueQ[jFirstBackendUsedQ] &&
+                            (jFirstBackendFallbackReason === None || jFirstBackendFallbackReason === "NotAttempted"),
+                            jFirstBackendFallbackReason =
                                 If[forcedRejectQ, "ForcedValidationFailure", "CriticalValidationFailed"]
-                            ,
-                            Return[BuildCriticalResult[PreEqs, "Success", status, None, numericCandidate, telemetry], Module]
-                        ],
+                        ];
+                        jFirstBackendUsedQ = False;
+                        numericBackendFallbackReason =
+                            If[forcedRejectQ, "ForcedValidationFailure", "CriticalValidationFailed"]
+                        ,
                         Return[BuildCriticalResult[PreEqs, "Success", status, None, numericCandidate, telemetry], Module]
                     ],
                     numericBackendFallbackReason = "FlowFeasibilityFailed"
@@ -1158,16 +1160,15 @@ CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
                 status = CheckFlowFeasibility[AssoCritical];
                 If[status === "Feasible",
                     PreEqs = EnsurePreprocessed[Eqs];
-                    If[validateQ,
-                        If[!TrueQ @ IsCriticalSolution[
+                    If[
+                        validateQ &&
+                        !TrueQ @ IsCriticalSolution[
                             Join[PreEqs, <|"AssoCritical" -> AssoCritical, "Solution" -> AssoCritical|>],
                             "Tolerance" -> validationTolerance,
                             "Verbose" -> validationVerboseQ
                         ],
-                            MFGPrint["Direct solver validation failed, falling back to symbolic solver."]
-                            ,
-                            Return[BuildCriticalResult[PreEqs, "Success", status, None, AssoCritical, telemetry], Module]
-                        ],
+                        MFGPrint["Direct solver validation failed, falling back to symbolic solver."]
+                        ,
                         Return[BuildCriticalResult[PreEqs, "Success", status, None, AssoCritical, telemetry], Module]
                     ],
                     MFGPrint["Direct solver produced infeasible result, falling back to symbolic solver."]
@@ -1342,6 +1343,19 @@ RulesConjunction[rules_] :=
         ]
     ];
 
+CriticalSolutionAssociation[Eqs_Association] :=
+    Module[{candidate},
+        candidate = Lookup[Eqs, "AssoCritical", Missing["NotAvailable"]];
+        If[AssociationQ[candidate],
+            candidate,
+            candidate = Lookup[Eqs, "Solution", Missing["NotAvailable"]];
+            If[AssociationQ[candidate], candidate, Missing["NotAvailable"]]
+        ]
+    ];
+
+CriticalFlowApproximation[Eqs_Association, solution_Association] :=
+    KeyTake[solution, Lookup[Eqs, "js", {}]];
+
 IsCriticalSolution[Eqs_Association, OptionsPattern[]] :=
     Module[{tol, verboseQ, returnReportQ, solution, blocks, blockResults,
          residual, residualPass, allBlocksPass, overall, report, flowApprox,
@@ -1387,14 +1401,7 @@ IsCriticalSolution[Eqs_Association, OptionsPattern[]] :=
             Return[If[returnReportQ, report, False], Module]
         ];
 
-        solution = Which[
-            AssociationQ[Lookup[Eqs, "AssoCritical", Missing["NotAvailable"]]],
-                Lookup[Eqs, "AssoCritical"],
-            AssociationQ[Lookup[Eqs, "Solution", Missing["NotAvailable"]]],
-                Lookup[Eqs, "Solution"],
-            True,
-                Missing["NotAvailable"]
-        ];
+        solution = CriticalSolutionAssociation[Eqs];
 
         If[!AssociationQ[solution],
             report = <|
@@ -1410,14 +1417,7 @@ IsCriticalSolution[Eqs_Association, OptionsPattern[]] :=
             Return[If[returnReportQ, report, False], Module]
         ];
 
-        flowApprox = Which[
-            AssociationQ[Lookup[Eqs, "AssoCritical", Missing["NotAvailable"]]],
-                KeyTake[Lookup[Eqs, "AssoCritical"], Lookup[Eqs, "js", {}]],
-            AssociationQ[Lookup[Eqs, "Solution", Missing["NotAvailable"]]],
-                KeyTake[Lookup[Eqs, "Solution"], Lookup[Eqs, "js", {}]],
-            True,
-                AssociationThread[Lookup[Eqs, "js", {}], 0 Lookup[Eqs, "js", {}]]
-        ];
+        flowApprox = CriticalFlowApproximation[Eqs, solution];
         costpluscurrents = Lookup[Eqs, "costpluscurrents", Missing["NotAvailable"]];
         eqGeneralCritical =
             Lookup[Eqs, "EqGeneral", True] /.

--- a/MFGraphs/Tests/solver-contracts.mt
+++ b/MFGraphs/Tests/solver-contracts.mt
@@ -1,6 +1,18 @@
 (* Wolfram Language Test file *)
 (* Contract tests for the standardized stationary-solver return shape. *)
 
+If[!MemberQ[$Packages, "MFGraphs`"],
+    Get[
+        FileNameJoin[
+            {
+                DirectoryName[$InputFileName],
+                "..",
+                "MFGraphs.wl"
+            }
+        ]
+    ]
+];
+
 Test[
     Module[{data, d2e, result},
         data = GetExampleData[7] /. {I1 -> 100, U1 -> 0, U2 -> 0};


### PR DESCRIPTION
## Summary
- remove duplicated visualization helper implementations from Getting started.wl and delegate to canonical package helpers
- expose shared graphics helpers (AssociationValue, NetEdgeFlows, NetworkVisualData, FlowStyleDirective) as public documented symbols in Graphics.wl
- simplify duplicated validation return branches in CriticalCongestionSolver
- centralize repeated critical-solution association/flow selection logic in IsCriticalSolution
- harden solver-contracts.mt bootstrap with package-load guard using $Packages

## Validation
- wolframscript -file MFGraphs/Tests/solver-contracts.mt (clean exit)
- wolframscript -file MFGraphs/Tests/graphics-public-api.mt (clean exit)
- package load and critical-solver smoke checks run successfully

## Notes
- this keeps behavior unchanged while reducing drift and warning-prone test execution paths
