### PR TITLE
Preserve underdetermined critical solutions as symbolic regions

### DIFF
--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -45,8 +45,10 @@ MFGPreprocessing::usage = "MFGPreprocessing[Eqs] returns the association Eqs wit
 
 
 
-MFGSystemSolver::usage = "MFGSystemSolver[Eqs][edgeEquations] returns the
-association with rules to the solution";
+MFGSystemSolver::usage = "MFGSystemSolver[Eqs][edgeEquations] returns an Association \
+<|\"Solution\" -> assoc_or_Null, \"UnresolvedConstraints\" -> expr_or_None|>. \
+\"Solution\" is Null on failure; \"UnresolvedConstraints\" is non-None when flows were determined \
+but u-variables remain symbolically underdetermined.";
 
 DNFSolveStep::usage = "DNFSolveStep[{EE,NN,OR}, rules] takes a grouped system and some Association of rules (a partial solution). It returns the result of applying DNFReduce.";
 
@@ -996,8 +998,8 @@ BuildOraclePrunedSystem[system_, flowAssoc_Association, oracleState_Association,
 (* --- MFGSystemSolver --- *)
 
 MFGSystemSolver[Eqs_][approxJs_] :=
-    Module[{NewSystem, InitRules, pickOne, vars, System, Ncpc, costpluscurrents,
-         us, js, jts, jjtsR, usR, time, ineqsByTransition,
+    Module[{NewSystem, InitRules, pickOne, pickOneFlowOnly, vars, System, Ncpc, costpluscurrents,
+         us, js, jts, jjtsR, time, ineqsByTransition, uResidual,
          ineqsWithoutTransition = {}},
         ClearSolveCache[];
         us = Lookup[Eqs, "us", $Failed];
@@ -1016,7 +1018,7 @@ MFGSystemSolver[Eqs_][approxJs_] :=
            triple infeasible, so stop before attempting inequality bucketing. *)
         If[MemberQ[NewSystem, False],
             Message[MFGSystemSolver::nosolution];
-            Return[Null, Module]
+            Return[<|"Solution" -> Null, "UnresolvedConstraints" -> None|>, Module]
         ];
 (* Retrieve some equalities from the inequalities: group by transition flow 
     
@@ -1091,7 +1093,7 @@ MFGSystemSolver[Eqs_][approxJs_] :=
         Which[
             System === False,
                 Message[MFGSystemSolver::nosolution];
-                Return[Null, Module]
+                Return[<|"Solution" -> Null, "UnresolvedConstraints" -> None|>, Module]
             ,
             System =!= True,
                 MFGPrint["MFGSS: (Possibly) Multiple solutions:\n", System
@@ -1102,8 +1104,7 @@ MFGSystemSolver[Eqs_][approxJs_] :=
                 vars = Complement[vars, Keys[InitRules]];
                 jjtsR = Select[vars, MatchQ[#, j[_, _, _] | j[_, _]]&
                     ];
-                usR = Select[vars, MatchQ[#, u[_, _, _] | u[_, _]]&];
-                    
+
 (* Pick one solution so that all the currents have numerical values 
     *)
                 If[Length[vars] > 0,
@@ -1121,9 +1122,25 @@ MFGSystemSolver[Eqs_][approxJs_] :=
                         InitRules = Expand /@ Join[InitRules /. pickOne,
                              pickOne]
                         ,
-                        MFGPrint["MFGSS: No feasible solution found"]
-                            ;
-                        Return[Null, Module]
+                        (* Both full-variable attempts failed. Try flows-only: WL existentially
+                           quantifies over u vars, finding j values for which some u satisfies System. *)
+                        pickOneFlowOnly = If[jjtsR =!= {},
+                            FindInstance[System && And @@ ((# >= 0)& /@ jjtsR), jjtsR, Reals],
+                            {}
+                        ];
+                        If[pickOneFlowOnly =!= {},
+                            pickOneFlowOnly = Association @ First @ pickOneFlowOnly;
+                            MFGPrint["MFGSS: Flow-only solution found (u underdetermined): ", pickOneFlowOnly];
+                            InitRules = Expand /@ Join[InitRules /. pickOneFlowOnly, pickOneFlowOnly];
+                            uResidual = Simplify[System /. pickOneFlowOnly];
+                            (* Resolve transitive chains early so the result is usable downstream *)
+                            InitRules = Expand /@ FixedPoint[Function[r, ReplaceAll[r] /@ r], InitRules, 10];
+                            InitRules = Join[KeyTake[InitRules, us], KeyTake[InitRules, js], KeyTake[InitRules, jts]];
+                            Return[<|"Solution" -> InitRules, "UnresolvedConstraints" -> uResidual|>, Module]
+                            ,
+                            MFGPrint["MFGSS: No feasible solution found"];
+                            Return[<|"Solution" -> Null, "UnresolvedConstraints" -> None|>, Module]
+                        ]
                     ]
                     ,
 (* All variables already solved — nothing to pick 
@@ -1150,7 +1167,7 @@ MFGSystemSolver[Eqs_][approxJs_] :=
                 ];
         InitRules = Join[KeyTake[InitRules, us], KeyTake[InitRules, js
             ], KeyTake[InitRules, jts]];
-        InitRules
+        <|"Solution" -> InitRules, "UnresolvedConstraints" -> None|>
     ];
 
 (* --- DNFSolveStep --- *)

--- a/MFGraphs/NonLinearSolver.wl
+++ b/MFGraphs/NonLinearSolver.wl
@@ -118,6 +118,7 @@ NonLinearSolver[Eqs_, OptionsPattern[]] :=
              status, resultKind, message, solution, comparisonData, convergenceData,
              flowDelta = Missing["NotAvailable"], iterations, stopReason, solveTime,
              seedMethod, timingResult, residualHistory = {}, demotedDueToFeasibilityQ},
+                js = Lookup[PreEqs, "js", {}];
                 {solveTime, timingResult} = AbsoluteTiming[
                     If[ KeyExistsQ[PreEqs, "AssoNonCritical"],
                         AssoNonCritical = PreEqs["AssoNonCritical"];
@@ -136,7 +137,10 @@ NonLinearSolver[Eqs_, OptionsPattern[]] :=
                                 ]
                         ]
                     ];
-                js = Lookup[PreEqs, "js", {}];
+                If[!AssociationQ[AssoNonCritical] && js =!= {},
+                    AssoNonCritical = AssociationThread[js, ConstantArray[0, Length[js]]];
+                    seedMethod = "ZeroFlowSeed"
+                ];
                 NonCriticalList =
                     If[!AssociationQ[AssoNonCritical],
                         {Null},
@@ -252,7 +256,7 @@ nonLinearStep[Eqs_][approxSol_] :=
         Nrhs = Lookup[Eqs, "Nrhs", $Failed];
         Nlhs = Lookup[Eqs, "Nlhs", $Failed];
         approxJs = KeyTake[approxSol, js];
-        approx = MFGSystemSolver[Eqs][approxJs];
+        approx = MFGSystemSolver[Eqs][approxJs]["Solution"];
         Newlhs = N[Nlhs/.approx];
         Newrhs = Nrhs/.approx;
         MFGPrint[Newlhs,"\n",Newrhs];

--- a/MFGraphs/Solvers.wl
+++ b/MFGraphs/Solvers.wl
@@ -233,7 +233,7 @@ DirectCriticalSolver[Eqs_Association] :=
                 ]
             ]
         ];
-        Do[If[!KeyExistsQ[result, var], result[var] = 0], {var, allVars}];
+        Do[If[!KeyExistsQ[result, var] && MatchQ[var, j[__]], result[var] = 0], {var, allVars}];
         (* Only resolve transitive chains if there are symbolic values *)
         If[!AllTrue[Values[result], NumericQ],
             result = Expand /@ FixedPoint[Function[r, ReplaceAll[r] /@ r], result, 10]
@@ -984,13 +984,16 @@ SolveCriticalNumericBackend[Eqs_Association] :=
 
 
 BuildCriticalResult[PreEqs_Association, resultKind_, status_, message_,
-    candidate_, telemetry_Association] :=
+    candidate_, telemetry_Association, unresolvedEqs_: True] :=
     Module[{solution, comparisonData},
         solution = If[AssociationQ[candidate], candidate, Missing["NotAvailable"]];
         comparisonData = BuildSolverComparisonData[PreEqs, solution];
         Join[PreEqs, MakeSolverResult["CriticalCongestion", resultKind,
             status, message, solution,
-            Join[comparisonData, <|"AssoCritical" -> candidate, "Status" -> status|>, telemetry]
+            Join[comparisonData,
+                <|"AssoCritical" -> candidate, "Status" -> status,
+                  "UnresolvedEquations" -> unresolvedEqs|>,
+                telemetry]
         ]]
     ];
 
@@ -1115,27 +1118,41 @@ CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
                     numericBackendUsedQ = True;
                     numericBackendFallbackReason = None;
                     PreEqs = EnsurePreprocessed[Eqs];
-                    If[
-                        validateQ &&
-                        (
-                            forcedRejectQ ||
-                            !TrueQ @ IsCriticalSolution[
-                                Join[PreEqs, <|"AssoCritical" -> numericCandidate, "Solution" -> numericCandidate|>],
-                                "Tolerance" -> validationTolerance,
-                                "Verbose" -> validationVerboseQ
+                    If[validateQ,
+                        Module[{valReport},
+                            valReport = If[forcedRejectQ,
+                                <|"Valid" -> False, "Reason" -> "ForcedValidationFailure",
+                                  "IndeterminateResiduals" -> <||>|>,
+                                IsCriticalSolution[
+                                    Join[PreEqs, <|"AssoCritical" -> numericCandidate, "Solution" -> numericCandidate|>],
+                                    "Tolerance" -> validationTolerance,
+                                    "Verbose" -> validationVerboseQ,
+                                    "ReturnReport" -> True
+                                ]
+                            ];
+                            Which[
+                                valReport["Reason"] === "IndeterminateConstraints",
+                                    Return[BuildCriticalResult[PreEqs, "Success", status, None,
+                                        numericCandidate, telemetry,
+                                        Lookup[valReport, "IndeterminateResiduals", <||>]], Module]
+                                ,
+                                !TrueQ[valReport["Valid"]],
+                                    numericBackendUsedQ = False;
+                                    numericBackendStrategy = "Symbolic";
+                                    If[
+                                        TrueQ[jFirstBackendUsedQ] &&
+                                        (jFirstBackendFallbackReason === None || jFirstBackendFallbackReason === "NotAttempted"),
+                                        jFirstBackendFallbackReason =
+                                            If[forcedRejectQ, "ForcedValidationFailure", "CriticalValidationFailed"]
+                                    ];
+                                    jFirstBackendUsedQ = False;
+                                    numericBackendFallbackReason =
+                                        If[forcedRejectQ, "ForcedValidationFailure", "CriticalValidationFailed"]
+                                ,
+                                True,
+                                    Return[BuildCriticalResult[PreEqs, "Success", status, None, numericCandidate, telemetry], Module]
                             ]
-                        ),
-                        numericBackendUsedQ = False;
-                        numericBackendStrategy = "Symbolic";
-                        If[
-                            TrueQ[jFirstBackendUsedQ] &&
-                            (jFirstBackendFallbackReason === None || jFirstBackendFallbackReason === "NotAttempted"),
-                            jFirstBackendFallbackReason =
-                                If[forcedRejectQ, "ForcedValidationFailure", "CriticalValidationFailed"]
-                        ];
-                        jFirstBackendUsedQ = False;
-                        numericBackendFallbackReason =
-                            If[forcedRejectQ, "ForcedValidationFailure", "CriticalValidationFailed"]
+                        ]
                         ,
                         Return[BuildCriticalResult[PreEqs, "Success", status, None, numericCandidate, telemetry], Module]
                     ],
@@ -1160,14 +1177,27 @@ CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
                 status = CheckFlowFeasibility[AssoCritical];
                 If[status === "Feasible",
                     PreEqs = EnsurePreprocessed[Eqs];
-                    If[
-                        validateQ &&
-                        !TrueQ @ IsCriticalSolution[
-                            Join[PreEqs, <|"AssoCritical" -> AssoCritical, "Solution" -> AssoCritical|>],
-                            "Tolerance" -> validationTolerance,
-                            "Verbose" -> validationVerboseQ
-                        ],
-                        MFGPrint["Direct solver validation failed, falling back to symbolic solver."]
+                    If[validateQ,
+                        Module[{valReport},
+                            valReport = IsCriticalSolution[
+                                Join[PreEqs, <|"AssoCritical" -> AssoCritical, "Solution" -> AssoCritical|>],
+                                "Tolerance" -> validationTolerance,
+                                "Verbose"   -> validationVerboseQ,
+                                "ReturnReport" -> True
+                            ];
+                            Which[
+                                valReport["Reason"] === "IndeterminateConstraints",
+                                    Return[BuildCriticalResult[PreEqs, "Success", status, None,
+                                        AssoCritical, telemetry,
+                                        Lookup[valReport, "IndeterminateResiduals", <||>]], Module]
+                                ,
+                                !TrueQ[valReport["Valid"]],
+                                    MFGPrint["Direct solver validation failed, falling back to symbolic solver."]
+                                ,
+                                True,
+                                    Return[BuildCriticalResult[PreEqs, "Success", status, None, AssoCritical, telemetry], Module]
+                            ]
+                        ]
                         ,
                         Return[BuildCriticalResult[PreEqs, "Success", status, None, AssoCritical, telemetry], Module]
                     ],
@@ -1201,18 +1231,34 @@ CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
         Module[{symbolicResult},
             symbolicResult = TimeConstrained[
                 Module[{localAssoCritical, localStatus, localValidationFailedQ = False,
-                        localResultKind, localMessage},
-                    localAssoCritical = MFGSystemSolver[PreEqs][AssociationThread[js, ConstantArray[0, Length[js]]]];
+                        localResultKind, localMessage, mfgssResult, unresolvedUConstraints, valReport},
+                    mfgssResult = MFGSystemSolver[PreEqs][AssociationThread[js, ConstantArray[0, Length[js]]]];
+                    localAssoCritical = mfgssResult["Solution"];
+                    unresolvedUConstraints = mfgssResult["UnresolvedConstraints"];
                     localStatus = CheckFlowFeasibility[localAssoCritical];
                     If[validateQ && AssociationQ[localAssoCritical] && localStatus === "Feasible",
-                        If[!TrueQ @ IsCriticalSolution[
+                        valReport = IsCriticalSolution[
                             Join[PreEqs, <|"AssoCritical" -> localAssoCritical, "Solution" -> localAssoCritical|>],
                             "Tolerance" -> validationTolerance,
-                            "Verbose" -> validationVerboseQ
-                        ],
-                            localValidationFailedQ = True;
-                            localAssoCritical = Null;
-                            localStatus = "Infeasible";
+                            "Verbose"   -> validationVerboseQ,
+                            "ReturnReport" -> True
+                        ];
+                        Which[
+                            valReport["Reason"] === "IndeterminateConstraints",
+                                Return[BuildCriticalResult[PreEqs, "Success", localStatus, None,
+                                    localAssoCritical, telemetry,
+                                    If[unresolvedUConstraints =!= None,
+                                        Join[Lookup[valReport, "IndeterminateResiduals", <||>],
+                                             <|"FlowSolveResidual" -> unresolvedUConstraints|>],
+                                        Lookup[valReport, "IndeterminateResiduals", <||>]
+                                    ]], Module]
+                            ,
+                            !TrueQ[valReport["Valid"]],
+                                localValidationFailedQ = True;
+                                localAssoCritical = Null;
+                                localStatus = "Infeasible"
+                            ,
+                            True, Null (* valid — fall through *)
                         ]
                     ];
                     localResultKind = If[localAssoCritical === Null, "Failure", "Success"];
@@ -1250,7 +1296,7 @@ NumericRelationSatisfiedQ[expr_, tol_?NumericQ] :=
                     HoldComplete[Inactive[Equal][l_, r_]] :> {l, r}
                 }];
                 delta = Quiet @ Check[N[pair[[1]] - pair[[2]]], $Failed];
-                NumericQ[delta] && Abs[delta] <= tol
+                Which[delta === $Failed, False, NumericQ[delta], Abs[delta] <= tol, True, Indeterminate]
             ,
             MatchQ[held, HoldComplete[LessEqual[_, _]] | HoldComplete[Inactive[LessEqual][_, _]]],
                 pair = Replace[held, {
@@ -1258,7 +1304,7 @@ NumericRelationSatisfiedQ[expr_, tol_?NumericQ] :=
                     HoldComplete[Inactive[LessEqual][l_, r_]] :> {l, r}
                 }];
                 delta = Quiet @ Check[N[pair[[1]] - pair[[2]]], $Failed];
-                NumericQ[delta] && delta <= tol
+                Which[delta === $Failed, False, NumericQ[delta], delta <= tol, True, Indeterminate]
             ,
             MatchQ[held, HoldComplete[GreaterEqual[_, _]] | HoldComplete[Inactive[GreaterEqual][_, _]]],
                 pair = Replace[held, {
@@ -1266,7 +1312,7 @@ NumericRelationSatisfiedQ[expr_, tol_?NumericQ] :=
                     HoldComplete[Inactive[GreaterEqual][l_, r_]] :> {l, r}
                 }];
                 delta = Quiet @ Check[N[pair[[2]] - pair[[1]]], $Failed];
-                NumericQ[delta] && delta <= tol
+                Which[delta === $Failed, False, NumericQ[delta], delta <= tol, True, Indeterminate]
             ,
             MatchQ[held, HoldComplete[Less[_, _]] | HoldComplete[Inactive[Less][_, _]]],
                 pair = Replace[held, {
@@ -1274,7 +1320,7 @@ NumericRelationSatisfiedQ[expr_, tol_?NumericQ] :=
                     HoldComplete[Inactive[Less][l_, r_]] :> {l, r}
                 }];
                 delta = Quiet @ Check[N[pair[[1]] - pair[[2]]], $Failed];
-                NumericQ[delta] && delta < -tol
+                Which[delta === $Failed, False, NumericQ[delta], delta < -tol, True, Indeterminate]
             ,
             MatchQ[held, HoldComplete[Greater[_, _]] | HoldComplete[Inactive[Greater][_, _]]],
                 pair = Replace[held, {
@@ -1282,7 +1328,7 @@ NumericRelationSatisfiedQ[expr_, tol_?NumericQ] :=
                     HoldComplete[Inactive[Greater][l_, r_]] :> {l, r}
                 }];
                 delta = Quiet @ Check[N[pair[[2]] - pair[[1]]], $Failed];
-                NumericQ[delta] && delta < -tol
+                Which[delta === $Failed, False, NumericQ[delta], delta < -tol, True, Indeterminate]
             ,
             MatchQ[held, HoldComplete[Unequal[_, _]] | HoldComplete[Inactive[Unequal][_, _]]],
                 pair = Replace[held, {
@@ -1290,7 +1336,7 @@ NumericRelationSatisfiedQ[expr_, tol_?NumericQ] :=
                     HoldComplete[Inactive[Unequal][l_, r_]] :> {l, r}
                 }];
                 delta = Quiet @ Check[N[pair[[1]] - pair[[2]]], $Failed];
-                NumericQ[delta] && Abs[delta] > tol
+                Which[delta === $Failed, False, NumericQ[delta], Abs[delta] > tol, True, Indeterminate]
             ,
             True,
                 False
@@ -1325,7 +1371,13 @@ LogicalSatisfiedQ[expr_, rules_Association, tol_?NumericQ] :=
                 ];
                 If[evaluated === $Failed,
                     False,
-                    TrueQ[Simplify[evaluated]]
+                    Module[{simplified = Simplify[evaluated]},
+                        Which[
+                            TrueQ[simplified],    True,
+                            simplified === False,  False,
+                            True,                  Indeterminate
+                        ]
+                    ]
                 ]
         ]
     ];
@@ -1358,9 +1410,10 @@ CriticalFlowApproximation[Eqs_Association, solution_Association] :=
 
 IsCriticalSolution[Eqs_Association, OptionsPattern[]] :=
     Module[{tol, verboseQ, returnReportQ, solution, blocks, blockResults,
-         residual, residualPass, allBlocksPass, overall, report, flowApprox,
+         residual, residualPass, overall, report, flowApprox,
          costpluscurrents, eqGeneralCritical, eqResidualPairs, eqResidualDeltas,
-         requiredKeys, missingKeys},
+         requiredKeys, missingKeys,
+         concretelyFailed, indeterminateBlocks, hasIndeterminate, indeterminateResiduals},
         tol = OptionValue["Tolerance"];
         verboseQ = TrueQ[OptionValue["Verbose"]];
         returnReportQ = TrueQ[OptionValue["ReturnReport"]];
@@ -1448,7 +1501,13 @@ IsCriticalSolution[Eqs_Association, OptionsPattern[]] :=
             #1 -> LogicalSatisfiedQ[#2, solution, tol] &,
             blocks
         ];
-        allBlocksPass = And @@ Values[blockResults];
+        concretelyFailed    = Keys @ Select[blockResults, (# === False) &];
+        indeterminateBlocks = Keys @ Select[blockResults, (# === Indeterminate) &];
+        hasIndeterminate    = indeterminateBlocks =!= {};
+        indeterminateResiduals = If[hasIndeterminate,
+            KeyTake[Map[Simplify[# /. solution] &, blocks], indeterminateBlocks],
+            <||>
+        ];
 
         eqResidualPairs =
             Cases[
@@ -1471,33 +1530,47 @@ IsCriticalSolution[Eqs_Association, OptionsPattern[]] :=
             ];
         residualPass =
             Which[
-                NumericQ[residual], residual <= tol,
+                NumericQ[residual],                  residual <= tol,
                 residual === Missing["NotAvailable"], TrueQ[Lookup[blockResults, "EqGeneralCritical", False]],
-                True, False
+                True,                                Indeterminate
             ];
 
-        overall = allBlocksPass && residualPass;
+        overall = Which[
+            concretelyFailed =!= {} || residualPass === False, False,
+            hasIndeterminate || residualPass === Indeterminate,  Indeterminate,
+            True,                                                True
+        ];
 
         If[verboseQ,
-            Print["IsCriticalSolution: all blocks pass = ", allBlocksPass];
-            If[!allBlocksPass,
-                Print["  Failed blocks: ", Keys @ Select[blockResults, !TrueQ[#]&]]
+            Print["IsCriticalSolution: overall = ", overall];
+            If[concretelyFailed =!= {},
+                Print["  Concretely failed blocks: ", concretelyFailed]
+            ];
+            If[indeterminateBlocks =!= {},
+                Print["  Indeterminate blocks: ", indeterminateBlocks]
             ];
             Print["IsCriticalSolution: equation residual = ", residual, " (tol=", tol, ")"];
             Print["IsCriticalSolution: equation residual pass = ", residualPass];
         ];
 
         report = <|
-            "Valid" -> overall,
-            "Reason" -> If[overall, None, "ConstraintViolation"],
-            "MissingKeys" -> {},
-            "BlockChecks" -> blockResults,
-            "EquationResidual" -> residual,
-            "EquationResidualPass" -> residualPass,
-            "Tolerance" -> tol
+            "Valid"                  -> overall,
+            "Reason"                 -> Which[
+                                            overall === True,  None,
+                                            hasIndeterminate ||
+                                            residualPass === Indeterminate, "IndeterminateConstraints",
+                                            True,             "ConstraintViolation"],
+            "IndeterminateResiduals" -> indeterminateResiduals,
+            "ConcretelyFailedBlocks" -> concretelyFailed,
+            "MissingKeys"            -> {},
+            "BlockChecks"            -> blockResults,
+            "EquationResidual"       -> residual,
+            "EquationResidualPass"   -> residualPass,
+            "Tolerance"              -> tol
         |>;
 
-        If[returnReportQ, report, overall]
+        (* Backward-compatible boolean: True for valid AND indeterminate, False only for concrete failure *)
+        If[returnReportQ, report, !MemberQ[{False}, overall]]
     ];
 
 

--- a/MFGraphs/Tests/infeasible-status.mt
+++ b/MFGraphs/Tests/infeasible-status.mt
@@ -74,7 +74,7 @@ Test[
                 "NewSystem" -> {True, False, True},
                 "costpluscurrents" -> <||>
             |>;
-            MFGSystemSolver[fakeSystem][<||>] === Null
+            MFGSystemSolver[fakeSystem][<||>]["Solution"] === Null
         ]
     ]
     ,

--- a/MFGraphs/Tests/solver-contracts.mt
+++ b/MFGraphs/Tests/solver-contracts.mt
@@ -28,6 +28,8 @@ Test[
         NumericQ[result["KirchhoffResidual"]] &&
         NumericQ[result["BoundaryMassResidual"]] &&
         KeyExistsQ[result, "UtilityClassResidual"] &&
+        KeyExistsQ[result, "UnresolvedEquations"] &&
+        result["UnresolvedEquations"] === True &&
         IsFeasible[result]
     ]
     ,
@@ -396,4 +398,26 @@ Test[
     True
     ,
     TestID -> "CriticalCongestionSolver: symbolic timeout returns structured envelope, not $Failed"
+]
+
+Test[
+    Module[{data, d2e, result},
+        data = Append[
+            GetExampleData["chain with two exits"] /. {I1 -> 100, U1 -> 0, U2 -> 0},
+            "Switching Costs" -> {{1, 2, 3, 10}}
+        ];
+        d2e = Quiet[DataToEquations[data], {DataToEquations::switchingcosts}];
+        result = Quiet[CriticalCongestionSolver[d2e, "SymbolicTimeLimit" -> 60], {DataToEquations::switchingcosts}];
+        Lookup[result, {"Solver", "ResultKind", "Feasibility", "Message"}] ===
+            {"CriticalCongestion", "Success", "Feasible", None} &&
+        AssociationQ[result["UnresolvedEquations"]] &&
+        AllTrue[
+            Values @ KeySelect[result["AssoCritical"], MatchQ[#, j[__]] &],
+            NumericQ
+        ]
+    ]
+    ,
+    True
+    ,
+    TestID -> "Critical solver: underdetermined inconsistent-switching is Success/Feasible with symbolic UnresolvedEquations"
 ]

--- a/MFGraphs/TimeDependentSolver.wl
+++ b/MFGraphs/TimeDependentSolver.wl
@@ -173,14 +173,14 @@ solveAtTimeStep[d2e_Association, entranceFlowValues_List,
         MFGPrint["  Preprocessing took ", time, " seconds."];
 
         (* Solve the spatial system *)
-        solution = MFGSystemSolver[preStep][approxJs];
+        solution = MFGSystemSolver[preStep][approxJs]["Solution"];
 
         (* Optional nonlinear iterations *)
         If[spatialIter > 0 && AssociationQ[solution],
             js = Lookup[preStep, "js", {}];
             Do[
                 ClearSolveCache[];
-                solution = MFGSystemSolver[preStep][KeyTake[solution, js]],
+                solution = MFGSystemSolver[preStep][KeyTake[solution, js]]["Solution"],
                 {spatialIter}
             ]
         ];

--- a/repro/quick/check_chain_two_exits_inconsistent_switching.wls
+++ b/repro/quick/check_chain_two_exits_inconsistent_switching.wls
@@ -1,0 +1,42 @@
+Get["/Users/ribeirrd/Documents/GitHub/MFGraphs/MFGraphs/MFGraphs.wl"];
+
+ClearAll[data, consistency, d2e, result, assocCritical, printable];
+
+printable[expr_] := StringReplace[
+  ToString[InputForm[expr]],
+  "MFGraphs`Private`" -> ""
+];
+
+data = GetExampleData["chain with two exits"] /. {I1 -> 100, U1 -> 0, U2 -> 20};
+data = AssociateTo[data, "Switching Costs" -> {{1, 2, 3, 10}}];
+
+Print["DATA=" <> printable[data]];
+
+consistency = IsSwitchingCostConsistent[Normal @ Association[Most /@ data["Switching Costs"], Last /@ data["Switching Costs"]]];
+Print["CONSISTENCY=" <> printable[consistency]];
+
+Quiet[
+  d2e = DataToEquations[data];
+  , {DataToEquations::switchingcosts}
+];
+
+Print["D2E_KEYS=" <> printable[Sort @ Keys[d2e]]];
+Print["D2E_SWITCHING=" <> printable[d2e["SwitchingCosts"]]];
+If[KeyExistsQ[d2e, "AllTransitionFlowsConstraint"],
+  Print["HAS_ALL_TRANSITION_FLOWS_CONSTRAINT=True"],
+  Print["HAS_ALL_TRANSITION_FLOWS_CONSTRAINT=False"]
+];
+
+Quiet[
+  result = CriticalCongestionSolver[d2e, "SymbolicTimeLimit" -> 60];
+  , {DataToEquations::switchingcosts}
+];
+
+Print["RESULT_KIND=" <> printable[Lookup[result, "ResultKind", Missing[]]]];
+Print["FEASIBILITY=" <> printable[Lookup[result, "Feasibility", Missing[]]]];
+Print["MESSAGE=" <> printable[Lookup[result, "Message", Missing[]]]];
+Print["SOLVER=" <> printable[Lookup[result, "Solver", Missing[]]]];
+
+assocCritical = Lookup[result, "AssoCritical", Missing[]];
+Print["ASSO_CRITICAL_HEAD=" <> printable[Head[assocCritical]]];
+Print["ASSO_CRITICAL=" <> printable[assocCritical]];

--- a/repro/quick/check_chain_two_exits_inconsistent_switching_compare.wls
+++ b/repro/quick/check_chain_two_exits_inconsistent_switching_compare.wls
@@ -1,0 +1,27 @@
+Get["/Users/ribeirrd/Documents/GitHub/MFGraphs/MFGraphs/MFGraphs.wl"];
+
+ClearAll[printable, runCase];
+printable[expr_] := StringReplace[
+  ToString[InputForm[expr]],
+  "MFGraphs`Private`" -> ""
+];
+
+runCase[label_, switchingCosts_] := Module[{data, d2e, consistency, result},
+  data = GetExampleData["chain with two exits"] /. {I1 -> 100, U1 -> 0, U2 -> 0};
+  data = AssociateTo[data, "Switching Costs" -> switchingCosts];
+  Print["CASE=" <> label];
+  Print["DATA_SWITCHING=" <> printable[data["Switching Costs"]]];
+  d2e = Quiet[DataToEquations[data], {DataToEquations::switchingcosts}];
+  consistency = IsSwitchingCostConsistent[Normal @ d2e["SwitchingCosts"]];
+  Print["CONSISTENCY_D2E=" <> printable[consistency]];
+  Print["ALT_TRANSITION_FLOWS_HEAD=" <> printable[Head[d2e["AltTransitionFlows"]]]];
+  result = Quiet[CriticalCongestionSolver[d2e, "SymbolicTimeLimit" -> 60], {DataToEquations::switchingcosts}];
+  Print["FEASIBILITY=" <> printable[Lookup[result, "Feasibility", Missing[]]]];
+  Print["MESSAGE=" <> printable[Lookup[result, "Message", Missing[]]]];
+  Print["ASSO_CRITICAL=" <> printable[Lookup[result, "AssoCritical", Missing[]]]];
+  Print["---"];
+];
+
+runCase["baseline_no_switching", {}];
+runCase["requested_single_switch_123_cost10", {{1, 2, 3, 10}}];
+runCase["symmetric_switch_123_and_321_cost10", {{1, 2, 3, 10}, {3, 2, 1, 10}}];


### PR DESCRIPTION
## Summary
- preserve underdetermined critical-solver outputs as feasible by classifying symbolic residual constraints as indeterminate instead of hard failures
- add UnresolvedEquations to critical result envelopes and thread indeterminate residuals through validation paths
- update MFGSystemSolver to return structured output and add a flow-only fallback when full variable solving fails
- update NonLinearSolver/TimeDependentSolver call sites for the new MFGSystemSolver return shape
- avoid zero-filling unresolved utility variables in DirectCriticalSolver
- add/update tests for unresolved-equation contract and inconsistent-switching regression

## Validation
- wolframscript -file Scripts/RunTests.wls fast
  - passed: 142
  - failed: 0
