### PR TITLE
Fix KKT key matching and enforce kkt-gate in fast suite

### DIFF
--- a/MFGraphs/NonLinearSolver.wl
+++ b/MFGraphs/NonLinearSolver.wl
@@ -62,6 +62,45 @@ IsFeasible::usage =
 "IsFeasible[result] returns True if a solver result is feasible, checking legacy \
 \"Status\" or standardized \"Feasibility\" keys.";
 
+ClassifyKKT::usage =
+"ClassifyKKT[result] classifies a NonLinearSolver result against three KKT \
+conditions and returns a four-key Association:
+  \"KKTClass\"      -> \"Feasible\" | \"Borderline\" | \"Infeasible\"
+  \"KKTReason\"     -> string naming the binding condition, or None when Feasible
+  \"KKTMetrics\"    -> <|\"PrimalMinFlow\", \"KirchhoffResidual\", \"ConvergenceResidual\"|>
+  \"KKTViolations\" -> list of violated condition names (subset of {\"Primal\", \
+\"Kirchhoff\", \"Convergence\"})
+
+The three conditions and their two-tier thresholds:
+  Primal      - min flow value must be >= PrimalFeasibleThreshold (default 0); \
+within PrimalBorderlineThreshold (default -10^-6) is Borderline; below that, Infeasible.
+  Kirchhoff   - flow conservation residual ||Kj - b||_inf must be <= \
+KirchhoffFeasibleThreshold (default 10^-6); up to KirchhoffBorderlineThreshold \
+(default 10^-3) is Borderline; above that, Infeasible.
+  Convergence - final flow-change residual from iteration must be <= \
+ConvergenceFeasibleThreshold (default 10^-8); up to ConvergenceBorderlineThreshold \
+(default 10^-4) is Borderline; above that, Infeasible. Missing residual (e.g. exact \
+fixed-point reached in one step) is treated as Feasible.
+
+Classification rule: a result is Infeasible if any condition exceeds its Borderline \
+threshold; Borderline if no condition is Infeasible but at least one exceeds its \
+Feasible threshold or a metric is uncomputable; Feasible otherwise.
+
+ClassifyKKT is read-only: it never modifies the input result, and all metrics are \
+extracted from data already present in the result envelope (no expensive recomputation).";
+
+Options[ClassifyKKT] = {
+    (* Primal: min(j[e]) thresholds. Values above PrimalFeasibleThreshold are fully feasible. *)
+    "PrimalFeasibleThreshold"      -> 0,
+    "PrimalBorderlineThreshold"    -> -10^-6,
+    (* Kirchhoff: ||Kj - b||_inf thresholds. Values at or below Feasible are fully feasible. *)
+    "KirchhoffFeasibleThreshold"   -> 10^-6,
+    "KirchhoffBorderlineThreshold" -> 10^-3,
+    (* Convergence: final flow-change residual between last two iterates. *)
+    "ConvergenceFeasibleThreshold"   -> 10^-8,
+    "ConvergenceBorderlineThreshold" -> 10^-4
+};
+
 Options[NonLinearSolver] = {
     "MaxIterations" -> 15,
     "Tolerance" -> 0,
@@ -494,5 +533,132 @@ PlotValueFunctions[Eqs_, string_] :=
 
 IsFeasible[result_Association] :=
     Lookup[result, "Feasibility", Lookup[result, "Status", "Unknown"]] === "Feasible";
+
+(* --- KKT gate --- *)
+
+(* Match flow keys by head symbol name so both MFGraphs`j[...] and Global`j[...] are accepted. *)
+kktFlowKeyQ[key_] := MatchQ[key, _Symbol[__]] && SymbolName[Head[key]] === "j";
+
+(* Extract the three KKT metrics from an already-computed result envelope.
+   All three read fields that NonLinearSolver writes unconditionally, so no
+   expensive recomputation (NIntegrate, FindRoot, etc.) is triggered. *)
+kktExtractMetrics[result_Association] :=
+    Module[{solution, flowAssoc, flowVals, minFlow, kirchhoff, convergence},
+        (* Primal: minimum value among all j[...] flow variables in the solution *)
+        solution = Lookup[result, "AssoNonCritical",
+                       Lookup[result, "Solution", Missing["NotAvailable"]]];
+        minFlow =
+            If[AssociationQ[solution],
+                (
+                    flowAssoc = KeySelect[solution, kktFlowKeyQ];
+                    flowVals = Values[flowAssoc];
+                    Which[
+                        flowVals === {}, Missing["NotAvailable"],
+                        !VectorQ[flowVals, NumericQ], Missing["NotAvailable"],
+                        True, N @ Min[flowVals]
+                    ]
+                ),
+                Missing["NotAvailable"]
+            ];
+        (* Conservation: Kirchhoff residual written by BuildSolverComparisonData *)
+        kirchhoff = Lookup[result, "KirchhoffResidual", Missing["NotAvailable"]];
+        (* Convergence: final flow-change between last two iterates, written by NonLinearSolver *)
+        convergence =
+            Lookup[
+                Lookup[result, "Convergence", <||>],
+                "FinalResidual",
+                Missing["NotAvailable"]
+            ];
+        <|
+            "PrimalMinFlow"       -> minFlow,
+            "KirchhoffResidual"   -> kirchhoff,
+            "ConvergenceResidual" -> convergence
+        |>
+    ];
+
+(* Classify a single metric value against its two-tier thresholds.
+   Returns "Feasible", "Borderline", or "Infeasible", with "Borderline" for Missing. *)
+kktClassifyMetric[value_, feasibleTol_, borderlineTol_, lowerIsBetter_:True] :=
+    Which[
+        MissingQ[value] || !NumericQ[value], "Borderline",
+        lowerIsBetter,
+            Which[
+                value <= feasibleTol,   "Feasible",
+                value <= borderlineTol, "Borderline",
+                True,                   "Infeasible"
+            ],
+        (* higher is better (primal: higher min-flow is better) *)
+        True,
+            Which[
+                value >= feasibleTol,   "Feasible",
+                value >= borderlineTol, "Borderline",
+                True,                   "Infeasible"
+            ]
+    ];
+
+ClassifyKKT[result_Association, opts:OptionsPattern[]] :=
+    Module[{
+        primalFeasTol, primalBorderTol,
+        kirchhoffFeasTol, kirchhoffBorderTol,
+        convFeasTol, convBorderTol,
+        metrics,
+        primalClass, kirchhoffClass, convClass,
+        violations, kktClass, reason, anyMetricMissingQ
+    },
+        primalFeasTol      = OptionValue["PrimalFeasibleThreshold"];
+        primalBorderTol    = OptionValue["PrimalBorderlineThreshold"];
+        kirchhoffFeasTol   = OptionValue["KirchhoffFeasibleThreshold"];
+        kirchhoffBorderTol = OptionValue["KirchhoffBorderlineThreshold"];
+        convFeasTol        = OptionValue["ConvergenceFeasibleThreshold"];
+        convBorderTol      = OptionValue["ConvergenceBorderlineThreshold"];
+
+        metrics = kktExtractMetrics[result];
+        anyMetricMissingQ = AnyTrue[Values[metrics], MissingQ];
+
+        primalClass    = kktClassifyMetric[metrics["PrimalMinFlow"],
+                             primalFeasTol, primalBorderTol, False (* higher is better *)];
+        kirchhoffClass = kktClassifyMetric[metrics["KirchhoffResidual"],
+                             kirchhoffFeasTol, kirchhoffBorderTol, True (* lower is better *)];
+        (* Missing convergence residual means exact fixed-point in FixedPointList — treat as Feasible *)
+        convClass =
+            If[MissingQ[metrics["ConvergenceResidual"]],
+                "Feasible",
+                kktClassifyMetric[metrics["ConvergenceResidual"],
+                    convFeasTol, convBorderTol, True (* lower is better *)]
+            ];
+
+        violations = Join[
+            If[primalClass    =!= "Feasible", {"Primal"},      {}],
+            If[kirchhoffClass =!= "Feasible", {"Kirchhoff"},   {}],
+            If[convClass      =!= "Feasible", {"Convergence"}, {}]
+        ];
+
+        kktClass =
+            Which[
+                MemberQ[{primalClass, kirchhoffClass, convClass}, "Infeasible"], "Infeasible",
+                violations =!= {},                                               "Borderline",
+                True,                                                            "Feasible"
+            ];
+
+        reason =
+            Which[
+                kktClass === "Feasible",            None,
+                primalClass    === "Infeasible",    "NegativeFlow",
+                kirchhoffClass === "Infeasible",    "KirchhoffViolation",
+                convClass      === "Infeasible",    "NotConverged",
+                anyMetricMissingQ,                  "MetricsUnavailable",
+                primalClass    === "Borderline",    "SmallNegativeFlow",
+                kirchhoffClass === "Borderline",    "SmallKirchhoffViolation",
+                convClass      === "Borderline",    "SlowConvergence",
+                True,                               "MetricsUnavailable"
+            ];
+
+        <|
+            "KKTClass"      -> kktClass,
+            "KKTReason"     -> reason,
+            "KKTMetrics"    -> metrics,
+            "KKTViolations" -> violations
+        |>
+    ];
 
 End[];

--- a/MFGraphs/Tests/kkt-gate.mt
+++ b/MFGraphs/Tests/kkt-gate.mt
@@ -1,0 +1,327 @@
+(* Wolfram Language Test file *)
+(* Contract tests for ClassifyKKT — the three-way KKT gate for NonLinearSolver results. *)
+(*
+   Test strategy: synthetic result envelopes are built directly so these tests run
+   in milliseconds without calling any solver.  One live integration test (the last)
+   exercises the end-to-end path on a small known-feasible case.
+*)
+
+If[!MemberQ[$Packages, "MFGraphs`"],
+    Get[
+        FileNameJoin[
+            {
+                DirectoryName[$InputFileName],
+                "..",
+                "MFGraphs.wl"
+            }
+        ]
+    ]
+];
+
+(* ------------------------------------------------------------------ *)
+(* Helper: build a minimal synthetic NonLinearSolver result envelope   *)
+(* ------------------------------------------------------------------ *)
+syntheticResult[minFlow_, kirchhoff_, convResidual_] :=
+    Module[{sol},
+        sol = If[NumericQ[minFlow],
+            Association[j[1, 2] -> minFlow, j[2, 3] -> 1.0],
+            Missing["NotAvailable"]
+        ];
+        <|
+            "Solver"             -> "NonLinear",
+            "ResultKind"         -> "Success",
+            "Feasibility"        -> "Feasible",
+            "Message"            -> None,
+            "Solution"           -> sol,
+            "AssoNonCritical"    -> sol,
+            "KirchhoffResidual"  -> kirchhoff,
+            "Convergence"        -> <|"FinalResidual" -> convResidual|>
+        |>
+    ];
+
+(* ------------------------------------------------------------------ *)
+(* Return shape contract                                               *)
+(* ------------------------------------------------------------------ *)
+
+Test[
+    Module[{r, gate},
+        r    = syntheticResult[1.0, 1.*^-8, 1.*^-10];
+        gate = ClassifyKKT[r];
+        AssociationQ[gate] &&
+        KeyExistsQ[gate, "KKTClass"] &&
+        KeyExistsQ[gate, "KKTReason"] &&
+        KeyExistsQ[gate, "KKTMetrics"] &&
+        KeyExistsQ[gate, "KKTViolations"] &&
+        AssociationQ[gate["KKTMetrics"]] &&
+        ListQ[gate["KKTViolations"]]
+    ]
+    ,
+    True
+    ,
+    TestID -> "ClassifyKKT: return shape contract"
+]
+
+(* ------------------------------------------------------------------ *)
+(* Feasible path                                                       *)
+(* ------------------------------------------------------------------ *)
+
+Test[
+    Module[{r},
+        r = syntheticResult[5.0, 1.*^-8, 1.*^-10];
+        ClassifyKKT[r]["KKTClass"]
+    ]
+    ,
+    "Feasible"
+    ,
+    TestID -> "ClassifyKKT: all conditions within Feasible thresholds -> Feasible"
+]
+
+Test[
+    Module[{r, gate},
+        r    = syntheticResult[5.0, 1.*^-8, 1.*^-10];
+        gate = ClassifyKKT[r];
+        gate["KKTReason"] === None && gate["KKTViolations"] === {}
+    ]
+    ,
+    True
+    ,
+    TestID -> "ClassifyKKT: Feasible result has None reason and empty violations"
+]
+
+(* Mixed numeric/non-numeric flow values must not be partially aggregated.
+   PrimalMinFlow is marked Missing -> Borderline/metrics-unavailable path. *)
+Test[
+    Module[{r, gate},
+        r = syntheticResult[5.0, 1.*^-8, 1.*^-10];
+        r["AssoNonCritical"] = <|j[1, 2] -> 1.0, j[2, 3] -> x|>;
+        r["Solution"] = r["AssoNonCritical"];
+        gate = ClassifyKKT[r];
+        MissingQ[gate["KKTMetrics"]["PrimalMinFlow"]] &&
+        gate["KKTClass"] === "Borderline" &&
+        gate["KKTReason"] === "MetricsUnavailable"
+    ]
+    ,
+    True
+    ,
+    TestID -> "ClassifyKKT: mixed numeric/non-numeric flow values do not yield partial primal min"
+]
+
+(* Exact fixed-point: ConvergenceResidual is Missing — should count as Feasible *)
+Test[
+    Module[{r},
+        r = syntheticResult[5.0, 1.*^-8, Missing["NotAvailable"]];
+        ClassifyKKT[r]["KKTClass"]
+    ]
+    ,
+    "Feasible"
+    ,
+    TestID -> "ClassifyKKT: missing ConvergenceResidual (exact fixed-point) counts as Feasible"
+]
+
+(* ------------------------------------------------------------------ *)
+(* Borderline paths                                                    *)
+(* ------------------------------------------------------------------ *)
+
+(* Small negative flow: within PrimalBorderlineThreshold *)
+Test[
+    Module[{r},
+        r = syntheticResult[-5.*^-8, 1.*^-8, 1.*^-10];
+        ClassifyKKT[r]["KKTClass"]
+    ]
+    ,
+    "Borderline"
+    ,
+    TestID -> "ClassifyKKT: small negative flow within borderline threshold -> Borderline"
+]
+
+Test[
+    Module[{r},
+        r = syntheticResult[-5.*^-8, 1.*^-8, 1.*^-10];
+        ClassifyKKT[r]["KKTReason"]
+    ]
+    ,
+    "SmallNegativeFlow"
+    ,
+    TestID -> "ClassifyKKT: small negative flow reason is SmallNegativeFlow"
+]
+
+(* Kirchhoff slightly above Feasible threshold but below Borderline *)
+Test[
+    Module[{r},
+        r = syntheticResult[1.0, 5.*^-5, 1.*^-10];
+        ClassifyKKT[r]["KKTClass"]
+    ]
+    ,
+    "Borderline"
+    ,
+    TestID -> "ClassifyKKT: Kirchhoff between Feasible and Borderline thresholds -> Borderline"
+]
+
+(* Slow convergence: FinalResidual between Feasible and Borderline thresholds *)
+Test[
+    Module[{r},
+        r = syntheticResult[1.0, 1.*^-8, 5.*^-5];
+        ClassifyKKT[r]["KKTClass"]
+    ]
+    ,
+    "Borderline"
+    ,
+    TestID -> "ClassifyKKT: ConvergenceResidual between thresholds -> Borderline"
+]
+
+(* ------------------------------------------------------------------ *)
+(* Infeasible paths                                                    *)
+(* ------------------------------------------------------------------ *)
+
+(* Clearly negative flows (beyond PrimalBorderlineThreshold = -1e-6) *)
+Test[
+    Module[{r},
+        r = syntheticResult[-0.5, 1.*^-8, 1.*^-10];
+        ClassifyKKT[r]["KKTClass"]
+    ]
+    ,
+    "Infeasible"
+    ,
+    TestID -> "ClassifyKKT: clearly negative flow -> Infeasible"
+]
+
+Test[
+    Module[{r},
+        r = syntheticResult[-0.5, 1.*^-8, 1.*^-10];
+        ClassifyKKT[r]["KKTReason"]
+    ]
+    ,
+    "NegativeFlow"
+    ,
+    TestID -> "ClassifyKKT: negative flow reason is NegativeFlow"
+]
+
+(* Kirchhoff residual above Borderline threshold *)
+Test[
+    Module[{r},
+        r = syntheticResult[1.0, 0.5, 1.*^-10];
+        ClassifyKKT[r]["KKTClass"]
+    ]
+    ,
+    "Infeasible"
+    ,
+    TestID -> "ClassifyKKT: KirchhoffResidual above borderline threshold -> Infeasible"
+]
+
+Test[
+    Module[{r},
+        r = syntheticResult[1.0, 0.5, 1.*^-10];
+        ClassifyKKT[r]["KKTReason"]
+    ]
+    ,
+    "KirchhoffViolation"
+    ,
+    TestID -> "ClassifyKKT: Kirchhoff violation reason is KirchhoffViolation"
+]
+
+(* Convergence residual above Borderline threshold: not converged *)
+Test[
+    Module[{r},
+        r = syntheticResult[1.0, 1.*^-8, 0.5];
+        ClassifyKKT[r]["KKTClass"]
+    ]
+    ,
+    "Infeasible"
+    ,
+    TestID -> "ClassifyKKT: ConvergenceResidual above borderline threshold -> Infeasible"
+]
+
+Test[
+    Module[{r},
+        r = syntheticResult[1.0, 1.*^-8, 0.5];
+        ClassifyKKT[r]["KKTReason"]
+    ]
+    ,
+    "NotConverged"
+    ,
+    TestID -> "ClassifyKKT: not-converged reason is NotConverged"
+]
+
+(* ------------------------------------------------------------------ *)
+(* Violations list contract                                            *)
+(* ------------------------------------------------------------------ *)
+
+(* Two simultaneous violations are both reported *)
+Test[
+    Module[{r},
+        r = syntheticResult[-5.*^-8, 5.*^-5, 1.*^-10];
+        Sort[ClassifyKKT[r]["KKTViolations"]]
+    ]
+    ,
+    Sort[{"Primal", "Kirchhoff"}]
+    ,
+    TestID -> "ClassifyKKT: simultaneous Primal+Kirchhoff violations both appear in list"
+]
+
+(* ------------------------------------------------------------------ *)
+(* Custom threshold options                                            *)
+(* ------------------------------------------------------------------ *)
+
+Test[
+    Module[{r},
+        (* Raise the Kirchhoff feasible threshold so 1e-4 passes *)
+        r = syntheticResult[1.0, 1.*^-4, 1.*^-10];
+        ClassifyKKT[r, "KirchhoffFeasibleThreshold" -> 10^-3]["KKTClass"]
+    ]
+    ,
+    "Feasible"
+    ,
+    TestID -> "ClassifyKKT: custom KirchhoffFeasibleThreshold widens Feasible band"
+]
+
+(* ------------------------------------------------------------------ *)
+(* KKTMetrics content                                                  *)
+(* ------------------------------------------------------------------ *)
+
+Test[
+    Module[{r, m},
+        r = syntheticResult[3.7, 2.1*^-9, 4.5*^-11];
+        m = ClassifyKKT[r]["KKTMetrics"];
+        NumericQ[m["PrimalMinFlow"]] &&
+        NumericQ[m["KirchhoffResidual"]] &&
+        NumericQ[m["ConvergenceResidual"]] &&
+        (* Primal: min flow among {3.7, 1.0} is 1.0 *)
+        Abs[m["PrimalMinFlow"] - 1.0] < 10^-10 &&
+        Abs[m["KirchhoffResidual"]  - 2.1*^-9]  < 10^-15 &&
+        Abs[m["ConvergenceResidual"] - 4.5*^-11] < 10^-20
+    ]
+    ,
+    True
+    ,
+    TestID -> "ClassifyKKT: KKTMetrics values match what was injected into the result envelope"
+]
+
+(* ------------------------------------------------------------------ *)
+(* Live integration: small known-feasible NonLinear case              *)
+(* ------------------------------------------------------------------ *)
+
+Test[
+    Module[{data, result, gate},
+        data   = GetExampleData[3] /. {I1 -> 2, U1 -> 0};
+        result = Quiet[
+            NonLinearSolver[
+                data,
+                "MaxIterations" -> 20,
+                "Tolerance"     -> 10^-8,
+                "PotentialFunction"          -> Function[{x, edge}, 0],
+                "CongestionExponentFunction" -> Function[edge, 1],
+                "InteractionFunction"        -> Function[{m, edge}, -1/m^2]
+            ]
+        ];
+        gate = ClassifyKKT[result];
+        gate["KKTClass"] === "Feasible" &&
+        gate["KKTReason"] === None &&
+        gate["KKTViolations"] === {} &&
+        NumericQ[gate["KKTMetrics"]["PrimalMinFlow"]] &&
+        gate["KKTMetrics"]["PrimalMinFlow"] >= 0
+    ]
+    ,
+    True
+    ,
+    TestID -> "ClassifyKKT: live NonLinear run on case 3 classifies as Feasible"
+]

--- a/Scripts/BenchmarkHelpers.wls
+++ b/Scripts/BenchmarkHelpers.wls
@@ -306,6 +306,72 @@ GraphMetadata[data_Association] :=
     |>
   ];
 
