### PR TITLE
Solver Dispatch Refactor & Benchmark Profiles (Phase 1)

### DIFF
--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -1197,6 +1197,21 @@ SolveMFGCompileInput[input_Association, opts_List:{}] :=
         ]
     ];
 
+(* SolveMFGRunStage — central dispatcher for one solver stage.
+
+   dispatchMode semantics
+   ----------------------
+   "Direct"    — called from SolveMFG with user-supplied input that may be raw or
+                 pre-compiled. The CriticalCongestion branch enforces the alpha guard here.
+
+   "Automatic" — called from SolveMFGAutomaticDispatch, which always pre-compiles input
+                 to a d2e before invoking this function. Two invariants hold:
+                   • SolveMFGCompiledInputQ[input] is True for every branch, so the
+                     SolveMFGCompileInput fallbacks below are dead code in this path.
+                   • "CriticalCongestion" only appears in the attempt list when
+                     isCritical=True, so the alpha guard is intentionally skipped.
+                 The SolveMFGCompileInput branches exist so Direct callers work correctly
+                 without a separate pre-compilation step. Do not remove them. *)
 SolveMFGRunStage[
     method_String,
     input_Association,
@@ -1210,6 +1225,9 @@ SolveMFGRunStage[
                 If[
                     SolveMFGCompiledInputQ[input],
                     d2e = input,
+                    (* Direct only: guard against alpha != 1 before compiling.
+                       Automatic callers guarantee isCritical=True before placing this
+                       stage in the attempt list, so the guard is skipped there. *)
                     If[dispatchMode === "Direct",
                         isCritical = SolveMFGIsCriticalQ[heldOpts];
                         If[!TrueQ[isCritical],
@@ -1224,6 +1242,11 @@ SolveMFGRunStage[
                 ]
             ,
             "Monotone",
+                (* Direct mode: raw input goes to MonotoneSolverFromData (which calls
+                   DataToEquations internally); pre-compiled input goes to MonotoneSolver.
+                   These are distinct entry points — MonotoneSolver requires a compiled d2e.
+                   Automatic mode: input is always pre-compiled, so MonotoneSolver is used
+                   directly and the SolveMFGCompileInput branch is dead code. *)
                 If[
                     dispatchMode === "Automatic",
                     d2e = If[SolveMFGCompiledInputQ[input], input, SolveMFGCompileInput[input, opts]];
@@ -1245,6 +1268,7 @@ SolveMFGRunStage[
                 ]
             ,
             "NonLinear",
+                (* SolveMFGCompileInput is a no-op when input is already compiled. *)
                 d2e = If[SolveMFGCompiledInputQ[input], input, SolveMFGCompileInput[input, opts]];
                 NonLinearSolver[
                     d2e,

--- a/MFGraphs/Tests/solve-mfg.mt
+++ b/MFGraphs/Tests/solve-mfg.mt
@@ -26,10 +26,11 @@ Test[
             "CongestionExponentFunction" -> Function[edge, 1],
             "InteractionFunction" -> Function[{m, edge}, -1/m^2]
         };
+        (* MaxSteps caps iteration count (deterministic); no wall-clock MaxTime.
+           Case 12 is a 4-vertex network — 2000 steps is enough for convergence. *)
         monotoneOpts = {
             "ResidualTolerance" -> 10^-6,
-            "MaxTime" -> 5,
-            "MaxSteps" -> 1000,
+            "MaxSteps" -> 2000,
             "PotentialFunction" -> Function[{x, edge}, 0],
             "CongestionExponentFunction" -> Function[edge, 1],
             "InteractionFunction" -> Function[{m, edge}, -1/m^2]
@@ -52,8 +53,10 @@ Test[
         matrix["Automatic"][[1]] === "CriticalCongestion" &&
         matrix["CriticalCongestion"] === {"CriticalCongestion", "Success", "Feasible"} &&
         matrix["NonLinear"] === {"NonLinear", "Success", "Feasible"} &&
+        (* Monotone: assert correct solver and feasible solution — ResultKind may be
+           "Success" or "NonConverged" depending on step count, but flows must be valid. *)
         matrix["Monotone"][[1]] === "Monotone" &&
-        MemberQ[{"Success", "NonConverged"}, matrix["Monotone"][[2]]]
+        matrix["Monotone"][[3]] === "Feasible"
     ]
     ,
     True

--- a/Scripts/BenchmarkHelpers.wls
+++ b/Scripts/BenchmarkHelpers.wls
@@ -383,6 +383,23 @@ $TierTimeouts = <|
   "vlarge" -> 1800
 |>;
 
+(* --- Benchmark Profiles --- *)
+
+$BenchmarkProfiles = <|
+  "critical-core" -> <|
+    "Tiers" -> {"small", "core"},
+    "Solvers" -> {"critical"}
+  |>,
+  "nonlinear-kkt" -> <|
+    "Tiers" -> {"core", "stress", "paper"},
+    "Solvers" -> {"nonlinear"}
+  |>,
+  "dnf-paper" -> <|
+    "Tiers" -> {"paper", "inconsistent-switching"},
+    "Solvers" -> {"all"}
+  |>
+|>;
+
 (* --- Results formatting --- *)
 
 FormatTime[t_?NumericQ] := ToString[CForm[N[t]]];

--- a/Scripts/BenchmarkSuite.wls
+++ b/Scripts/BenchmarkSuite.wls
@@ -1,3 +1,4 @@
+#!/usr/bin/env wolframscript
 (* Usage: wolframscript -file Scripts/BenchmarkSuite.wls [tier] [case=key] [timeout=seconds] [isolation=mode] [solver=name] [tag=label] [rationale=...] [changes=...] [interpretation=...] *)
 (* tier: "small", "core", "stress", "paper", "inconsistent-switching", "large", "vlarge", legacy "medium", or "all" (default: "all") *)
 (* solver: "critical" (default), "nonlinear", "monotone", "all" *)
@@ -44,11 +45,15 @@ $TimeoutOverride = Automatic;
 $IsolationModeArg = "auto";
 $KernelPathArg = Automatic;
 $SelectedSolverArg = "critical";   (* default: CriticalCongestion only *)
+$SelectedProfile = None;
 
 Module[{args = Rest[$ScriptCommandLine], i = 1, arg, parsedTimeout, parsedIsolation},
   While[i <= Length[args],
     arg = args[[i]];
     Switch[arg,
+      "--profile",
+        i++;
+        If[i <= Length[args], $SelectedProfile = args[[i]]],
       "--tag",
         i++;
         $HistoryTag = If[i <= Length[args], args[[i]], "untagged"],
@@ -122,25 +127,65 @@ Module[{args = Rest[$ScriptCommandLine], i = 1, arg, parsedTimeout, parsedIsolat
   }];
 ];
 
-(* Resolve solver selection *)
-$SolversToRun = Switch[$SelectedSolverArg,
-  "critical" | "criticalcongestion", {"CriticalCongestion"},
-  "nonlinear" | "nl",               {"CriticalCongestion", "NonLinearSolver"},
-  "monotone" | "mono",              {"CriticalCongestion", "Monotone"},
-  "all",                            {"CriticalCongestion", "NonLinearSolver", "Monotone"},
-  _,
-    Print["Unknown solver argument: ", $SelectedSolverArg,
-          ". Valid values: critical, nonlinear, monotone, all."];
-    Exit[2]
+(* Apply profile if selected *)
+If[$SelectedProfile =!= None,
+  Module[{profileData = Lookup[$BenchmarkProfiles, $SelectedProfile]},
+    If[AssociationQ[profileData],
+      Print["Applying profile: ", $SelectedProfile];
+      $SelectedTier = "profile-derived";
+      $SolversToRun = Lookup[profileData, "Solvers", {"critical"}];
+      $SolversToRun = Switch[#,
+        "critical" | "criticalcongestion", "CriticalCongestion",
+        "nonlinear" | "nl",               "NonLinearSolver",
+        "monotone" | "mono",              "Monotone",
+        "all",                            {"CriticalCongestion", "NonLinearSolver", "Monotone"},
+        s_String, s,
+        l_List, l,
+        _, "CriticalCongestion"
+      ] & /@ $SolversToRun;
+      $SolversToRun = Flatten[$SolversToRun];
+      If[$SelectedCase === All,
+        $CasesToRun = Flatten[Lookup[$BenchmarkTiers, #, {}] & /@ Lookup[profileData, "Tiers", {}]],
+        $CasesToRun = {$SelectedCase}
+      ];
+      ,
+      Print["Unknown profile: ", $SelectedProfile];
+      Print["Available profiles: ", StringRiffle[Keys[$BenchmarkProfiles], ", "]];
+      Exit[2]
+    ];
+  ],
+  (* Default behavior if no profile *)
+  (* Resolve solver selection *)
+  $SolversToRun = Switch[$SelectedSolverArg,
+    "critical" | "criticalcongestion", {"CriticalCongestion"},
+    "nonlinear" | "nl",               {"CriticalCongestion", "NonLinearSolver"},
+    "monotone" | "mono",              {"CriticalCongestion", "Monotone"},
+    "all",                            {"CriticalCongestion", "NonLinearSolver", "Monotone"},
+    _,
+      Print["Unknown solver argument: ", $SelectedSolverArg,
+            ". Valid values: critical, nonlinear, monotone, all."];
+      Exit[2]
+  ];
+
+  $RequestedTier = $SelectedTier;
+  $SelectedTier = Lookup[$BenchmarkTierAliases, $SelectedTier, $SelectedTier];
+
+  (* --- Determine which cases to run --- *)
+  $CasesToRun = If[$SelectedCase =!= All,
+    {$SelectedCase},
+    If[$SelectedTier === "all",
+      Flatten[Lookup[$BenchmarkTiers, $DefaultBenchmarkTiers]],
+      Lookup[$BenchmarkTiers, $SelectedTier, {}]
+    ]
+  ];
 ];
+
 (* When only CriticalCongestion is requested, suppress the seed-only runs *)
 $CriticalOnlyMode = $SolversToRun === {"CriticalCongestion"};
 
-$RequestedTier = $SelectedTier;
-$SelectedTier = Lookup[$BenchmarkTierAliases, $SelectedTier, $SelectedTier];
-
+Print["Selected profile: ", If[$SelectedProfile === None, "None", $SelectedProfile]];
 Print["Selected tier: ", $SelectedTier];
-If[$RequestedTier =!= $SelectedTier, Print["Requested alias: ", $RequestedTier]];
+If[$SelectedProfile === None && $RequestedTier =!= $SelectedTier, Print["Requested alias: ", $RequestedTier]];
 If[$SelectedCase =!= All, Print["Selected case: ", $SelectedCase]];
 If[NumericQ[$TimeoutOverride], Print["Timeout override: ", $TimeoutOverride, "s"]];
 Print["Solvers: ", StringRiffle[$SolversToRun, ", "]];
@@ -154,15 +199,6 @@ If[$HistoryTag =!= None &&
 ];
 Print["Subkernels:    ", $KernelCount, " (of ", $ProcessorCount, " processors)"];
 Print[];
-
-(* --- Determine which cases to run --- *)
-$CasesToRun = If[$SelectedCase =!= All,
-  {$SelectedCase},
-  If[$SelectedTier === "all",
-    Flatten[Lookup[$BenchmarkTiers, $DefaultBenchmarkTiers]],
-    Lookup[$BenchmarkTiers, $SelectedTier, {}]
-  ]
-];
 
 GetTier[key_] := SelectFirst[Keys[$BenchmarkTiers], MemberQ[$BenchmarkTiers[#], key] &, "unknown"];
 ResolveCaseIsolationMode[tier_String] :=

--- a/Scripts/BenchmarkSuite.wls
+++ b/Scripts/BenchmarkSuite.wls
@@ -539,9 +539,10 @@ If[$HistoryTag =!= None,
       StringRiffle[tableLines, "\n"]
     ];
 
-    tiers = If[$SelectedTier === "all",
-      $DefaultBenchmarkTiers,
-      {$SelectedTier}
+    tiers = Which[
+      $SelectedTier === "all", $DefaultBenchmarkTiers,
+      $SelectedProfile =!= None, Lookup[Lookup[$BenchmarkProfiles, $SelectedProfile, <||>], "Tiers", {$SelectedTier}],
+      True, {$SelectedTier}
     ];
     tierTables = StringRiffle[
       Select[BuildTierTable /@ tiers, StringLength[#] > 0&],


### PR DESCRIPTION
## Overview
This PR initiates restructuring of the `SolveMFG` pipeline to improve modularity and observability. It introduces a centralized solver-stage dispatcher and standardizes benchmark profiles for consistent verification across solver modes.

## Key Changes

### 1. Solver Dispatcher & Reorganization (Plan A)
- Introduced `SolveMFGRunStage` to centralize stage routing for `CriticalCongestion`, `NonLinearSolver`, and `Monotone`.
- Added a baseline routing matrix test in `MFGraphs/Tests/solve-mfg.mt` to freeze expected core-case stage envelopes.
- Incorporated review-driven comments in `SolveMFGRunStage` documenting:
  - `Automatic`-mode invariants
  - why compile fallbacks remain present
  - why alpha guard is `Direct`-mode only.

### 2. Benchmark Harness Alignment (Plan C)
- Added benchmark profiles in `Scripts/BenchmarkHelpers.wls`:
  - `critical-core`
  - `nonlinear-kkt`
  - `dnf-paper`
- Added `--profile` support to `Scripts/BenchmarkSuite.wls`, so runs can be profile-driven instead of manually composing tiers/solvers.
- Fixed profile history rendering so `--profile` runs group history output by underlying tiers (e.g., `small`, `core`) rather than internal label `profile-derived`.
- Added shebang and argument parsing improvements for `wolframscript` compatibility.

## Verification

### Standardized profiles
```bash
# Verify the core critical path
wolframscript -file Scripts/BenchmarkSuite.wls --profile critical-core

# Verify the DNF paper profile
wolframscript -file Scripts/BenchmarkSuite.wls --profile dnf-paper
```

### Regression tests
Fast suite passed:

```bash
wolframscript -file Scripts/RunTests.wls fast
# Output: Tests run: 141, Passed: 141, Failed: 0
```

## Next Steps
- Implement Plan B: three-way KKT gating in `NonLinearSolver`.
- Move remaining critical-specific branching from shared flow into `Solvers.wl` helpers.
- Standardize benchmark output schema to include explicit KKT failure reasons.
