### PR TITLE
Refactor SolveMFG routing via unified stage dispatcher (Plan A steps 1-2)

### DIFF
--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -1197,6 +1197,65 @@ SolveMFGCompileInput[input_Association, opts_List:{}] :=
         ]
     ];
 
+SolveMFGRunStage[
+    method_String,
+    input_Association,
+    opts_List,
+    heldOpts_HoldComplete,
+    dispatchMode_String : "Direct"
+] :=
+    Module[{d2e, isCritical},
+        Switch[method,
+            "CriticalCongestion",
+                If[
+                    SolveMFGCompiledInputQ[input],
+                    d2e = input,
+                    If[dispatchMode === "Direct",
+                        isCritical = SolveMFGIsCriticalQ[heldOpts];
+                        If[!TrueQ[isCritical],
+                            Return[SolveMFGUnsupportedCriticalAlphaResult[], Module]
+                        ]
+                    ];
+                    d2e = SolveMFGCompileInput[input, opts]
+                ];
+                CriticalCongestionSolver[
+                    d2e,
+                    Sequence @@ FilterRules[opts, Options[CriticalCongestionSolver]]
+                ]
+            ,
+            "Monotone",
+                If[
+                    dispatchMode === "Automatic",
+                    d2e = If[SolveMFGCompiledInputQ[input], input, SolveMFGCompileInput[input, opts]];
+                    MonotoneSolver[
+                        d2e,
+                        Sequence @@ FilterRules[opts, Options[MonotoneSolver]]
+                    ],
+                    If[
+                        SolveMFGCompiledInputQ[input],
+                        MonotoneSolver[
+                            input,
+                            Sequence @@ FilterRules[opts, Options[MonotoneSolver]]
+                        ],
+                        MonotoneSolverFromData[
+                            input,
+                            Sequence @@ FilterRules[opts, Options[MonotoneSolverFromData]]
+                        ]
+                    ]
+                ]
+            ,
+            "NonLinear",
+                d2e = If[SolveMFGCompiledInputQ[input], input, SolveMFGCompileInput[input, opts]];
+                NonLinearSolver[
+                    d2e,
+                    Sequence @@ FilterRules[opts, Options[NonLinearSolver]]
+                ]
+            ,
+            _,
+                SolveMFGUnknownMethodResult[method]
+        ]
+    ];
+
 SolveMFGAutomaticDispatch[input_Association, opts_List] :=
     Module[{d2e, result = Missing["NotAvailable"], decision, trace = {}, methodUsed = "Automatic",
             attempts, isCritical, heldOpts},
@@ -1208,43 +1267,13 @@ SolveMFGAutomaticDispatch[input_Association, opts_List] :=
         isCritical = SolveMFGIsCriticalQ[heldOpts];
         attempts = Join[
             (* alpha=1: try CriticalCongestion first; alpha!=1: skip it *)
-            If[isCritical,
-                {<|
-                    "Method" -> "CriticalCongestion",
-                    "Run" -> Function[
-                        CriticalCongestionSolver[
-                            d2e,
-                            Sequence @@ FilterRules[opts, Options[CriticalCongestionSolver]]
-                        ]
-                    ]
-                |>},
-                {}
-            ],
-            {
-                <|
-                    "Method" -> "Monotone",
-                    "Run" -> Function[
-                        MonotoneSolver[
-                            d2e,
-                            Sequence @@ FilterRules[opts, Options[MonotoneSolver]]
-                        ]
-                    ]
-                |>,
-                <|
-                    "Method" -> "NonLinear",
-                    "Run" -> Function[
-                        NonLinearSolver[
-                            d2e,
-                            Sequence @@ FilterRules[opts, Options[NonLinearSolver]]
-                        ]
-                    ]
-                |>
-            }
+            If[isCritical, {"CriticalCongestion"}, {}],
+            {"Monotone", "NonLinear"}
         ];
         Do[
-            result = attempt["Run"][];
+            result = SolveMFGRunStage[attempt, d2e, opts, heldOpts, "Automatic"];
             decision = SolveMFGClassifyOutcome[result];
-            methodUsed = attempt["Method"];
+            methodUsed = attempt;
             trace = Append[trace, SolveMFGBuildTraceEntry[methodUsed, result, decision]];
             Switch[decision,
                 "Done",
@@ -1263,53 +1292,23 @@ SolveMFGAutomaticDispatch[input_Association, opts_List] :=
     ];
 
 SolveMFG[input_Association, opts:OptionsPattern[]] :=
-    Module[{method, normalizedMethod, d2e, heldOpts, isCritical},
+    Module[{method, normalizedMethod, heldOpts},
         heldOpts = HoldComplete[{opts}];
         method = OptionValue[Method];
         normalizedMethod = ToString[method];
 
         Switch[normalizedMethod,
             "Monotone" | "MonotoneSolver",
-                If[
-                    SolveMFGCompiledInputQ[input],
-                    MonotoneSolver[
-                        input,
-                        Sequence @@ FilterRules[{opts}, Options[MonotoneSolver]]
-                    ],
-                    MonotoneSolverFromData[
-                        input,
-                        Sequence @@ FilterRules[{opts}, Options[MonotoneSolverFromData]]
-                    ]
-                ]
+                SolveMFGRunStage["Monotone", input, {opts}, heldOpts, "Direct"]
             ,
             "CriticalCongestion" | "CriticalCongestionSolver",
-                If[
-                    SolveMFGCompiledInputQ[input],
-                    d2e = input;
-                    CriticalCongestionSolver[
-                        d2e,
-                        Sequence @@ FilterRules[{opts}, Options[CriticalCongestionSolver]]
-                    ],
-                    isCritical = SolveMFGIsCriticalQ[heldOpts];
-                    If[!TrueQ[isCritical],
-                        SolveMFGUnsupportedCriticalAlphaResult[],
-                        d2e = SolveMFGCompileInput[input, {opts}];
-                        CriticalCongestionSolver[
-                            d2e,
-                            Sequence @@ FilterRules[{opts}, Options[CriticalCongestionSolver]]
-                        ]
-                    ]
-                ]
+                SolveMFGRunStage["CriticalCongestion", input, {opts}, heldOpts, "Direct"]
             ,
             "Automatic",
                 SolveMFGAutomaticDispatch[input, {opts}]
             ,
             "NonLinear" | "NonLinearSolver",
-                d2e = If[SolveMFGCompiledInputQ[input], input, SolveMFGCompileInput[input, {opts}]];
-                NonLinearSolver[
-                    d2e,
-                    Sequence @@ FilterRules[{opts}, Options[NonLinearSolver]]
-                ]
+                SolveMFGRunStage["NonLinear", input, {opts}, heldOpts, "Direct"]
             ,
             _,
                 SolveMFGUnknownMethodResult[method]

--- a/MFGraphs/Tests/solve-mfg.mt
+++ b/MFGraphs/Tests/solve-mfg.mt
@@ -14,6 +14,53 @@ Test[
     TestID -> "SolveMFG routing: Automatic defaults to critical congestion"
 ]
 
+(* Baseline matrix for Plan A step 1: freeze SolveMFG stage-routing behavior on a core case. *)
+Test[
+    Module[{data, d2e, matrix, nonLinearOpts, monotoneOpts},
+        data = GetExampleData[12] /. {I1 -> 80, U1 -> 0};
+        d2e = DataToEquations[data];
+        nonLinearOpts = {
+            "MaxIterations" -> 5,
+            "Tolerance" -> 10^-6,
+            "PotentialFunction" -> Function[{x, edge}, 0],
+            "CongestionExponentFunction" -> Function[edge, 1],
+            "InteractionFunction" -> Function[{m, edge}, -1/m^2]
+        };
+        monotoneOpts = {
+            "ResidualTolerance" -> 10^-6,
+            "MaxTime" -> 5,
+            "MaxSteps" -> 1000,
+            "PotentialFunction" -> Function[{x, edge}, 0],
+            "CongestionExponentFunction" -> Function[edge, 1],
+            "InteractionFunction" -> Function[{m, edge}, -1/m^2]
+        };
+        matrix = <|
+            "Automatic" -> Lookup[Quiet[SolveMFG[d2e]], {"Solver", "ResultKind", "Feasibility"}],
+            "CriticalCongestion" -> Lookup[
+                Quiet[SolveMFG[d2e, Method -> "CriticalCongestion"]],
+                {"Solver", "ResultKind", "Feasibility"}
+            ],
+            "NonLinear" -> Lookup[
+                Quiet[SolveMFG[d2e, Method -> "NonLinear", Sequence @@ nonLinearOpts]],
+                {"Solver", "ResultKind", "Feasibility"}
+            ],
+            "Monotone" -> Lookup[
+                Quiet[SolveMFG[d2e, Method -> "Monotone", Sequence @@ monotoneOpts]],
+                {"Solver", "ResultKind", "Feasibility"}
+            ]
+        |>;
+        matrix["Automatic"][[1]] === "CriticalCongestion" &&
+        matrix["CriticalCongestion"] === {"CriticalCongestion", "Success", "Feasible"} &&
+        matrix["NonLinear"] === {"NonLinear", "Success", "Feasible"} &&
+        matrix["Monotone"][[1]] === "Monotone" &&
+        MemberQ[{"Success", "NonConverged"}, matrix["Monotone"][[2]]]
+    ]
+    ,
+    True
+    ,
+    TestID -> "SolveMFG baseline matrix: core case preserves stage-routing envelopes"
+]
+
 Test[
     Module[{data, d2e, direct, routed, drift},
         data = GetExampleData[7] /. {I1 -> 100, U1 -> 0, U2 -> 0};


### PR DESCRIPTION
## Summary
- introduce a single internal stage dispatcher `SolveMFGRunStage` to centralize method-stage execution paths
- rewire `SolveMFG` direct-method routes (`CriticalCongestion`, `Monotone`, `NonLinear`) through the dispatcher
- rewire `SolveMFGAutomaticDispatch` to dispatch by stage name via the same dispatcher (behavior-preserving refactor)
- add a baseline routing matrix test on a core case in `solve-mfg.mt` to freeze stage envelope behavior for Plan A step 1

## Scope
This PR intentionally keeps solver behavior unchanged and only restructures routing.

## Validation
- `wolframscript -code 'Get["MFGraphs/MFGraphs.wl"]; rep = TestReport["MFGraphs/Tests/solve-mfg.mt"]; Print[rep["TestsSucceededCount"]]; Print[rep["TestsFailedCount"]];'`
- Result: `0` failed (targeted SolveMFG routing suite)

## Notes
- committed files only:
  - `MFGraphs/MFGraphs.wl`
  - `MFGraphs/Tests/solve-mfg.mt`