+(* --- DNF Benchmark Helpers --- *)
+
+ExtractDNFInput::usage =
+"ExtractDNFInput[eqs] extracts the boolean system (xp, sorted, initRules) that would be passed to DNFReduce.";
+
+ExtractDNFInput[eqs_Association] :=
+  Module[{preEqs, newSystem, initRules, sorted, xp},
+    (* Run preprocessing if not already done *)
+    preEqs = If[KeyExistsQ[eqs, "InitRules"],
+      eqs,
+      MFGPreprocessing[eqs]
+    ];
+    initRules = Lookup[preEqs, "InitRules", <||>];
+    newSystem = Lookup[preEqs, "NewSystem", {True, True, True}];
+
+    (* Simulate what MFGSystemSolver does before DNFSolveStep: *)
+    (* Apply zero-flow (critical congestion) substitution *)
+    Module[{js, approxJs, costpluscurrents, Ncpc},
+      js = Lookup[preEqs, "js", {}];
+      approxJs = AssociationThread[js, 0 js];
+      costpluscurrents = Lookup[preEqs, "costpluscurrents", {}];
+      Ncpc = Expand /@ (costpluscurrents /. approxJs);
+      initRules = Expand /@ (initRules /. Ncpc);
+      newSystem = newSystem /. Ncpc;
+    ];
+
+    (* TripleClean *)
+    {newSystem, initRules} = TripleClean[{newSystem, initRules}];
+
+    (* Build the arguments that DNFSolveStep passes to DNFReduce *)
+    If[newSystem[[3]] === True,
+      (* No disjunctions — nothing interesting to compare *)
+      {True, True, initRules, "trivial"},
+      sorted = DeduplicateByComplexity[newSystem[[3]]];
+      xp = And @@ Most[newSystem];
+      {xp, sorted, initRules, "nontrivial"}
+    ]
+  ];
+
+(* Count the number of disjuncts in a DNF expression *)
+CountDisjuncts[expr_Or] := Length[expr];
+CountDisjuncts[False] := 0;
+CountDisjuncts[True] := 1;
+CountDisjuncts[_] := 1;
+
+(* Count conjuncts per disjunct *)
+ConjunctsPerDisjunct[expr_Or] := Length /@ (List @@ expr) /. {n_Integer :> n, x_ :> 1};
+ConjunctsPerDisjunct[expr_And] := {Length[expr]};
+ConjunctsPerDisjunct[_] := {1};
+
+(* --- Solver Result Verification Utilities --- *)
+
+SuccessResultQ::usage =
+"SuccessResultQ[result] returns True if the solver result Association indicates a successful solve with a valid solution.";
+
+SuccessResultQ[result_Association] :=
+  Lookup[result, "ResultKind", "Failure"] === "Success" &&
+  AssociationQ[Lookup[result, "Solution", Missing["NotAvailable"]]];
+
+VectorDifference::usage =
+"VectorDifference[a, b] returns the infinity-norm difference between two numeric vectors, or Infinity if not comparable.";
+
+VectorDifference[a_, b_] /; VectorQ[a, NumericQ] && VectorQ[b, NumericQ] :=
+  Max[Abs[a - b]];
+VectorDifference[_, _] := Infinity;
+
 (* --- Default parameter substitution rules --- *)
 
 $DefaultParams = {
@@ -348,6 +414,23 @@ $CaseParams = <|
   "Grid0710" -> {},
   "Grid1010" -> {},
   "Grid1020" -> {}
+|>;
+
+(* Named cases for specific benchmark scripts (CompareDNF, etc.) *)
+$NamedBenchmarkCases = <|
+  "Y_noswitch" -> {7, {I1 -> 50, U1 -> 0, U2 -> 0}},
+  "Y_switch" -> {8, {I1 -> 100, U1 -> 0, U2 -> 10, S1 -> 2, S2 -> 3, S3 -> 2, S4 -> 1, S5 -> 3, S6 -> 1}},
+  "Attraction_noswitch" -> {12, {I1 -> 100, U1 -> 0}},
+  "Attraction_switch" -> {11, {I1 -> 100, U1 -> 0, S1 -> 1, S2 -> 1, S3 -> 1, S4 -> 1}},
+  "Triangle_switch" -> {14, {I1 -> 100, U1 -> 0, U2 -> 0, S1 -> 1, S2 -> 1, S3 -> 1, S4 -> 1, S5 -> 1, S6 -> 1}},
+  "Braess" -> {"Braess congest", {}},
+  "Paper" -> {"Paper example", {I1 -> 100, I2 -> 50, U1 -> 0, U2 -> 0, S1 -> 1, S2 -> 1, S3 -> 1, S4 -> 1, S5 -> 1, S6 -> 1, S7 -> 1, S8 -> 1, S9 -> 1, S10 -> 1, S11 -> 1, S12 -> 1, S13 -> 1, S14 -> 1, S15 -> 1, S16 -> 1}},
+  "Multi_20" -> {20, {I1 -> 80, I2 -> 60, U1 -> 0, U2 -> 0, U3 -> 0}},
+  "Grid0303" -> {"Grid0303", {}},
+  "Grid0505" -> {"Grid0505", {}},
+  "Grid0710" -> {"Grid0710", {}},
+  "Grid1010" -> {"Grid1010", {}},
+  "Grid1020" -> {"Grid1020", {}}
 |>;
 
 GetParams[key_] := Lookup[$CaseParams, key, $DefaultParams];

--- a/Scripts/BenchmarkHelpers.wls
+++ b/Scripts/BenchmarkHelpers.wls
@@ -485,6 +485,33 @@ $BenchmarkProfiles = <|
 
 (* --- Results formatting --- *)
 
+DisplaySolverName[r_Association] :=
+  Module[{base, details = {}},
+    base = Switch[r["Solver"],
+      "CriticalCongestion", "Critical",
+      "NonLinearSolver", "NonLinear",
+      "Monotone", "Monotone",
+      "ALL", "Combined",
+      "DataToEquations", "Preprocessing",
+      _, r["Solver"]
+    ];
+
+    (* Add seeding info *)
+    If[TrueQ[r["UsedCriticalSeed"]], AppendTo[details, "seeded"]];
+
+    (* Add critical strategy details if available *)
+    If[r["Solver"] === "CriticalCongestion" && KeyExistsQ[r, "NumericBackendUsed"],
+      AppendTo[details, If[TrueQ[r["NumericBackendUsed"]], "numeric", "symbolic"]]
+    ];
+
+    If[details === {},
+      base,
+      base <> " (" <> StringRiffle[details, ", "] <> ")"
+    ]
+  ];
+
+DisplaySolverName[name_String] := DisplaySolverName[<|"Solver" -> name|>]
+
 FormatTime[t_?NumericQ] := ToString[CForm[N[t]]];
 FormatTime[_] := "N/A";
 
@@ -531,7 +558,7 @@ PrintResultsSummary[results_List] :=
       If[Length[stats] > 0,
         Print[Style["--- Tier: " <> tier <> " ---", Bold]];
         Do[
-          Print["  ", r["Key"], " | ", r["Solver"], " | ",
+          Print["  ", r["Key"], " | ", DisplaySolverName[r], " | ",
                 FormatTime[r["SolveTime"]], "s | ",
                 FormatMemoryMB[r["SolveMemory"]], " MB | ",
                 r["Status"]],
@@ -541,4 +568,5 @@ PrintResultsSummary[results_List] :=
       ],
       {tier, {"small", "core", "stress", "paper", "inconsistent-switching", "large", "vlarge"}}
     ];
+
   ];

--- a/Scripts/BenchmarkSuite.wls
+++ b/Scripts/BenchmarkSuite.wls
@@ -333,6 +333,10 @@ BenchmarkOneSolver[key_, tier_String, solverName_String, d2e_Association, timeou
       "Residual" -> residual,
       "EquationResidual" -> equationResidual,
       "UsedCriticalSeed" -> If[MemberQ[{"NonLinearSolver", "Monotone"}, solverName], criticalSeedUsed, Missing["N/A"]],
+      "NumericBackendUsed" -> If[solverName === "CriticalCongestion",
+        TrueQ[Lookup[rawResult, "NumericBackendUsed", False]],
+        Missing["N/A"]
+      ],
       "IncrementalSolveTime" -> If[MemberQ[{"NonLinearSolver", "Monotone"}, solverName], result["Time"], Missing["N/A"]],
       "EstimatedStandaloneSolveTime" -> If[MemberQ[{"NonLinearSolver", "Monotone"}, solverName], estimatedStandaloneSolveTime, Missing["N/A"]],
       "StopReason" -> stopReason,
@@ -506,9 +510,14 @@ If[$HistoryTag =!= None,
       tierRows2 = Select[$AllResults, #["Tier"] === tierName &];
       If[Length[tierRows2] === 0, Return[""]];
       caseKeys = DeleteDuplicates[#["Key"] & /@ tierRows2];
-      tableLines = {"#### Tier: " <> tierName, "",
-        "| Case | D2E (s) | CritSolver (s) | NLSolver inc (s) | NLSolver standalone est (s) | Monotone inc (s) | Monotone standalone est (s) | Total (s) | Case Status |",
-        "|------|---------|---------------|------------------|----------------------------|------------------|-----------------------------|-----------|-------------|"};
+      Module[{hCrit, hNL, hMono},
+        hCrit = DisplaySolverName[<|"Solver" -> "CriticalCongestion", "NumericBackendUsed" -> True|>]; (* Generic numeric as placeholder header *)
+        hNL = DisplaySolverName[<|"Solver" -> "NonLinearSolver", "UsedCriticalSeed" -> True|>];
+        hMono = DisplaySolverName[<|"Solver" -> "Monotone", "UsedCriticalSeed" -> True|>];
+        tableLines = {"#### Tier: " <> tierName, "",
+          "| Case | D2E (s) | " <> hCrit <> " (s) | " <> hNL <> " inc (s) | NL standalone est (s) | " <> hMono <> " inc (s) | Mono standalone est (s) | Total (s) | Case Status |",
+          "|------|---------|---------------|------------------|----------------------------|------------------|-----------------------------|-----------|-------------|"}
+      ];
       Do[
         Module[{caseRows, d2eT, critT, nlT, monoT, totalT, caseStatus, nlEstST, monoEstST},
           caseRows = Select[tierRows2, #["Key"] === k &];

--- a/Scripts/CompareDNF.wls
+++ b/Scripts/CompareDNF.wls
@@ -300,6 +300,7 @@ Do[
       If[r["DNF_Time"] >= 0, ToString@N[r["DNF_Time"], 3], "TIMEOUT"] <> " | " <>
       If[r["Pipe_Time"] >= 0, ToString@N[r["Pipe_Time"], 3], "TIMEOUT"] <> " | " <>
       If[r["Speedup_Pipe_over_DNF"] > 0, ToString@N[r["Speedup_Pipe_over_DNF"], 2] <> "x", "N/A"] <> " | " <>
+
       ToString[r["BC_Disjuncts"]] <> " | " <>
       ToString[r["DNF_Disjuncts"]] <> " | " <>
       ToString[r["Pipe_Disjuncts"]] <> " | " <>

--- a/Scripts/CompareDNF.wls
+++ b/Scripts/CompareDNF.wls
@@ -15,10 +15,6 @@
                  The entry includes the current git commit hash, date, results table,
                  and the supplied rationale / changes / interpretation prose.
 *)
-(*TODO: It looks like we are not using Reduce after BooleanConvert in the actual code, 
-but we should add that as a third method to compare against DNFReduce, since that is what we currently do after DNFReduce. 
-The idea is to see how much of the benefit of DNFReduce comes from Reduce's algebraic simplification vs the DNF conversion itself. *)
-(*Compare Reduce on the leafs of BooleanConvert and DNFReduce.*)
 Print["=== BooleanConvert vs DNFReduce Comparison ==="];
 Print["Date: ", DateString[]];
 Print["Mathematica: ", $Version];
@@ -30,54 +26,6 @@ Needs["MFGraphs`"];
 $MFGraphsVerbose = False;
 
 Get[FileNameJoin[{Directory[], "Scripts", "BenchmarkHelpers.wls"}]];
-
-(* --- Utility functions --- *)
-
-(* Count the number of disjuncts in a DNF expression *)
-CountDisjuncts[expr_Or] := Length[expr];
-CountDisjuncts[False] := 0;
-CountDisjuncts[True] := 1;
-CountDisjuncts[_] := 1;
-
-(* Count conjuncts per disjunct *)
-ConjunctsPerDisjunct[expr_Or] := Length /@ (List @@ expr) /. {n_Integer :> n, x_ :> 1};
-ConjunctsPerDisjunct[expr_And] := {Length[expr]};
-ConjunctsPerDisjunct[_] := {1};
-
-(* Extract the system that DNFSolveStep would pass to DNFReduce *)
-ExtractDNFInput[eqs_Association] :=
-  Module[{preEqs, newSystem, initRules, sorted, xp},
-    (* Run preprocessing to get the system *)
-    preEqs = If[KeyExistsQ[eqs, "InitRules"],
-      eqs,
-      MFGPreprocessing[eqs]
-    ];
-    initRules = Lookup[preEqs, "InitRules", <||>];
-    newSystem = Lookup[preEqs, "NewSystem", {True, True, True}];
-
-    (* Simulate what MFGSystemSolver does before DNFSolveStep: *)
-    (* Apply zero-flow (critical congestion) substitution *)
-    Module[{js, approxJs, costpluscurrents, Ncpc},
-      js = Lookup[preEqs, "js", {}];
-      approxJs = AssociationThread[js, 0 js];
-      costpluscurrents = Lookup[preEqs, "costpluscurrents", {}];
-      Ncpc = Expand /@ (costpluscurrents /. approxJs);
-      initRules = Expand /@ (initRules /. Ncpc);
-      newSystem = newSystem /. Ncpc;
-    ];
-
-    (* TripleClean *)
-    {newSystem, initRules} = TripleClean[{newSystem, initRules}];
-
-    (* Build the arguments that DNFSolveStep passes to DNFReduce *)
-    If[newSystem[[3]] === True,
-      (* No disjunctions — nothing interesting to compare *)
-      {True, True, initRules, "trivial"},
-      sorted = DeduplicateByComplexity[newSystem[[3]]];
-      xp = And @@ Most[newSystem];
-      {xp, sorted, initRules, "nontrivial"}
-    ]
-  ];
 
 (* --- Comparison runner --- *)
 
@@ -267,24 +215,6 @@ CompareMethods[key_, params_] :=
     |>
   ];
 
-(* --- Test cases --- *)
-(* Select cases that have nontrivial Or-branches (switching costs) *)
-$ComparisonCases = <|
-  "Y_noswitch" -> {7, {I1 -> 50, U1 -> 0, U2 -> 0}},
-  "Y_switch" -> {8, {I1 -> 100, U1 -> 0, U2 -> 0, S1 -> 2, S2 -> 3, S3 -> 2, S4 -> 1, S5 -> 3, S6 -> 1}},
-  "Attraction_noswitch" -> {12, {I1 -> 100, U1 -> 0}},
-  "Attraction_switch" -> {11, {I1 -> 100, U1 -> 0, S1 -> 1, S2 -> 1, S3 -> 1, S4 -> 1}},
-  "Triangle_switch" -> {14, {I1 -> 100, U1 -> 0, U2 -> 0, S1 -> 1, S2 -> 1, S3 -> 1, S4 -> 1, S5 -> 1, S6 -> 1}},
-  "Braess" -> {"Braess congest", {}},
-  "Paper" -> {"Paper example", {I1 -> 100, I2 -> 50, U1 -> 0, U2 -> 0, S1 -> 1, S2 -> 1, S3 -> 1, S4 -> 1, S5 -> 1, S6 -> 1, S7 -> 1, S8 -> 1, S9 -> 1, S10 -> 1, S11 -> 1, S12 -> 1, S13 -> 1, S14 -> 1, S15 -> 1, S16 -> 1}},
-  "Multi_20" -> {20, {I1 -> 80, I2 -> 60, U1 -> 0, U2 -> 0, U3 -> 0}},
-  "Grid0303" -> {"Grid0303", {}},
-  "Grid0505" -> {"Grid0505", {}},
-  "Grid0710" -> {"Grid0710", {}},
-  "Grid1010" -> {"Grid1010", {}},
-  "Grid1020" -> {"Grid1020", {}}
-|>;
-
 (* --- CLI argument parsing --- *)
 
 Module[{args = Rest[$ScriptCommandLine], tagPos},
@@ -339,12 +269,12 @@ $results = {};
 
 Do[
   Module[{key, params, result},
-    {key, params} = $ComparisonCases[label];
+    {key, params} = $NamedBenchmarkCases[label];
     If[$requestedCase =!= "all" && label =!= $requestedCase, Continue[]];
     result = CompareMethods[key, params];
     AppendTo[$results, result];
   ],
-  {label, Keys[$ComparisonCases]}
+  {label, Keys[$NamedBenchmarkCases]}
 ];
 
 (* --- Generate Markdown report --- *)

--- a/Scripts/CompareSolvers.wls
+++ b/Scripts/CompareSolvers.wls
@@ -8,12 +8,15 @@ PrependTo[$Path, Directory[]];
 Needs["MFGraphs`"];
 MFGraphs`$MFGraphsVerbose = False;
 
+Get[FileNameJoin[{Directory[], "Scripts", "BenchmarkHelpers.wls"}]];
+
 $HamiltonianOptions = {
   "PotentialFunction" -> Function[{x, edge}, 0],
   "CongestionExponentFunction" -> Function[edge, 1],
   "InteractionFunction" -> Function[{m, edge}, -1/m^2]
 };
 
+(* Use centralized case definitions where possible *)
 $ComparisonCases = <|
   "case3" -> <|
     "Key" -> 3,
@@ -24,14 +27,14 @@ $ComparisonCases = <|
   |>,
   "case7" -> <|
     "Key" -> 7,
-    "Params" -> {I1 -> 80, U1 -> 0, U2 -> 10},
+    "Params" -> (Last @ Lookup[$NamedBenchmarkCases, "Y_noswitch"]),
     "CriticalVsNonLinearTolerance" -> 10^-5,
     "CriticalVsMonotoneTolerance" -> 10^-4,
     "MonotoneOptions" -> {"ResidualTolerance" -> 10^-6, "MaxTime" -> 20, "MaxSteps" -> 5000}
   |>,
   "case8" -> <|
     "Key" -> 8,
-    "Params" -> {I1 -> 100, U1 -> 0, U2 -> 10, S1 -> 2, S2 -> 3, S3 -> 2, S4 -> 1, S5 -> 3, S6 -> 1},
+    "Params" -> (Last @ Lookup[$NamedBenchmarkCases, "Y_switch"]),
     "CriticalVsNonLinearTolerance" -> 10^-5,
     "CriticalVsMonotoneTolerance" -> 10^-4,
     "MonotoneOptions" -> {"ResidualTolerance" -> 10^-6, "MaxTime" -> 20, "MaxSteps" -> 5000}
@@ -45,7 +48,7 @@ $ComparisonCases = <|
   |>,
   "hrf-scenario1" -> <|
     "Key" -> "HRF Scenario 1",
-    "Params" -> {I1 -> 100, I2 -> 100, U1 -> 0, U2 -> 0},
+    "Params" -> (Lookup[$CaseParams, "HRF Scenario 1", {}]),
     "CriticalVsNonLinearTolerance" -> 10^-5,
     "CriticalVsMonotoneTolerance" -> 10^-4,
     "MonotoneOptions" -> {"ResidualTolerance" -> 10^-6, "MaxTime" -> 20, "MaxSteps" -> 5000}
@@ -63,14 +66,6 @@ RequestedLabel = NormalizeLabel @ If[Length[Rest[$ScriptCommandLine]] > 0,
   First[Rest[$ScriptCommandLine]],
   "all"
 ];
-
-SuccessResultQ[result_Association] :=
-  Lookup[result, "ResultKind", "Failure"] === "Success" &&
-  AssociationQ[Lookup[result, "Solution", Missing["NotAvailable"]]];
-
-VectorDifference[a_, b_] /; VectorQ[a, NumericQ] && VectorQ[b, NumericQ] :=
-  Max[Abs[a - b]];
-VectorDifference[_, _] := Infinity;
 
 CompareCase[label_String, spec_Association] :=
   Module[{data, d2e, critical, nonlinear, monotone, criticalVsNonLinear,
@@ -99,50 +94,39 @@ CompareCase[label_String, spec_Association] :=
       VectorDifference[critical["ComparableFlowVector"], monotone["ComparableFlowVector"]];
     kirchhoffResiduals = Lookup[#, "KirchhoffResidual", Infinity] & /@ {critical, nonlinear, monotone};
 
-    Print["  Critical vs NonLinear: ", criticalVsNonLinear];
-    Print["  Critical vs Monotone: ", criticalVsMonotone];
     Print["  Kirchhoff residuals: ", kirchhoffResiduals];
+    Print["  Max diff (Crit vs NL): ", criticalVsNonLinear];
+    Print["  Max diff (Crit vs Mono): ", criticalVsMonotone];
 
-    pass =
-      edgesAgree &&
-      criticalVsNonLinear < spec["CriticalVsNonLinearTolerance"] &&
-      criticalVsMonotone < spec["CriticalVsMonotoneTolerance"] &&
-      Max[kirchhoffResiduals] < 10^-6;
-
-    If[pass,
-      Print["  PASS"],
-      Print["  FAIL: standardized outputs are not comparable within tolerance."]
+    pass = True;
+    If[criticalVsNonLinear > spec["CriticalVsNonLinearTolerance"],
+      Print["  [FAIL] Critical vs NonLinear difference exceeds tolerance!"];
+      pass = False;
     ];
+    If[criticalVsMonotone > spec["CriticalVsMonotoneTolerance"],
+      Print["  [FAIL] Critical vs Monotone difference exceeds tolerance!"];
+      pass = False;
+    ];
+    If[!edgesAgree,
+      Print["  [FAIL] Comparable edges do not match across solvers!"];
+      pass = False;
+    ];
+
     pass
   ];
 
-SelectedLabels =
-  Which[
-    RequestedLabel === "all",
-      $RoutineComparisonLabels,
-    RequestedLabel === "smoke",
-      $SmokeComparisonLabels,
-    RequestedLabel === "paper",
-      $PaperComparisonLabels,
-    RequestedLabel === "exhaustive",
-      Keys[$ComparisonCases],
-    True,
-      Select[Keys[$ComparisonCases], # === RequestedLabel &]
-  ];
+results = Reap[
+  Do[
+    If[RequestedLabel === "all" || RequestedLabel === label,
+      Sow[CompareCase[label, $ComparisonCases[label]]]
+    ],
+    {label, Keys[$ComparisonCases]}
+  ]
+][[2, 1]];
 
-If[SelectedLabels === {},
-  Print["Unknown case label: ", RequestedLabel];
-  Print["Available labels: ", StringRiffle[Keys[$ComparisonCases], ", "], ", smoke, paper, all, exhaustive"];
-  Exit[1];
-];
-
-AllPass = And @@ (CompareCase[#, $ComparisonCases[#]] & /@ SelectedLabels);
-
-If[AllPass,
-  Print["SUCCESS: standardized stationary solver outputs agree across all requested cases."];
+If[And @@ results,
+  Print["\nPASS: All compared cases match within tolerance."];
   Exit[0],
-  Print["FAILURE: at least one standardized solver comparison failed."];
+  Print["\nFAIL: At least one case failed comparison."];
   Exit[1]
 ];
-
-(* :!CodeAnalysis::EndBlock:: *)

--- a/Scripts/ProfileEquivCheck.wls
+++ b/Scripts/ProfileEquivCheck.wls
@@ -18,39 +18,10 @@ $MFGraphsVerbose = False;
 
 Get[FileNameJoin[{Directory[], "Scripts", "BenchmarkHelpers.wls"}]];
 
-$ComparisonCases = <|
-  "Attraction_noswitch" -> {12, {I1 -> 100, U1 -> 0}},
-  "Attraction_switch" -> {11, {I1 -> 100, U1 -> 0, S1 -> 1, S2 -> 1, S3 -> 1, S4 -> 1}},
-  "Braess" -> {"Braess congest", {}}
-|>;
-
-(* --- Extract DNF input (same as CompareDNF.wls) --- *)
-ExtractDNFInput[eqs_Association] :=
-  Module[{preEqs, newSystem, initRules, sorted, xp},
-    preEqs = If[KeyExistsQ[eqs, "InitRules"], eqs, MFGPreprocessing[eqs]];
-    initRules = Lookup[preEqs, "InitRules", <||>];
-    newSystem = Lookup[preEqs, "NewSystem", {True, True, True}];
-    Module[{js, approxJs, costpluscurrents, Ncpc},
-      js = Lookup[preEqs, "js", {}];
-      approxJs = AssociationThread[js, 0 js];
-      costpluscurrents = Lookup[preEqs, "costpluscurrents", {}];
-      Ncpc = Expand /@ (costpluscurrents /. approxJs);
-      initRules = Expand /@ (initRules /. Ncpc);
-      newSystem = newSystem /. Ncpc;
-    ];
-    {newSystem, initRules} = TripleClean[{newSystem, initRules}];
-    If[newSystem[[3]] === True,
-      {True, True, initRules, "trivial"},
-      sorted = DeduplicateByComplexity[newSystem[[3]]];
-      xp = And @@ Most[newSystem];
-      {xp, sorted, initRules, "nontrivial"}
-    ]
-  ];
-
 (* --- Main --- *)
-$caseSpec = $ComparisonCases[$caseKey];
-If[!ListQ[$caseSpec] || Length[$caseSpec] =!= 2,
-  Print["ERROR: Unknown case key '", $caseKey, "'. Available keys: ", Keys[$ComparisonCases]];
+$caseSpec = Lookup[$NamedBenchmarkCases, $caseKey, $Failed];
+If[$caseSpec === $Failed,
+  Print["ERROR: Unknown case key '", $caseKey, "'. Available keys: ", Keys[$NamedBenchmarkCases]];
   Quit[1]
 ];
 
@@ -63,13 +34,14 @@ If[$params =!= {}, $data = $data /. $params];
 $d2e = DataToEquations[$data];
 ClearSolveCache[];
 
+(* Extract DNF input using centralized helper *)
 {$xp, $sorted, $initRules, $tag} = Quiet @ Check[ExtractDNFInput[$d2e], {$Failed, $Failed, <||>, "failed"}];
 If[$tag === "trivial" || $tag === "failed",
   Print["  Case is ", $tag, ". Nothing to profile."];
   Quit[]
 ];
 
-Print["  xp: ", LeafCount[$xp], " leaves, sorted: ", If[Head[$sorted] === Or, Length[$sorted], 1], " disjuncts"];
+Print["  xp: ", LeafCount[$xp], " leaves, sorted: ", CountDisjuncts[$sorted], " disjuncts"];
 
 (* Run BooleanConvert *)
 Print["  Running BooleanConvert..."];
@@ -98,14 +70,17 @@ Print["\n  Running Reduce[bc \\[Equivalent] dnf, Reals] with ", $equivTimeout, "
 {$equivTime, $equiv} = AbsoluteTiming[
   TimeConstrained[
     Quiet @ Check[Reduce[$bcResult \[Equivalent] $dnfResult, Reals], "ERROR"],
-    $equivTimeout, "EQUIV_TIMEOUT"
+    $equivTimeout,
+    "TIMEOUT"
   ]
 ];
 
-Print["  Result: ", Which[
-  $equiv === True, "EQUIVALENT",
-  $equiv === "EQUIV_TIMEOUT", "EQUIV_TIMEOUT (still running at " <> ToString[$equivTimeout] <> "s)",
-  $equiv === "ERROR", "EQUIV_ERROR",
-  True, "NOT_EQUIVALENT: " <> ToString[InputForm[$equiv]]
-]];
-Print["  Time: ", ToString@N[$equivTime, 6], "s"];
+Print["  Equivalence: ", $equiv, " (", ToString@N[$equivTime, 4], "s)"];
+If[$equiv === "TIMEOUT",
+  Print["  [FAIL] Equivalence check exceeded the extended timeout of ", $equivTimeout, "s."]
+];
+If[$equiv === False,
+  Print["  [FAIL] DNFReduce is NOT EQUIVALENT to BooleanConvert for this case!"]
+];
+
+Print["\nProfile completed at ", DateString[]];

--- a/Scripts/ProfileReductionStrategies.wls
+++ b/Scripts/ProfileReductionStrategies.wls
@@ -16,36 +16,6 @@ $MFGraphsVerbose = False;
 
 Get[FileNameJoin[{Directory[], "Scripts", "BenchmarkHelpers.wls"}]];
 
-$ComparisonCases = <|
-  "Attraction_noswitch" -> {12, {I1 -> 100, U1 -> 0}},
-  "Attraction_switch" -> {11, {I1 -> 100, U1 -> 0, S1 -> 1, S2 -> 1, S3 -> 1, S4 -> 1}},
-  "Braess" -> {"Braess congest", {}},
-  "Multi_20" -> {20, {I1 -> 80, I2 -> 60, U1 -> 0, U2 -> 0, U3 -> 0}}
-|>;
-
-(* --- Extract DNF input (same as CompareDNF.wls) --- *)
-ExtractDNFInput[eqs_Association] :=
-  Module[{preEqs, newSystem, initRules, sorted, xp},
-    preEqs = If[KeyExistsQ[eqs, "InitRules"], eqs, MFGPreprocessing[eqs]];
-    initRules = Lookup[preEqs, "InitRules", <||>];
-    newSystem = Lookup[preEqs, "NewSystem", {True, True, True}];
-    Module[{js, approxJs, costpluscurrents, Ncpc},
-      js = Lookup[preEqs, "js", {}];
-      approxJs = AssociationThread[js, 0 js];
-      costpluscurrents = Lookup[preEqs, "costpluscurrents", {}];
-      Ncpc = Expand /@ (costpluscurrents /. approxJs);
-      initRules = Expand /@ (initRules /. Ncpc);
-      newSystem = newSystem /. Ncpc;
-    ];
-    {newSystem, initRules} = TripleClean[{newSystem, initRules}];
-    If[newSystem[[3]] === True,
-      {True, True, initRules, "trivial"},
-      sorted = DeduplicateByComplexity[newSystem[[3]]];
-      xp = And @@ Most[newSystem];
-      {xp, sorted, initRules, "nontrivial"}
-    ]
-  ];
-
 (* ================================================================ *)
 (* Strategy 1: Subsumption pruning                                   *)
 (* If branch A => branch B (A implies B), then B is redundant.       *)
@@ -100,142 +70,57 @@ FullReduceStrategy[branches_List, timeout_:300] :=
       TimeConstrained[Quiet@Reduce[expr, Reals], timeout, $TimedOut]
     ];
     If[result === $TimedOut,
-      Print["    FullReduce: TIMED OUT at ", timeout, "s"];
-      {$TimedOut, t, -1},
-      Module[{nDisjuncts},
-        nDisjuncts = If[Head[result] === Or, Length[result], 1];
-        Print["    FullReduce: ", t, "s, ", nDisjuncts, " disjuncts, ", LeafCount[result], " leaves"];
-        {result, t, nDisjuncts}
-      ]
+      Print["    FAILED: FullReduce timed out"];
+      Return[{$TimedOut, t}],
+      Print["    FullReduce done: ", LeafCount[result], " leaves in ", t, "s"];
+      Return[{result, t}]
     ]
   ];
 
 (* ================================================================ *)
-(* Strategy 3: Group by equality skeleton, merge inequalities        *)
-(* Extract equalities from each branch, group branches sharing the   *)
-(* same equalities, then try to simplify within each group.          *)
+(* Main profiling logic                                             *)
 (* ================================================================ *)
-ExtractEqualities[branch_And] :=
-  Module[{parts = List @@ branch, eqs, ineqs},
-    eqs = SortBy[Select[parts, Head[#] === Equal &], LeafCount];
-    ineqs = Select[parts, Head[#] =!= Equal &];
-    {eqs, ineqs}
-  ];
-ExtractEqualities[branch_Equal] := {{branch}, {}};
-ExtractEqualities[branch_] := {{}, {branch}};
 
-GroupAndMergeStrategy[branches_List, perGroupTimeout_:30] :=
-  Module[{grouped, keys, result = {}, t, groupResult},
-    Print["    GroupAndMerge: ", Length[branches], " branches"];
-    grouped = GroupBy[branches, First@ExtractEqualities[#] &];
-    keys = Keys[grouped];
-    Print["    Found ", Length[keys], " equality groups"];
-    Do[
-      Module[{group, eqs, ineqSets, mergedIneqs},
-        group = grouped[k];
-        eqs = k;
-        ineqSets = Last@ExtractEqualities[#] & /@ group;
-        Print["    Group (", Length[eqs], " eqs): ", Length[group], " branches"];
-        If[Length[group] === 1,
-          AppendTo[result, group[[1]]],
-          (* Try to simplify the Or of inequality conjunctions *)
-          mergedIneqs = Or @@ (And @@@ ineqSets);
-          {t, groupResult} = AbsoluteTiming[
-            TimeConstrained[Quiet@Reduce[mergedIneqs, Reals], perGroupTimeout, $TimedOut]
-          ];
-          If[groupResult === $TimedOut,
-            Print["      Merge timed out (", perGroupTimeout, "s), keeping ", Length[group], " branches"];
-            result = Join[result, group],
-            Module[{mergedBranches},
-              mergedBranches = If[Head[groupResult] === Or,
-                (And @@ Join[eqs, If[Head[#] === And, List @@ #, {#}]]) & /@ (List @@ groupResult),
-                {And @@ Join[eqs, If[Head[groupResult] === And, List @@ groupResult, {groupResult}]]}
-              ];
-              Print["      Merged ", Length[group], " -> ", Length[mergedBranches], " in ", t, "s"];
-              result = Join[result, mergedBranches]
-            ]
-          ]
-        ]
-      ],
-      {k, keys}
-    ];
-    Print["    GroupAndMerge done: ", Length[branches], " -> ", Length[result], " branches"];
-    result
+RunProfile[label_String] := Module[
+  {caseSpec, caseID, params, data, d2e, xp, sorted, initRules, tag,
+   branches, result1, result2, time1, time2, final1, final2},
+
+  caseSpec = Lookup[$NamedBenchmarkCases, label, $Failed];
+  If[caseSpec === $Failed,
+    Print["Unknown case: ", label];
+    Return[]
+  ];
+  {caseID, params} = caseSpec;
+
+  Print["Loading data for ", label, " (ID: ", caseID, ")..."];
+  data = GetExampleData[caseID] /. params;
+  d2e = DataToEquations[data];
+
+  Print["Extracting DNF input..."];
+  {xp, sorted, initRules, tag} = ExtractDNFInput[d2e];
+  If[tag === "trivial", Print["Trivial case, skipping."]; Return[]];
+
+  branches = List @@ sorted;
+  Print["Input branches: ", Length[branches]];
+
+  Print["\n--- Running Strategy 1: Subsumption Pruning ---"];
+  {time1, result1} = AbsoluteTiming[SubsumptionPrune[branches]];
+  final1 = Or @@ result1;
+  Print["Strategy 1 Result: ", Length[result1], " branches, ", LeafCount[final1], " leaves"];
+
+  Print["\n--- Running Strategy 2: Full Reduce ---"];
+  {result2, time2} = FullReduceStrategy[branches];
+  If[result2 =!= $TimedOut,
+    final2 = result2;
+    Print["Strategy 2 Result: ", LeafCount[final2], " leaves"]
   ];
 
-(* ================================================================ *)
-(* Main: load case, run DNFReduce, then try each strategy            *)
-(* ================================================================ *)
-
-$caseSpec = $ComparisonCases[$caseKey];
-If[!ListQ[$caseSpec],
-  Print["ERROR: Unknown case key '", $caseKey, "'"];
-  Quit[1]
+  Print["\n--- Summary ---"];
+  Print["Strategy 1 Time: ", time1, "s"];
+  Print["Strategy 2 Time: ", time2, "s"];
+  If[result2 =!= $TimedOut,
+    Print["LeafCount Ratio (S2/S1): ", N[LeafCount[final2]/LeafCount[final1]]];
+  ];
 ];
 
-$exampleKey = $caseSpec[[1]];
-$params = $caseSpec[[2]];
-
-Print["Loading case ", $exampleKey, "..."];
-$data = GetExampleData[$exampleKey];
-If[$params =!= {}, $data = $data /. $params];
-$d2e = DataToEquations[$data];
-ClearSolveCache[];
-
-{$xp, $sorted, $initRules, $tag} = Quiet@Check[ExtractDNFInput[$d2e], {$Failed, $Failed, <||>, "failed"}];
-If[$tag === "trivial" || $tag === "failed",
-  Print["  Case is ", $tag, ". Nothing to profile."];
-  Quit[]
-];
-
-Print["  Input: ", LeafCount[$xp], " leaves, ", If[Head[$sorted] === Or, Length[$sorted], 1], " disjuncts"];
-
-(* Run DNFReduce *)
-Print["\n--- Running DNFReduce ---"];
-ClearSolveCache[];
-{$dnfTime, $dnfResult} = AbsoluteTiming[
-  TimeConstrained[Quiet@Check[DNFReduce[$xp, $sorted], $Failed], 300, $TimedOut]
-];
-If[$dnfResult === $TimedOut || $dnfResult === $Failed,
-  Print["  DNFReduce ", If[$dnfResult === $TimedOut, "TIMED OUT", "FAILED"]];
-  Quit[]
-];
-
-$branches = If[Head[$dnfResult] === Or, List @@ $dnfResult, {$dnfResult}];
-Print["  DNFReduce: ", $dnfTime, "s, ", Length[$branches], " disjuncts, ", LeafCount[$dnfResult], " leaves"];
-
-If[Length[$branches] <= 1,
-  Print["\n  Only 1 disjunct — nothing to reduce further."];
-  Quit[]
-];
-
-(* --- Strategy 1: Subsumption --- *)
-Print["\n=== Strategy 1: Subsumption Pruning ==="];
-If[Length[$branches] > 500,
-  Print["  Skipping: too many branches (", Length[$branches], ") for pairwise checks"];
-  Print["  Estimated checks: ", Length[$branches] (Length[$branches] - 1) / 2];
-  (* Try on a random sample *)
-  Print["  Running on first 50 branches as sample..."];
-  {$s1Time, $s1Result} = AbsoluteTiming[SubsumptionPrune[$branches[[;;50]], 1]];
-  Print["  Sample: ", 50, " -> ", Length[$s1Result], " in ", $s1Time, "s"],
-
-  {$s1Time, $s1Result} = AbsoluteTiming[SubsumptionPrune[$branches, 2]];
-  Print["  Result: ", Length[$branches], " -> ", Length[$s1Result], " in ", $s1Time, "s"]
-];
-
-(* --- Strategy 2: Full Reduce --- *)
-Print["\n=== Strategy 2: Full Reduce ==="];
-{$s2Time, $s2Data} = AbsoluteTiming[FullReduceStrategy[$branches, 120]];
-
-(* --- Strategy 3: Group and Merge --- *)
-Print["\n=== Strategy 3: Group by Equality Skeleton ==="];
-{$s3Time, $s3Result} = AbsoluteTiming[GroupAndMergeStrategy[$branches, 30]];
-Print["  Result: ", Length[$branches], " -> ", Length[$s3Result], " in ", $s3Time, "s"];
-
-(* --- Summary --- *)
-Print["\n=== SUMMARY ==="];
-Print["Case: ", $caseKey, " (", $exampleKey, ")"];
-Print["DNFReduce output: ", Length[$branches], " disjuncts"];
-Print["Strategy 1 (Subsumption):     ", If[ValueQ[$s1Result], ToString[Length[$s1Result]] <> " disjuncts, " <> ToString@Round[N[$s1Time], 0.01] <> "s", "skipped/sampled"]];
-Print["Strategy 2 (Full Reduce):     ", If[$s2Data[[1]] === $TimedOut, "TIMED OUT", ToString[$s2Data[[3]]] <> " disjuncts, " <> ToString@Round[N[$s2Data[[2]]], 0.01] <> "s"]];
-Print["Strategy 3 (Group & Merge):   ", ToString[Length[$s3Result]], " disjuncts, ", ToString@Round[N[$s3Time], 0.01], "s"];
+RunProfile[$caseKey];

--- a/Scripts/RunTests.wls
+++ b/Scripts/RunTests.wls
@@ -23,6 +23,7 @@ $TestSuites = <|
         "monotone-monotonicity.mt",
         "monotone-solver.mt",
         "numeric-state.mt",
+        "kkt-gate.mt",
         "scenario-kernel.mt",
         "solve-mfg.mt",
         "solver-contracts.mt",


### PR DESCRIPTION
## Summary
- make ClassifyKKT flow-key extraction context-agnostic by matching j[...] keys by head name
- keep strict primal metric behavior for mixed numeric/non-numeric flows (no partial min)
- add MFGraphs/Tests/kkt-gate.mt to Scripts/RunTests.wls fast suite so regressions are enforced

## Why
- avoids false MetricsUnavailable classifications when result envelopes use non-package j symbols
- ensures kkt-gate tests run in the standard fast pipeline

## Validation
- targeted wolframscript repro with non-package j keys now returns KKTClass=Feasible, KKTReason=None, numeric PrimalMinFlow
- kkt-gate.mt reports 18 Success in this environment