### PR TITLE
Add planning docs and update solve-mfg test

### DIFF
--- a/MFGraphs/Tests/solve-mfg.mt
+++ b/MFGraphs/Tests/solve-mfg.mt
@@ -1,6 +1,18 @@
 (* Wolfram Language Test file *)
 (* Thin-routing tests for SolveMFG (phase 1 unified API). *)
 
+If[!MemberQ[$Packages, "MFGraphs`"],
+    Get[
+        FileNameJoin[
+            {
+                DirectoryName[$InputFileName],
+                "..",
+                "MFGraphs.wl"
+            }
+        ]
+    ]
+];
+
 Test[
     Module[{data, result},
         data = GetExampleData[7] /. {I1 -> 100, U1 -> 0, U2 -> 0};

--- a/docs/planning/issue_86_scenario_kernel.md
+++ b/docs/planning/issue_86_scenario_kernel.md
@@ -1,0 +1,32 @@
+## Summary
+MFGraphs should adopt a **typed scenario kernel** modeled on the validate-then-complete object pattern used in `gridtools.m`. The target is a scenario lifecycle of:
+
+`makeScenario -> validateScenario -> completeScenario -> scenario[...]`
+
+This should become the canonical entry point for defining cases, instead of relying on ad hoc example records and script-local assumptions.
+
+## Why this matters
+- A typed `scenario[...]` wrapper gives downstream code a stable contract and avoids running solvers on raw, partially formed associations.
+- A validate-then-complete workflow creates one canonical internal representation for benchmarks, solvers, graphics, and docs.
+- The current refactor roadmap depends on this kernel: benchmark cleanup, solver segregation, and graphics cleanup all become easier once scenarios are first-class objects.
+
+## Scope
+- define the public planning contract for `makeScenario`, `validateScenario`, `completeScenario`, and `scenarioQ`
+- define the canonical nested blocks for a scenario object, including at least `Model`, `Data`, `Validation`, `Benchmark`, `Visualization`, and `Inheritance`
+- decide which scenario fields may be values versus callables, and how validation should check admissibility
+- define how completed scenarios receive stable identity metadata such as scenario hashes or canonical-version markers
+- keep this issue focused on the **scenario kernel**, not full migration of all existing examples
+
+## Deliverables
+- a design brief for the scenario kernel
+- a canonical scenario schema proposal aligned with MFGraphs needs
+- a clear typed-object contract for downstream consumers
+
+## Out of scope
+- full migration of all benchmark cases
+- full benchmark runner rewrite
+- moving graphics helpers into the public API
+
+## Related issues
+- This is the architectural prerequisite for a scenario catalog and scenario-based benchmark runner.
+- Related to #82, #83, and #25, but not covered by them.

--- a/docs/planning/issue_87_scenario_catalog.md
+++ b/docs/planning/issue_87_scenario_catalog.md
@@ -1,0 +1,31 @@
+## Summary
+After the scenario kernel is defined, MFGraphs should add a **scenario catalog** that registers named scenarios and supports controlled migration away from the current example-definition style.
+
+The first migration wave should stay intentionally small and representative: one core benchmark case and one inconsistent-switching case first, with a paper-tier scenario only after the kernel assumptions are stable.
+
+## Why this matters
+- A catalog makes benchmark selection, documentation, and example discovery queryable by name, tier, tags, and eligibility.
+- It provides a clean replacement for script-local case lists and scattered example metadata.
+- It creates the bridge between the scenario kernel and a future benchmark v2 workflow.
+
+## Scope
+- define a `scenarioCatalog[]` or equivalent registry concept for named scenarios
+- define `scenarioByName[...]` and the resolution rules for retrieving a canonical scenario object
+- define a `deriveScenario[...]` planning contract for parent-child variants
+- require lineage-aware metadata for derived scenarios, including parent identity and scenario-hash provenance
+- migrate a minimal representative set first: a core 4x4-type case and an inconsistent-switching case; treat a paper-tier case as the next migration wave
+- define a recursive merge policy for inheritance so nested blocks are not accidentally overwritten wholesale
+
+## Deliverables
+- a scenario catalog design note
+- a migration checklist for representative scenarios
+- a clear parent-child lineage policy for derived scenarios
+
+## Out of scope
+- bulk migration of the full examples library in one pass
+- solver implementation changes beyond the catalog contract
+
+## Related issues
+- Depends on the scenario kernel issue.
+- Enables a scenario-driven benchmark runner and documentation cleanup.
+- Related to #82 and #83, but distinct from both.

--- a/docs/planning/mfgraphs_scenario_schema_proposal.md
+++ b/docs/planning/mfgraphs_scenario_schema_proposal.md
@@ -1,0 +1,313 @@
+# Proposed MFGraphs Scenario Schema
+
+This note proposes a **scenario-object architecture** for MFGraphs inspired by the design pattern used in `gridtools.m`: a raw specification is validated, completed into a canonical representation, and then consumed by downstream computational layers.
+
+## Design objective
+
+The central objective is to make every MFGraphs case a **first-class scenario object** rather than an ad hoc bundle of graph data, parameters, and benchmark-specific metadata. The scenario should be the single authoritative source for equation generation, solver dispatch, benchmarking, visualization, and documentation.
+
+| Design principle | Meaning for MFGraphs |
+|---|---|
+| **Canonical schema** | Every scenario resolves to one stable internal representation |
+| **Validate then complete** | Authors may write compact specs, but execution uses completed canonical objects |
+| **Inheritance** | Variants can derive from parent scenarios and override only selected fields |
+| **Derived artifacts are separate** | Equations, solver results, and plots should not be stored as raw case definitions |
+| **Explicit metadata** | Tier, tags, assumptions, and expected properties should live with the scenario |
+
+## Recommended object lifecycle
+
+The most important architectural lesson from `gridtools.m` is the lifecycle:
+
+> raw spec -> validator -> completer -> canonical object -> derived computational objects
+
+For MFGraphs, I recommend the following analogous lifecycle.
+
+| Stage | Suggested MFGraphs function | Output |
+|---|---|---|
+| Authoring | `makeScenario[assoc]` | User-facing scenario constructor |
+| Validation | `validateScenario[assoc]` | Boolean plus diagnostics |
+| Completion | `completeScenario[assoc]` | Canonical scenario association |
+| Wrapping | `Scenario[assoc]` or equivalent typed wrapper | Stable typed object |
+| Equation derivation | `makeEquationSystem[scenario]` or `DataToEquations[scenario]` | Equation-system object |
+| Solver derivation | `solveScenario[scenario, stage]` | Solver-result object |
+| Benchmark derivation | `benchmarkScenario[scenario, opts]` | Normalized benchmark result |
+| Graphics derivation | `scenarioPlots[scenario, result]` | Graphics/visualization objects |
+
+This lifecycle keeps case definition concerns separate from solver internals and benchmark orchestration.
+
+## Proposed canonical scenario schema
+
+I recommend dividing the schema into field groups. Some fields are **required authoring fields**, while others are **completed or derived fields** added automatically.
+
+### 1. Identity and catalog metadata
+
+These fields make the scenario addressable inside benchmarks, papers, tests, and documentation.
+
+| Field | Required | Purpose |
+|---|---|---|
+| `"Name"` | Yes | Stable machine-readable identifier |
+| `"DisplayName"` | No | Human-readable label for tables and plots |
+| `"ScenarioGroup"` | No | Family label, such as `"Core"`, `"Paper"`, or `"Switching"` |
+| `"Tier"` | No | Benchmark tier such as `"core"`, `"large"`, `"paper"` |
+| `"Tags"` | No | Search/filter tags |
+| `"Description"` | No | Short prose summary |
+| `"Source"` | No | Provenance, e.g. paper section, example source, or benchmark family |
+| `"Version"` | No | Optional semantic revision marker |
+
+### 2. Structural model definition
+
+These fields define the mathematical scenario itself.
+
+| Field | Required | Purpose |
+|---|---|---|
+| `"Network"` | Yes | Canonical graph/network description |
+| `"States"` | Optional | Explicit state list if not derivable from the network |
+| `"Transitions"` | Optional | Explicit transition list if not derivable |
+| `"Modes"` | Optional | Population classes, regimes, or agent types |
+| `"TimeDomain"` | Optional | Horizon or temporal structure |
+| `"Populations"` | Optional | Population specifications when multi-population is supported |
+| `"BoundaryConditions"` | Optional | Terminal, initial, or boundary data |
+
+The exact split between `"Network"`, `"States"`, and `"Transitions"` should depend on how much can be derived automatically. The better pattern is to store one authoritative structural representation and derive the rest during completion.
+
+### 3. Model data and economics
+
+These fields capture the costs and parameters that drive equation construction.
+
+| Field | Required | Purpose |
+|---|---|---|
+| `"RunningCost"` | Usually | Cost structure used in HJB or flow equations |
+| `"TerminalCost"` | Optional | Terminal objective data |
+| `"SwitchingCosts"` | Optional | Switching or transition cost specification |
+| `"CongestionData"` | Optional | Congestion coefficients, capacities, or related model parameters |
+| `"Demand"` | Optional | Demand, mass, or forcing data |
+| `"Parameters"` | No | General scalar/vector parameter association |
+| `"Assumptions"` | No | Symbolic assumptions used by simplification or solver routines |
+
+I strongly recommend collecting numerically meaningful constants under `"Parameters"`, while keeping large structural objects such as switching-cost maps and congestion models in dedicated fields.
+
+### 4. Validation and expected properties
+
+This group is where MFGraphs can encode known scenario-level invariants and expected behavior.
+
+| Field | Required | Purpose |
+|---|---|---|
+| `"ExpectedConsistency"` | No | Expected consistency status for switching or structural checks |
+| `"ExpectedProperties"` | No | Known properties such as symmetry, monotonicity, or inconsistency |
+| `"Eligibility"` | No | Which solvers or benchmark stages apply |
+| `"KnownIssues"` | No | Explicit caveats for documentation and benchmarking |
+| `"ReferenceResults"` | No | Historical expected outputs, timings, or structural summaries |
+
+This field group is especially useful for your recent inconsistent-switching examples, because the scenario can directly declare the expectation that consistency should fail and that extra alternative-flow structure should appear.
+
+### 5. Benchmark and workflow metadata
+
+These fields help centralize benchmark handling instead of scattering it across scripts.
+
+| Field | Required | Purpose |
+|---|---|---|
+| `"Benchmark"` | No | Benchmark-specific metadata bundle |
+| `"DefaultStages"` | No | Recommended stages such as `DataToEquations` or `CriticalCongestion` |
+| `"Timeouts"` | No | Suggested per-stage timeouts |
+| `"IsolationMode"` | No | Preferred execution mode for benchmarks |
+| `"ResultLabels"` | No | Stable labels for CSV/JSON export |
+
+A good design is for `"Benchmark"` itself to be a nested association, rather than flattening every operational field into the top level.
+
+### 6. Visualization metadata
+
+These fields allow plots to be driven by scenario metadata rather than by notebook-local conventions.
+
+| Field | Required | Purpose |
+|---|---|---|
+| `"Visualization"` | No | Nested defaults for layout, colors, ordering, and labels |
+| `"PlotLabels"` | No | Scenario-specific naming for states, edges, or controls |
+| `"DisplayOrder"` | No | Stable ordering for tables and charts |
+| `"PublicationStyle"` | No | Defaults for publication-ready rendering |
+
+This helps move graphics logic out of `GettingStarted.wl` and into a reusable layer.
+
+### 7. Inheritance and derivation metadata
+
+This is the part most directly inspired by the parent-child pattern in `gridtools.m`.
+
+| Field | Required | Purpose |
+|---|---|---|
+| `"ParentScenario"` | No | Reference to base scenario |
+| `"Overrides"` | No | Explicit override record for changed fields |
+| `"DerivedFrom"` | No | Provenance string or symbolic link to a scenario family |
+| `"VariantKind"` | No | E.g. `"BenchmarkVariant"`, `"PaperVariant"`, `"InconsistentSwitchingVariant"` |
+
+The key rule should be that inherited scenarios are still completed into the **same canonical schema** as standalone scenarios.
+
+## Suggested canonical top-level shape
+
+A practical top-level schema could look like this.
+
+```wl
+<|
+  "Name" -> "Grid0404",
+  "DisplayName" -> "4x4 Grid",
+  "ScenarioGroup" -> "Large",
+  "Tier" -> "large",
+  "Tags" -> {"grid", "benchmark", "switching"},
+  "Description" -> "Large benchmark grid scenario.",
+
+  "Model" -> <|
+    "Network" -> ..., 
+    "Modes" -> ...,
+    "TimeDomain" -> ...,
+    "BoundaryConditions" -> ...
+  |>,
+
+  "Data" -> <|
+    "RunningCost" -> ...,
+    "TerminalCost" -> ...,
+    "SwitchingCosts" -> ...,
+    "CongestionData" -> ...,
+    "Demand" -> ...,
+    "Parameters" -> <||>,
+    "Assumptions" -> True
+  |>,
+
+  "Validation" -> <|
+    "ExpectedConsistency" -> True,
+    "ExpectedProperties" -> {},
+    "Eligibility" -> <|
+      "DataToEquations" -> True,
+      "CriticalCongestion" -> True,
+      "NonLinearSolver" -> True,
+      "Monotone" -> False
+    |>,
+    "KnownIssues" -> {}
+  |>,
+
+  "Benchmark" -> <|
+    "DefaultStages" -> {"DataToEquations", "CriticalCongestion"},
+    "Timeouts" -> <|"CriticalCongestion" -> 120|>,
+    "IsolationMode" -> "Process"
+  |>,
+
+  "Visualization" -> <|
+    "PlotLabels" -> <||>,
+    "DisplayOrder" -> Automatic,
+    "PublicationStyle" -> "Default"
+  |>,
+
+  "Inheritance" -> <|
+    "ParentScenario" -> None,
+    "Overrides" -> <||>,
+    "VariantKind" -> None
+  |>,
+
+  "Derived" -> <|
+    "ScenarioHash" -> ...,
+    "CanonicalVersion" -> 1
+  |>
+|>
+```
+
+I recommend this **nested** structure over a flat one, because it separates semantic roles cleanly and makes documentation easier. The top level should remain compact, while each subsystem reads only the nested block it needs.
+
+## Constructor and helper API
+
+The schema becomes much more useful if it is paired with a small public API.
+
+| Function | Role |
+|---|---|
+| `makeScenario[assoc_]` | Public constructor from raw authoring spec |
+| `validateScenario[assoc_]` | Shape and semantic validation |
+| `completeScenario[assoc_]` | Fill defaults, derive metadata, normalize fields |
+| `scenarioQ[obj_]` | Predicate for typed scenario objects |
+| `scenarioCatalog[]` | Return registry of named scenarios |
+| `scenarioByName[name_]` | Resolve one scenario from registry |
+| `deriveScenario[parent_, overrides_]` | Create a variant from a base scenario |
+
+This is the direct analogue of the `makeGrid` / `validateGrid` / `completeGrid` pattern.
+
+## Recommended inheritance model
+
+I would keep inheritance intentionally simple at first. A derived scenario should reference a parent and provide only a shallow override association. Completion should merge parent and child definitions, then re-run validation on the completed result.
+
+| Inheritance rule | Recommendation |
+|---|---|
+| Parent lookup | Resolve parent before validation of derived fields |
+| Merge policy | Deep merge nested associations by key |
+| Validation timing | Validate both override shape and final merged scenario |
+| Provenance | Preserve `ParentScenario` and explicit `Overrides` |
+| Derived metadata | Recompute hashes, derived defaults, and benchmark hints after merge |
+
+This will let you define families of cases without duplicating full records.
+
+## Scenario categories that would benefit immediately
+
+Several existing MFGraphs workflows appear to map naturally onto this schema.
+
+| Current MFGraphs need | Scenario-schema benefit |
+|---|---|
+| Core benchmark cases | Stable `Tier`, `Tags`, and `Benchmark` metadata |
+| Paper scenarios | Better `DisplayName`, `Source`, and publication metadata |
+| Inconsistent-switching examples | Direct `ExpectedConsistency -> False` and expected-structure annotations |
+| Large process-isolated cases | Benchmark defaults live with the scenario instead of in runner branches |
+| Getting-started examples | Clean visualization and description metadata |
+
+## Separation from downstream artifacts
+
+One of the most important structural rules should be that scenarios do **not** directly store full solver outputs or benchmark tables as part of the canonical definition. Those should be separate derived objects.
+
+| Object | What it should contain |
+|---|---|
+| `Scenario[...]` | Canonical model definition and metadata |
+| `EquationSystem[...]` | Variables, equations, and structural summaries |
+| `SolverResult[...]` | Stage-specific output and diagnostics |
+| `BenchmarkResult[...]` | Timings, statuses, and export-ready metadata |
+| `VisualizationResult[...]` | Generated graphics or plot specifications |
+
+That separation will help answer your later question about whether `MFGSystemSolver` belongs in equation generation or the solver layer.
+
+## Minimal migration strategy
+
+I recommend a staged migration rather than a one-shot rewrite.
+
+| Step | Action |
+|---|---|
+| 1 | Define `makeScenario`, `validateScenario`, and `completeScenario` |
+| 2 | Create the canonical schema and nested field groups |
+| 3 | Migrate three representative cases: one core case, one inconsistent-switching case, and one paper case |
+| 4 | Add compatibility wrappers so current benchmark and solver code can still consume old case definitions temporarily |
+| 5 | Move benchmark selection to use scenario catalog queries by tier/tag/name |
+| 6 | Update documentation and graphics utilities to consume scenario metadata |
+
+This minimizes disruption and keeps the refactor testable.
+
+## Recommended first implementation scope
+
+To keep the first step small, I would initially implement only the following required authoring fields:
+
+| Initial required fields | Reason |
+|---|---|
+| `"Name"` | Stable identifier |
+| `"Model" -> "Network"` | Core structural input |
+| `"Data" -> "RunningCost"` | Essential model content |
+| `"Data" -> "SwitchingCosts"` | Essential for your current scenario families |
+| `"Benchmark" -> "DefaultStages"` | Immediate benchmark usefulness |
+
+Everything else can be completed by defaults or added gradually.
+
+## Recommendation
+
+The best MFGraphs adaptation of `gridtools.m` is **not** to copy its exact code style, but to adopt its object discipline: canonical validated records, explicit completion, optional inheritance, and strict separation between source objects and derived computational objects. If you do that, the later cleanup of benchmarks, solver boundaries, graphics, and documentation will become much easier.
+
+## Suggested immediate next step
+
+The next practical step should be to draft a first `Scenario` API file with:
+
+| Item | Purpose |
+|---|---|
+| `makeScenario` | Public constructor |
+| `validateScenario` | Schema and semantic checks |
+| `completeScenario` | Defaulting and canonicalization |
+| `scenarioCatalog` | Central registry of named scenarios |
+| `deriveScenario` | Parent-child variant creation |
+
+Once that exists, you can migrate a very small subset of cases and let the benchmark reorganization follow from the new schema.

--- a/docs/planning/revised_mfgraphs_plan_response.md
+++ b/docs/planning/revised_mfgraphs_plan_response.md
@@ -1,0 +1,108 @@
+# Revised MFGraphs Refactor Plan
+
+This revision incorporates your feedback and stays strictly at the **planning** level. The main adjustment is that the earlier roadmap should lean more explicitly into the `gridtools.m` pattern by treating scenarios as **typed, validated objects** rather than only as canonical associations.
+
+## Architectural revision
+
+The most important refinement is that the future MFGraphs case layer should revolve around a **typed scenario object**, written conceptually as `scenario[<|...|>]`. The association remains the canonical payload, but the wrapper becomes the contract that downstream code consumes. This makes it possible for solver and benchmark entry points to accept only validated scenario objects, just as `gridtools.m` uses typed wrappers to separate raw input from completed domain objects.
+
+| Revised principle | Planning implication |
+|---|---|
+| **Typed wrapper** | Downstream functions should target `scenario[...]`, not raw associations |
+| **Validate then complete** | Scenario authoring remains flexible, but execution always uses canonical completed objects |
+| **Lineage-aware inheritance** | Derived scenarios should preserve parent identity and override provenance |
+| **Callable data support** | Data fields such as `RunningCost` should be allowed to be values or functions |
+| **Solver as consumer** | `MFGSystemSolver` should consume scenarios rather than define them |
+
+## Revised scenario-model direction
+
+The schema proposal should be refined in three concrete ways.
+
+First, the wrapper should be explicit. Instead of thinking only in terms of `makeScenario` returning an association, the planning target should be a constructor pipeline that produces `scenario[completedAssoc]`. This supports stricter interfaces such as `solveScenario[s_scenario]` and reduces accidental execution on partially formed case data.
+
+Second, inheritance should carry **lineage metadata**. The earlier `Inheritance` block should be extended conceptually to preserve a parent identifier and a parent scenario hash. The purpose is not just provenance, but also reproducibility: benchmark tooling can detect whether a derived scenario is materially distinct from its parent or only cosmetically renamed.
+
+Third, the `Data` block should explicitly allow **coordinate-aware or callable specifications**. In other words, fields like `RunningCost` should be permitted to be static values, vectors, or callables, provided the future validator checks that they are admissible for the intended discretization and evaluation pipeline.
+
+| Revised schema area | Added planning requirement |
+|---|---|
+| `scenario[...]` wrapper | Typed public object, not only a completed association |
+| `Inheritance` | Add lineage identity, including parent hash/provenance |
+| `Data` | Permit callable or coordinate-aware inputs where appropriate |
+| `Validation` | Include admissibility checks for callable fields |
+| `Benchmark` | Use scenario identity and lineage in run metadata |
+
+## Revised answer to the solver-boundary question
+
+Your feedback sharpens the answer to the earlier architectural question about `MFGSystemSolver`.
+
+> **`MFGSystemSolver` should be treated as a coordinator in the solver layer, not as part of scenario definition or equation-definition ownership.**
+
+That means the planning target should place it under a solver-oriented module structure. Conceptually, it should receive a validated `scenario[...]` object, invoke `DataToEquations` to obtain the symbolic system, and then dispatch to specialized solver families according to scenario eligibility and congestion regime.
+
+| Module area | Planned role |
+|---|---|
+| `Scenario` layer | Define, validate, complete, and catalog scenarios |
+| `DataToEquations` | Transform a completed scenario into an equation system |
+| `Solvers/MFGSystemSolver` | Coordinate stage selection and dispatch |
+| `Solvers/CriticalCongestionSolvers` | Critical-congestion-specific methods |
+| `Solvers/NonCriticalCongestionSolvers` | Non-critical-congestion-specific methods |
+
+This clarifies the ownership boundary: **scenario construction defines what the problem is; solver modules decide how to solve it**.
+
+## Revised roadmap
+
+The work should be reordered slightly so that the typed scenario kernel and registry are established before broader solver or benchmark refactors. This makes the benchmark and solver cleanup a downstream consequence of the scenario architecture rather than a parallel redesign.
+
+| Phase | Milestone | Revised planning focus |
+|---|---|---|
+| **1** | **Scenario Kernel** | Define the planning contract for `makeScenario`, `validateScenario`, `completeScenario`, and the `scenario[...]` typed wrapper |
+| **2** | **Scenario Registry** | Introduce a scenario catalog concept and migrate a very small representative set first |
+| **3** | **Solver Interface Cleanup** | Make `MFGSystemSolver` and related solver layers consume scenario objects |
+| **4** | **Benchmark v2** | Rebuild benchmark selection around catalog queries such as tier, tags, and eligibility |
+| **5** | **Graphics Reorganization** | Move visualization to a scenario-aware graphics layer |
+| **6** | **Documentation Audit** | Rewrite docs after the scenario and solver boundaries are stable |
+
+## Revised migration priority
+
+The first migrated scenarios should be chosen to stress the architecture in different ways. I agree with the direction implied by your feedback: the initial set should include one core benchmark case and one inconsistent-switching case. I would add one paper-tier case only after the kernel and registry assumptions are stable enough to support a more complex scenario cleanly.
+
+| Migration wave | Scenario type | Why it matters |
+|---|---|---|
+| Wave 1 | Core 4x4 grid | Small, representative, benchmark-relevant baseline |
+| Wave 1 | Inconsistent-switching example | Exercises validation metadata and expected inconsistency behavior |
+| Wave 2 | Paper-tier case | Exercises richer metadata, display labels, and benchmark defaults |
+
+## Planning note on inheritance merge
+
+Your note about deep merge is important and should be promoted from an implementation detail to a planning requirement. Derived scenarios should not replace whole nested blocks when only one parameter changes. The roadmap should therefore assume a **recursive association merge policy** for inheritance, especially in `Model`, `Data`, `Validation`, `Benchmark`, and `Visualization` blocks.
+
+| Merge rule | Planning consequence |
+|---|---|
+| Shallow merge is insufficient | Nested blocks would be too easy to wipe accidentally |
+| Deep merge required | Derived scenarios can override one field without destroying siblings |
+| Revalidation after merge | The merged scenario must still pass full validation |
+| Recomputed identity | Hashes and derived metadata must be refreshed after inheritance resolution |
+
+## Revised immediate next step
+
+The most appropriate next planning step is no longer a generic schema note, but a **small design brief for the Scenario Kernel**. That brief should define:
+
+| Item | Planning target |
+|---|---|
+| Public typed object | `scenario[assoc]` |
+| Constructor lifecycle | `makeScenario -> validateScenario -> completeScenario -> scenario[...]` |
+| Canonical nested blocks | `Model`, `Data`, `Validation`, `Benchmark`, `Visualization`, `Inheritance` |
+| Lineage contract | Parent reference plus scenario hash/provenance |
+| Merge contract | Recursive inheritance merge with revalidation |
+| Admissibility rules | Callable/value support for data fields |
+
+## Final revised recommendation
+
+The plan should now be framed around a stronger central claim:
+
+> **MFGraphs should adopt a typed scenario kernel, with validated canonical scenario objects serving as the common input to equation generation, solver dispatch, benchmarking, visualization, and documentation.**
+
+That refinement makes the later tasks more coherent. It also gives a cleaner answer to your original repository questions: benchmark cleanup follows from the catalog, solver segregation follows from the typed scenario consumer model, graphics cleanup follows from scenario metadata, and documentation cleanup follows once these boundaries are stable.
+
+If you want, the next planning-only step can be a **revised Scenario Kernel brief** that narrows this further into public functions, nested blocks, and merge semantics, still without implementing any code.


### PR DESCRIPTION
Summary
- add planning docs for scenario kernel and catalog work
- add scenario schema proposal and revised plan response docs
- update solve-mfg test file with current local changes

Notes
- this PR contains docs and test updates only