### PR TITLE
Add scenario kernel (P1): makeScenario, validateScenario, completeScenario

### DIFF
--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -4,9 +4,12 @@
    
    Main Components:
    - DataToEquations: Symbolic graph-to-equation converter.
+   - Solvers: Critical-congestion solver suite (extracted Phase 3).
    - NonLinearSolver: Iterative solver for general congestion.
    - Monotone: Hessian Riemannian Flow numerical solver.
    - DNFReduce: Symbolic logical reduction engine.
+   - Graphics: Public visualization helpers.
+   - Scenario: Typed scenario kernel (makeScenario, validateScenario, etc.).
 *)
 
 (* Created by the Wolfram Workbench May 5, 2020 *)
@@ -1057,6 +1060,7 @@ Get["MFGraphs`NonLinearSolver`"];
 Get["MFGraphs`Monotone`"];
 Get["MFGraphs`TimeDependentSolver`"];
 Get["MFGraphs`Graphics`"];
+Get["MFGraphs`Scenario`"];
 
 Options[SolveMFG] = DeleteDuplicatesBy[
     Join[

--- a/MFGraphs/Scenario.wl
+++ b/MFGraphs/Scenario.wl
@@ -1,0 +1,158 @@
+(*
+   Scenario: typed scenario kernel for MFGraphs.
+
+   Provides a typed wrapper around network-plus-parameters data so that
+   scenarios can be constructed, validated, completed, and stored uniformly.
+
+   Lifecycle:
+     makeScenario[rawAssoc]  →  validates + completes + wraps in scenario[...] head
+     validateScenario[s]     →  checks required keys; returns s or Failure[...]
+     completeScenario[s]     →  fills Identity (hash), Benchmark defaults; returns s
+     scenarioQ[x]            →  True iff x is a well-formed typed scenario
+
+   Canonical top-level blocks inside scenario[<|...|>]:
+     "Identity"    — name, version, contentHash
+     "Model"       — raw network topology accepted by DataToEquations
+     "Data"        — parameter substitution rules (e.g. {I1 -> 100, U1 -> 0})
+     "Validation"  — consistency check results (populated after solving)
+     "Benchmark"   — tier, timeout
+     "Visualization" — optional plotting hints
+     "Inheritance" — optional lineage/parent reference
+*)
+
+(* --- Public API declarations --- *)
+
+scenario::usage =
+"scenario[assoc] is the typed head for a MFGraphs scenario object. Use makeScenario \
+to construct one; use ScenarioData to access keys.";
+
+scenarioQ::usage =
+"scenarioQ[x] returns True if x is a typed scenario[assoc_Association] object, \
+False otherwise.";
+
+makeScenario::usage =
+"makeScenario[assoc] constructs a typed scenario from a raw association. The input \
+must contain a \"Model\" key whose value is a network topology association accepted by \
+DataToEquations (required keys: \"Vertices List\", \"Adjacency Matrix\", \
+\"Entrance Vertices and Flows\", \"Exit Vertices and Terminal Costs\", \
+\"Switching Costs\"). Optional keys: \"Data\" (parameter substitution rules), \
+\"Identity\" (name, version), \"Benchmark\" (tier, timeout), \"Visualization\", \
+\"Inheritance\". Returns a scenario[...] object on success or Failure[...] on error.";
+
+validateScenario::usage =
+"validateScenario[s] checks that the scenario s has all required Model keys and that \
+the Model value is an Association. Returns s unchanged on success, or \
+Failure[\"ScenarioValidation\", <|\"Message\" -> msg, \"MissingKeys\" -> {...}|>] \
+on failure.";
+
+completeScenario::usage =
+"completeScenario[s] fills in derived fields: sets \"contentHash\" in the Identity \
+block (SHA256 of the canonical Model string), and supplies default Benchmark values \
+(\"Tier\" -> \"core\", \"Timeout\" -> 300) when missing. Returns a new scenario object.";
+
+ScenarioData::usage =
+"ScenarioData[s, key] returns the value associated with key in the scenario s, or \
+Missing[\"KeyAbsent\", key] if absent. ScenarioData[s] returns the underlying \
+Association.";
+
+Begin["`Private`"];
+
+(* Required keys that must appear inside the "Model" block. *)
+$RequiredModelKeys = {
+    "Vertices List",
+    "Adjacency Matrix",
+    "Entrance Vertices and Flows",
+    "Exit Vertices and Terminal Costs",
+    "Switching Costs"
+};
+
+(* Default benchmark settings applied by completeScenario. *)
+$DefaultBenchmarkTier    = "core";
+$DefaultBenchmarkTimeout = 300;
+
+(* --- Type predicate --- *)
+
+scenarioQ[scenario[_Association]] := True;
+scenarioQ[_]                       := False;
+
+(* --- Accessor --- *)
+
+ScenarioData[scenario[assoc_Association]]           := assoc;
+ScenarioData[scenario[assoc_Association], key_]     := Lookup[assoc, key, Missing["KeyAbsent", key]];
+
+(* --- Validate --- *)
+
+validateScenario[s_scenario] :=
+    Module[{assoc, model, missing},
+        assoc = ScenarioData[s];
+        model = Lookup[assoc, "Model", Missing["KeyAbsent", "Model"]];
+        Which[
+            MissingQ[model],
+                Failure["ScenarioValidation",
+                    <|"Message" -> "\"Model\" key is absent.",
+                      "MissingKeys" -> {"Model"}|>],
+            !AssociationQ[model],
+                Failure["ScenarioValidation",
+                    <|"Message" -> "\"Model\" value must be an Association.",
+                      "MissingKeys" -> {}|>],
+            True,
+                missing = Select[$RequiredModelKeys, !KeyExistsQ[model, #] &];
+                If[missing === {},
+                    s,
+                    Failure["ScenarioValidation",
+                        <|"Message" ->
+                            "Missing required Model keys: " <> StringRiffle[missing, ", "],
+                          "MissingKeys" -> missing|>]
+                ]
+        ]
+    ];
+
+(* Reject non-scenario inputs immediately. *)
+validateScenario[x_] :=
+    Failure["ScenarioValidation",
+        <|"Message" -> "Input is not a scenario object.",
+          "MissingKeys" -> {}|>];
+
+(* --- Complete --- *)
+
+completeScenario[s_scenario] :=
+    Module[{assoc, identity, benchmark, model, hash, newAssoc},
+        assoc     = ScenarioData[s];
+        model     = Lookup[assoc, "Model", <||>];
+        identity  = Lookup[assoc, "Identity", <||>];
+        benchmark = Lookup[assoc, "Benchmark", <||>];
+
+        (* Compute content hash from the canonical string of the Model. *)
+        hash = Hash[ToString[model, InputForm], "SHA256", "HexString"];
+
+        identity  = Join[<|"contentHash" -> hash|>, identity];
+        benchmark = Join[
+            <|"Tier" -> $DefaultBenchmarkTier, "Timeout" -> $DefaultBenchmarkTimeout|>,
+            benchmark
+        ];
+
+        newAssoc = Join[assoc, <|"Identity" -> identity, "Benchmark" -> benchmark|>];
+        scenario[newAssoc]
+    ];
+
+completeScenario[x_] := x;   (* pass-through for non-scenario values *)
+
+(* --- Constructor --- *)
+
+makeScenario[rawAssoc_Association] :=
+    Module[{wrapped, validated, completed},
+        wrapped   = scenario[rawAssoc];
+        validated = validateScenario[wrapped];
+        If[FailureQ[validated],
+            validated,
+            completed = completeScenario[validated];
+            completed
+        ]
+    ];
+
+makeScenario[_] :=
+    Failure["ScenarioValidation",
+        <|"Message" -> "makeScenario requires an Association as input.",
+          "MissingKeys" -> {}|>];
+
+End[];

--- a/MFGraphs/Scenario.wl
+++ b/MFGraphs/Scenario.wl
@@ -125,7 +125,8 @@ completeScenario[s_scenario] :=
         (* Compute content hash from the canonical string of the Model. *)
         hash = Hash[ToString[model, InputForm], "SHA256", "HexString"];
 
-        identity  = Join[<|"contentHash" -> hash|>, identity];
+        (* Computed hash always wins: placed on the right so it overrides any user-supplied value. *)
+        identity  = Join[identity, <|"contentHash" -> hash|>];
         benchmark = Join[
             <|"Tier" -> $DefaultBenchmarkTier, "Timeout" -> $DefaultBenchmarkTimeout|>,
             benchmark

--- a/MFGraphs/Tests/package-loading.mt
+++ b/MFGraphs/Tests/package-loading.mt
@@ -9,7 +9,8 @@ Test[
     NameQ["MFGraphs`GetExampleData"] && NameQ["MFGraphs`DNFReduce"] &&
     NameQ["MFGraphs`GetKirchhoffLinearSystem"] && NameQ["MFGraphs`V"] &&
     NameQ["MFGraphs`alpha"] && NameQ["MFGraphs`g"] &&
-    NameQ["MFGraphs`WithHamiltonianFunctions"]
+    NameQ["MFGraphs`WithHamiltonianFunctions"] &&
+    NameQ["MFGraphs`makeScenario"] && NameQ["MFGraphs`scenarioQ"]
     ,
     True
     ,

--- a/MFGraphs/Tests/scenario-kernel.mt
+++ b/MFGraphs/Tests/scenario-kernel.mt
@@ -1,0 +1,124 @@
+(* Smoke tests for the scenario kernel (makeScenario, validateScenario, completeScenario, scenarioQ). *)
+
+(* Test: public symbols exist in MFGraphs` context *)
+Test[
+    NameQ["MFGraphs`scenario"] &&
+    NameQ["MFGraphs`scenarioQ"] &&
+    NameQ["MFGraphs`makeScenario"] &&
+    NameQ["MFGraphs`validateScenario"] &&
+    NameQ["MFGraphs`completeScenario"] &&
+    NameQ["MFGraphs`ScenarioData"]
+    ,
+    True
+    ,
+    TestID -> "Scenario kernel: public symbols exist"
+]
+
+(* Test: makeScenario returns a typed scenario for valid input *)
+Test[
+    Module[{data, s},
+        data = GetExampleData[12] /. {I1 -> 100, U1 -> 0};
+        s = makeScenario[<|"Model" -> data|>];
+        scenarioQ[s]
+    ]
+    ,
+    True
+    ,
+    TestID -> "Scenario kernel: makeScenario returns typed scenario"
+]
+
+(* Test: completed scenario carries a non-empty content hash *)
+Test[
+    Module[{data, s, hash},
+        data = GetExampleData[12] /. {I1 -> 100, U1 -> 0};
+        s = makeScenario[<|"Model" -> data|>];
+        hash = ScenarioData[s, "Identity"]["contentHash"];
+        StringQ[hash] && StringLength[hash] > 0
+    ]
+    ,
+    True
+    ,
+    TestID -> "Scenario kernel: completed scenario has contentHash"
+]
+
+(* Test: Benchmark block defaults are filled *)
+Test[
+    Module[{data, s, bench},
+        data = GetExampleData[12] /. {I1 -> 100, U1 -> 0};
+        s = makeScenario[<|"Model" -> data|>];
+        bench = ScenarioData[s, "Benchmark"];
+        bench["Tier"] === "core" && bench["Timeout"] === 300
+    ]
+    ,
+    True
+    ,
+    TestID -> "Scenario kernel: default Benchmark tier and timeout"
+]
+
+(* Test: user-supplied Benchmark values override defaults *)
+Test[
+    Module[{data, s, bench},
+        data = GetExampleData[12] /. {I1 -> 100, U1 -> 0};
+        s = makeScenario[<|"Model" -> data, "Benchmark" -> <|"Tier" -> "stress", "Timeout" -> 900|>|>];
+        bench = ScenarioData[s, "Benchmark"];
+        bench["Tier"] === "stress" && bench["Timeout"] === 900
+    ]
+    ,
+    True
+    ,
+    TestID -> "Scenario kernel: user Benchmark values are preserved"
+]
+
+(* Test: missing required Model key produces Failure *)
+Test[
+    Module[{incomplete, result},
+        incomplete = <|
+            "Vertices List" -> {1, 2},
+            "Adjacency Matrix" -> {{0, 1}, {0, 0}},
+            "Entrance Vertices and Flows" -> {{1, 100}},
+            "Exit Vertices and Terminal Costs" -> {{2, 0}}
+            (* "Switching Costs" intentionally absent *)
+        |>;
+        result = makeScenario[<|"Model" -> incomplete|>];
+        FailureQ[result] && result["Tag"] === "ScenarioValidation"
+    ]
+    ,
+    True
+    ,
+    TestID -> "Scenario kernel: missing Model key yields Failure"
+]
+
+(* Test: absent Model key produces Failure *)
+Test[
+    Module[{result},
+        result = makeScenario[<|"Identity" -> <|"name" -> "no model"|>|>];
+        FailureQ[result]
+    ]
+    ,
+    True
+    ,
+    TestID -> "Scenario kernel: absent Model key yields Failure"
+]
+
+(* Test: non-scenario input to validateScenario yields Failure *)
+Test[
+    FailureQ[validateScenario["not a scenario"]]
+    ,
+    True
+    ,
+    TestID -> "Scenario kernel: non-scenario input rejected by validateScenario"
+]
+
+(* Test: ScenarioData accessor returns underlying association *)
+Test[
+    Module[{data, s, underlying},
+        data = GetExampleData[12] /. {I1 -> 100, U1 -> 0};
+        s = makeScenario[<|"Model" -> data|>];
+        underlying = ScenarioData[s];
+        AssociationQ[underlying] && KeyExistsQ[underlying, "Model"]
+    ]
+    ,
+    True
+    ,
+    TestID -> "Scenario kernel: ScenarioData returns association"
+]

--- a/MFGraphs/Tests/scenario-kernel.mt
+++ b/MFGraphs/Tests/scenario-kernel.mt
@@ -122,3 +122,46 @@ Test[
     ,
     TestID -> "Scenario kernel: ScenarioData returns association"
 ]
+
+(* Test: partial Identity override — user name is preserved and contentHash is always computed *)
+Test[
+    Module[{data, s, identity},
+        data = GetExampleData[12] /. {I1 -> 100, U1 -> 0};
+        s = makeScenario[<|"Model" -> data, "Identity" -> <|"name" -> "my-scenario"|>|>];
+        identity = ScenarioData[s, "Identity"];
+        StringQ[identity["contentHash"]] && identity["name"] === "my-scenario"
+    ]
+    ,
+    True
+    ,
+    TestID -> "Scenario kernel: partial Identity override preserves name and computes hash"
+]
+
+(* Test: contentHash is stable — same input produces the same hash *)
+Test[
+    Module[{data, s1, s2},
+        data = GetExampleData[12] /. {I1 -> 100, U1 -> 0};
+        s1 = makeScenario[<|"Model" -> data|>];
+        s2 = makeScenario[<|"Model" -> data|>];
+        ScenarioData[s1, "Identity"]["contentHash"] === ScenarioData[s2, "Identity"]["contentHash"]
+    ]
+    ,
+    True
+    ,
+    TestID -> "Scenario kernel: contentHash is stable for identical input"
+]
+
+(* Test: completeScenario can be called directly on a validated scenario *)
+Test[
+    Module[{data, raw, validated, completed},
+        data      = GetExampleData[12] /. {I1 -> 100, U1 -> 0};
+        raw       = scenario[<|"Model" -> data|>];
+        validated = validateScenario[raw];
+        completed = completeScenario[validated];
+        scenarioQ[completed] && StringQ[ScenarioData[completed, "Identity"]["contentHash"]]
+    ]
+    ,
+    True
+    ,
+    TestID -> "Scenario kernel: completeScenario callable directly on validated scenario"
+]

--- a/Scripts/RunTests.wls
+++ b/Scripts/RunTests.wls
@@ -24,6 +24,7 @@ $TestSuites = <|
         "monotone-solver.mt",
         "numeric-state.mt",
         "solve-mfg.mt",
+        "scenario-kernel.mt",
         "solver-contracts.mt",
         "time-dependent-data.mt"
     },

--- a/Scripts/RunTests.wls
+++ b/Scripts/RunTests.wls
@@ -23,8 +23,8 @@ $TestSuites = <|
         "monotone-monotonicity.mt",
         "monotone-solver.mt",
         "numeric-state.mt",
-        "solve-mfg.mt",
         "scenario-kernel.mt",
+        "solve-mfg.mt",
         "solver-contracts.mt",
         "time-dependent-data.mt"
     },


### PR DESCRIPTION
## Summary

- Adds `MFGraphs/Scenario.wl` with a typed `scenario[assoc]` head and validate-then-complete lifecycle
- Public API: `makeScenario`, `validateScenario`, `completeScenario`, `scenarioQ`, `ScenarioData`
- 8 smoke tests in `MFGraphs/Tests/scenario-kernel.mt` covering the full lifecycle, default filling, user overrides, and rejection of invalid inputs
- Wired into `MFGraphs.wl` load order (after `Graphics.wl`) and `RunTests.wls` fast suite
- `package-loading.mt` extended to assert scenario kernel symbols exist in public context

## Design

Scenarios are typed `scenario[assoc_Association]` objects. The constructor follows a strict lifecycle:

```mathematica
s = makeScenario[<|"Model" -> GetExampleData[12] /. {I1->100, U1->0}|>]
scenarioQ[s]           (* True *)
ScenarioData[s, "Identity"]["contentHash"]   (* SHA256 hex string *)
ScenarioData[s, "Benchmark")["Tier"]         (* "core" *)
```

`makeScenario` → `validateScenario` (checks required Model keys) → `completeScenario` (fills Identity contentHash + Benchmark defaults). Returns `Failure[...]` on any validation error.

## Test plan

- [ ] `wolframscript -file MFGraphs/Tests/scenario-kernel.mt` — all 8 smoke tests pass
- [ ] `wolframscript -file Scripts/RunTests.wls fast` — no regressions in fast suite
- [ ] `wolframscript -file MFGraphs/Tests/package-loading.mt` — public symbol check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)