### PR TITLE
Critical-only solver track: symbolic-region fixes + docs/archive cleanup

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -2,14 +2,6 @@
 
 This document is automatically generated from the Wolfram Language package usage metadata.
 
-## alpha
-
-alpha[edge] is the edge-dependent congestion exponent used in the Hamiltonian. The default is 1.
-
-## alphaFun
-
-MFGraphs`alphaFun
-
 ## AltFlowOp
 
 AltFlowOp[j][list] returns the alternative: j@@list ==0 || j@@Reverse@list ==0.
@@ -51,17 +43,6 @@ switching costs too, does not have a numerical value.
 
 CriticalCongestionSolver[Eqs] returns Eqs with an association "AssoCritical" with rules to
 the solution to the critical congestion case. Option: "ReturnShape" (default "Legacy"); use "Standard" to add normalized solver-result keys.
-
-## Data2Equations
-
-DataToEquations[Data] returns the equations, inequalities, and alternatives associated to the Data. 
-
-## DataG
-
-GetExampleData[n] returns an Association with keys "Vertices List", "Adjacency Matrix",
-"Entrance Vertices and Flows", "Exit Vertices and Terminal Costs", and "Switching Costs"
-from the test case test[n].
-Supports test cases with 5 fields (basic), 6 fields (+cost function 'a'), or 7 fields (+alpha).
 
 ## DataToEquations
 
@@ -121,86 +102,6 @@ FlowGathering[auxTriples_List][x_] returns the triples that end with x.
 
 FlowSplitting[AT][UndirectedEdge[a, b]] returns the splitting that start with {a,b}.
 
-## g
-
-g[m, edge] is the edge-dependent interaction term as a function of density m. The default is -1/m^2.
-
-## GetExampleData
-
-GetExampleData[n] returns an Association with keys "Vertices List", "Adjacency Matrix",
-"Entrance Vertices and Flows", "Exit Vertices and Terminal Costs", and "Switching Costs"
-from the test case test[n].
-Supports test cases with 5 fields (basic), 6 fields (+cost function 'a'), or 7 fields (+alpha).
-
-## GetKirchhoffLinearSystem
-
-GetKirchhoffLinearSystem[d2e] returns the entry current vector, Kirchhoff matrix, and the variables in the order corresponding to the Kirchhoff matrix.
-
-## GetKirchhoffMatrix
-
-GetKirchhoffMatrix[d2e] returns the entry current vector, Kirchhoff matrix, (critical congestion) cost function placeholder, and the variables in the order corresponding to the Kirchhoff matrix. The third slot is retained for backward compatibility and should not be used by new code.
-
-## GetTimeDependentExampleData
-
-GetTimeDependentExampleData[key] returns an Association with all standard network keys
-plus time-dependent keys ("Time Horizon", "Time Steps", etc.).
-Available keys: "TD-1" through "TD-5".
-
-## gFun
-
-MFGraphs`gFun
-
-## GradientProjection
-
-GradientProjection[x, A, dim, At] returns the projected gradient operator matrix.
-This is InverseHessian[x] . (I - At . PseudoInverse[A . InverseHessian[x] . At] . A . InverseHessian[x]).
-
-## Hess
-
-Hess[j] returns a numeric diagonal matrix with the reciprocals of the elements in the (numeric) vector j.
-
-## HessianSandwich
-
-HessianSandwich[j, A, At] returns the product A . InverseHessian[j] . At.
-
-## I1
-
-Symbolic parameter: input flow at entrance 1.
-
-## I2
-
-Symbolic parameter: input flow at entrance 2.
-
-## I3
-
-Symbolic parameter: input flow at entrance 3.
-
-## IneqSwitch
-
-IneqSwitch[u, switchingCosts][v, e1, e2] returns the optimality condition at the vertex v related to switching from e1 to e2. Namely,
-u[v, e1] <= u[v, e2] + switchingCosts[{v, e1, e2}]
-
-## InverseHessian
-
-InverseHessian[j] returns a diagonal matrix with the (numeric) vector j. This is the inverse of the matrix Hess[j].
-
-## IsFeasible
-
-IsFeasible[result] returns True if a solver result is feasible, checking legacy "Status" or standardized "Feasibility" keys.
-
-## IsNonLinearSolution
-
-IsNonLinearSolution[Eqs] extracts AssoNonCritical and checks equations and inequalities. The right and left hand sides of the nonlinear equations are shown with the sup-norm of the difference.
-
-## IsSwitchingCostConsistent
-
-IsSwitchingCostConsistent[List of switching costs] is True if all switching costs satisfy the triangle inequality. If some switching costs are symbolic, then it returns the consistency conditions.
-
-## IsTimeDependentQ
-
-IsTimeDependentQ[data] returns True if the data Association contains time-dependent keys
-(specifically, "Time Horizon").
-
 ## list
 
 MFGraphs`list
@@ -231,30 +132,6 @@ MFGPrintTemporary[args___] prints a temporary message only when $MFGraphsVerbose
 MFGSystemSolver[Eqs][edgeEquations] returns the
 association with rules to the solution
 
-## MonotoneSolver
-
-MonotoneSolver[d2e] solves the MFG problem using the monotone operator method.
-Options: "TimeSteps" (default 100), "UseCachedGradient" (default True), "ReturnShape" (default "Legacy"; use "Standard" for a normalized solver-result association), "PotentialFunction", "CongestionExponentFunction", and "InteractionFunction" (default Automatic, meaning use the current global MFGraphs` definitions of V, alpha, and g).
-
-## MonotoneSolverFromData
-
-MonotoneSolverFromData[Data] solves the MFG problem from raw Data using the monotone operator method.
-Options: "TimeSteps" (default 100), "UseCachedGradient" (default True), "ReturnShape" (default "Legacy"; use "Standard" for a normalized solver-result association), "PotentialFunction", "CongestionExponentFunction", and "InteractionFunction" (default Automatic, meaning use the current global MFGraphs` definitions of V, alpha, and g).
-
-## MonotoneSolverODE
-
-MonotoneSolverODE[x0, KM, jj, cc] solves the gradient flow ODE from initial condition x0.
-Options: "TimeSteps" (default 100), "UseCachedGradient" (default True).
-
-## m$
-
-MFGraphs`m$
-
-## NonLinearSolver
-
-NonLinearSolver[Eqs] takes an association resulting from DataToEquations and returns an approximation to the solution of the non-critical congestion case with alpha = value, specified by alpha[edge_] := value.
-Options: "MaxIterations" (default 15), "Tolerance" (default 0), "ReturnShape" (default "Legacy"; use "Standard" to add normalized solver-result keys), "PotentialFunction", "CongestionExponentFunction", and "InteractionFunction" (default Automatic, meaning use the current global MFGraphs` definitions of V, alpha, and g). When Tolerance > 0, iteration stops early when the infinity-norm change in flow variables between consecutive steps falls below the given tolerance.
-
 ## NumberMatrixQ
 
 NumberMatrixQ[A] returns True if the elements of the matrix A are numeric.
@@ -266,12 +143,6 @@ NumberVectorQ[j] returns True if the vector j is numeric.
 ## p
 
 MFGraphs`p
-
-## PrecomputeM
-
-PrecomputeM[jMin, jMax, edge, nPoints] precomputes M[j,x,edge] on a grid and returns
-an InterpolatingFunction. This avoids per-point FindRoot calls during NIntegrate.
-nPoints controls the grid resolution (default 50).
 
 ## ReduceDisjuncts
 
@@ -366,16 +237,6 @@ Otherwise, it simplifies the whole expression.
 SystemToTriple[sys] returns a triple {equalities, inequalities, alternatives} from sys.
 The input should be a system of equations, inequalities and (simple) alternatives.
 
-## TimeDependentSolver
-
-TimeDependentSolver[data] solves the time-dependent MFG problem on a network.
-The data Association must include "Time Horizon" and optionally
-"Time Steps", "Initial Mass Distribution", "Terminal Cost Function",
-"Time Dependent Entrance Flows", and "Time Dependent Switching Costs".
-Options: "MaxOuterIterations" (default 20), "Tolerance" (default 10^-6),
-"SpatialSolverIterations" (default 0; when > 0, runs nonlinear iterations per step),
-"ReturnShape" (default "Legacy"; use "Standard" for normalized output).
-
 ## TripleClean
 
 TripleClean[{{EE,NN,OR},Rules}] composes TripleStep until it reaches a fixed point, that is, {{True,NewNN,NewOR},NewRules} such that replacement of NewRules in NewNN and NewOR do not produce equalities.
@@ -400,23 +261,6 @@ Symbolic parameter: terminal cost at exit 2.
 
 Symbolic parameter: terminal cost at exit 3.
 
-## V
-
-V[x, edge] is the along-edge potential term in the Hamiltonian. Lower values make locations on an edge more attractive to agents. The default is 0.
-
-## ValidateTimeDependentData
-
-ValidateTimeDependentData[data] checks that the required time-dependent keys are present
-and consistent. Returns True or a failure message string.
-
-## vFun
-
-MFGraphs`vFun
-
-## WithHamiltonianFunctions
-
-WithHamiltonianFunctions[vFun, alphaFun, gFun, expr] temporarily overrides the public MFGraphs Hamiltonian ingredients V, alpha, and g while evaluating expr. Any argument may be Automatic to keep the current definition.
-
 ## x
 
 MFGraphs`x
@@ -435,4 +279,4 @@ False is the symbol for the Boolean value false.
 
 ## $MFGraphsVerbose
 
-False is the symbol for the Boolean value false. 
+True is the symbol for the Boolean value true. 

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -2,6 +2,14 @@
 
 This document is automatically generated from the Wolfram Language package usage metadata.
 
+## alpha
+
+alpha[edge] is the congestion exponent for an edge. Default is 1.
+
+## alpha$
+
+MFGraphs`alpha$
+
 ## AltFlowOp
 
 AltFlowOp[j][list] returns the alternative: j@@list ==0 || j@@Reverse@list ==0.
@@ -11,25 +19,74 @@ AltFlowOp[j][list] returns the alternative: j@@list ==0 || j@@Reverse@list ==0.
 AltSwitch[j, u, switchingCosts][v, e1, e2] returns the complementarity condition:
 (j[v, e1, e2] == 0) || (u[v, e1] == u[e2, e1] + switchingCosts[{v, e1, e2}])
 
-## args
+## AssociationValue
 
-MFGraphs`args
+AssociationValue[assoc, key, default] returns assoc[key] when key exists, otherwise default (Missing["NotAvailable"] by default).
 
-## args$
+## BuildBoundaryMassData
 
-MFGraphs`args$
+BuildBoundaryMassData[Eqs, flowAssoc] returns mass balance metrics.
 
-## CachedGradientProjection
+## BuildCriticalQuadraticObjective
 
-CachedGradientProjection[x, KM, dim, At, cache] is a version of GradientProjection
-that caches the PseudoInverse result and reuses it when x has not changed significantly.
-cache must be a symbol holding a 1-element list {Null} or {<|"x" -> ..., "pi" -> ...|>}.
-The function has the HoldAll attribute so that cache is passed by reference.
+BuildCriticalQuadraticObjective[d2e] returns a quadratic approximation of the MFG objective.
+
+## BuildFeasibleFlowSeed
+
+BuildFeasibleFlowSeed[backendState] returns an initial feasible flow for FP.
+
+## BuildMonotonePairCostAssociation
+
+BuildMonotonePairCostAssociation[halfPairs, edgeList, q] returns signed edge costs.
+
+## BuildMonotoneStateData
+
+BuildMonotoneStateData[d2e] returns shared linear state for monotone-like solvers.
+
+## BuildMonotoneValueSystem
+
+BuildMonotoneValueSystem[d2e] returns a function to solve for node potentials.
+
+## BuildReducedKirchhoffCoordinates
+
+BuildReducedKirchhoffCoordinates[d2e, basePoint] returns reduced affine coordinates on the Kirchhoff manifold.
+
+## BuildSoftPolicyAndPropagate
+
+BuildSoftPolicyAndPropagate[backendState, flowState, potentialState] propagates policy.
+
+## BuildSolverComparisonData
+
+BuildSolverComparisonData[Eqs, solution] returns an association with comparison metrics like Kirchhoff residual and boundary mass balance.
+
+## BuildUtilityReductionResidualData
+
+BuildUtilityReductionResidualData[Eqs, solution] returns utility reduction metrics.
+
+## CheckFlowFeasibility
+
+CheckFlowFeasibility[assoc] returns "Feasible" if all flow variables in assoc are non-negative, and "Infeasible" otherwise.
+
+## ClassifyAndCheckStability
+
+ClassifyAndCheckStability[backendState, flowState, potentialState, history] checks stability.
 
 ## ClearSolveCache
 
 ClearSolveCache[] clears the internal caches used by CachedSolve and CachedReduce.
 Call this between different problem instances to prevent stale results.
+
+## completeScenario
+
+completeScenario[s] fills in derived fields: sets "contentHash" in the Identity block (SHA256 of the canonical Model string), and supplies default Benchmark values ("Tier" -> "core", "Timeout" -> 300) when missing. Returns a new scenario object.
+
+## ComputeKirchhoffResidualFast
+
+ComputeKirchhoffResidualFast[ns, vec] returns the maximum Kirchhoff residual.
+
+## ComputeSignedEdgeFlowsFast
+
+ComputeSignedEdgeFlowsFast[ns, vec] returns a vector of signed edge flows.
 
 ## ConsistentSwitchingCosts
 
@@ -39,14 +96,35 @@ such as, ab to bd and then from db to bc.
 Returns the condition for this switching cost to satisfy the triangle inequality when S, and the other
 switching costs too, does not have a numerical value.
 
+## Cost
+
+Cost[m, edge] is the congestion cost function.
+
 ## CriticalCongestionSolver
 
 CriticalCongestionSolver[Eqs] returns Eqs with an association "AssoCritical" with rules to
-the solution to the critical congestion case. Option: "ReturnShape" (default "Legacy"); use "Standard" to add normalized solver-result keys.
+the solution to the critical congestion case. It returns a standardized association
+containing solver metadata, feasibility, comparison fields, and the solver-specific
+payload key "AssoCritical". Options: "ValidateSolution" (default True), "ValidationTolerance" (default $CriticalSolverTolerance), and "ValidationVerbose" (default False).
+
+## Data2Equations
+
+DataToEquations[Data] returns the equations, inequalities, and alternatives associated to the Data. 
+
+## DataG
+
+GetExampleData[n] returns an Association with keys "Vertices List", "Adjacency Matrix",
+"Entrance Vertices and Flows", "Exit Vertices and Terminal Costs", and "Switching Costs"
+from the test case test[n].
+Supports test cases with 5 fields (basic), 6 fields (+cost function 'a'), or 7 fields (+alpha).
 
 ## DataToEquations
 
 DataToEquations[Data] returns the equations, inequalities, and alternatives associated to the Data. 
+
+## DecodeFlowVector
+
+DecodeFlowVector[ns, vec] returns a flow association from a packed numeric vector.
 
 ## DeduplicateByComplexity
 
@@ -65,30 +143,21 @@ otherwise, absorb elem into xp and continue with sys.
 
 DNFSolveStep[{EE,NN,OR}, rules] takes a grouped system and some Association of rules (a partial solution). It returns the result of applying DNFReduce.
 
-## edge
+## EncodeFlowAssociation
 
-MFGraphs`edge
-
-## edge$
-
-MFGraphs`edge$
+EncodeFlowAssociation[ns, assoc] returns a packed numeric vector from a flow association.
 
 ## EnsureParallelKernels
 
 EnsureParallelKernels[] launches parallel subkernels if none are running.
 
-## expr
+## ExitFlowPlot
 
-MFGraphs`expr
+ExitFlowPlot[exitFlows] produces a bar chart of exit-flow totals from an association mapping exit vertices to numeric flow values. An optional second argument sets the plot title.
 
-## f
+## ExtractBellmanPotentials
 
-MFGraphs`f
-
-## FastIntegratedMass
-
-FastIntegratedMass[interpM, j, edge] computes IntegratedMass using a precomputed interpolation of M.
-interpM should be the result of PrecomputeM.
+ExtractBellmanPotentials[backendState, flowState] extracts node potentials.
 
 ## FinalStep
 
@@ -102,18 +171,75 @@ FlowGathering[auxTriples_List][x_] returns the triples that end with x.
 
 FlowSplitting[AT][UndirectedEdge[a, b]] returns the splitting that start with {a,b}.
 
-## list
+## FlowStyleDirective
 
-MFGraphs`list
+FlowStyleDirective[flow, maxFlow] returns an edge style directive (color/thickness/opacity) scaled by flow magnitude and sign.
 
-## m
+## GetExampleData
 
-MFGraphs`m
+GetExampleData[n] returns an Association with keys "Vertices List", "Adjacency Matrix",
+"Entrance Vertices and Flows", "Exit Vertices and Terminal Costs", and "Switching Costs"
+from the test case test[n].
+Supports test cases with 5 fields (basic), 6 fields (+cost function 'a'), or 7 fields (+alpha).
+
+## GetKirchhoffLinearSystem
+
+GetKirchhoffLinearSystem[d2e] returns the entry current vector, Kirchhoff matrix, and the variables in the order corresponding to the Kirchhoff matrix.
+
+## GetKirchhoffMatrix
+
+GetKirchhoffMatrix[d2e] returns the entry current vector, Kirchhoff matrix, (critical congestion) cost function placeholder, and the variables in the order corresponding to the Kirchhoff matrix. The third slot is retained for backward compatibility and should not be used by new code.
+
+## I1
+
+Symbolic parameter: input flow at entrance 1.
+
+## I2
+
+Symbolic parameter: input flow at entrance 2.
+
+## I3
+
+Symbolic parameter: input flow at entrance 3.
+
+## IneqSwitch
+
+IneqSwitch[u, switchingCosts][v, e1, e2] returns the optimality condition at the vertex v related to switching from e1 to e2. Namely,
+u[v, e1] <= u[v, e2] + switchingCosts[{v, e1, e2}]
+
+## IsCriticalSolution
+
+IsCriticalSolution[Eqs] validates whether the critical-congestion solution stored in "AssoCritical" satisfies the full symbolic MFG constraint set (equalities, inequalities, alternatives/complementarity) and the critical EqGeneral residual. By default it returns True/False. Options: "Tolerance" (default $CriticalSolverTolerance), "Verbose" (default False), and "ReturnReport" (default False).
+
+## IsFeasible
+
+IsFeasible[result] returns True if the solver result indicates a feasible solution (all flows non-negative and constraints satisfied within tolerance).
+
+## IsSwitchingCostConsistent
+
+IsSwitchingCostConsistent[List of switching costs] is True if all switching costs satisfy the triangle inequality. If some switching costs are symbolic, then it returns the consistency conditions.
+
+## j
+
+j[v, e] or j[v, e1, e2] represents a flow variable.
+
+## j$
+
+MFGraphs`j$
+
+## LookupAssociationValue
+
+LookupAssociationValue[assoc, key, default] is a robust Lookup helper.
+
+## makeScenario
+
+makeScenario[assoc] constructs a typed scenario from a raw association. The input must contain a "Model" key whose value is a network topology association accepted by DataToEquations (required keys: "Vertices List", "Adjacency Matrix", "Entrance Vertices and Flows", "Exit Vertices and Terminal Costs", "Switching Costs"). Optional keys: "Data" (parameter substitution rules), "Identity" (name, version), "Benchmark" (tier, timeout), "Visualization", "Inheritance". Returns a scenario[...] object on success or Failure[...] on error.
 
 ## MFGParallelMap
 
 MFGParallelMap[f, list] applies f to each element of list, using ParallelMap
-when Length[list] >= $MFGraphsParallelThreshold, otherwise Map.
+when Length[list] >= $MFGraphsParallelThreshold (and kernels are already running)
+or Length[list] >= $MFGraphsParallelLaunchThreshold (when kernels must be launched).
 
 ## MFGPreprocessing
 
@@ -129,20 +255,27 @@ MFGPrintTemporary[args___] prints a temporary message only when $MFGraphsVerbose
 
 ## MFGSystemSolver
 
-MFGSystemSolver[Eqs][edgeEquations] returns the
-association with rules to the solution
+MFGSystemSolver[Eqs][edgeEquations] returns an Association <|"Solution" -> assoc_or_Null, "UnresolvedConstraints" -> expr_or_None|>. "Solution" is Null on failure; "UnresolvedConstraints" is non-None when flows were determined but u-variables remain symbolically underdetermined.
 
-## NumberMatrixQ
+## MonotoneVariableFieldValue
 
-NumberMatrixQ[A] returns True if the elements of the matrix A are numeric.
+MonotoneVariableFieldValue[var, values, switching] returns the field value for a variable.
+
+## NetEdgeFlows
+
+NetEdgeFlows[d2e, solution, pairs] returns the net signed flow on each requested edge pair after applying balance and boundary flow rules. pairs defaults to all model edges.
+
+## NetworkGraphPlot
+
+NetworkGraphPlot[d2e] plots the network structure contained in the standardized DataToEquations association d2e. An optional second argument sets the plot title. The function is intended for workbook and package-level visualization of the directed network topology.
+
+## NetworkVisualData
+
+NetworkVisualData[d2e] builds reusable graph layout and vertex styling metadata used by plotting helpers.
 
 ## NumberVectorQ
 
 NumberVectorQ[j] returns True if the vector j is numeric.
-
-## p
-
-MFGraphs`p
 
 ## ReduceDisjuncts
 
@@ -226,6 +359,44 @@ Symbolic parameter: switching cost 8.
 
 Symbolic parameter: switching cost 9.
 
+## scenario
+
+scenario[assoc] is the typed head for a MFGraphs scenario object. Use makeScenario to construct one; use ScenarioData to access keys.
+
+## ScenarioData
+
+ScenarioData[s, key] returns the value associated with key in the scenario s, or Missing["KeyAbsent", key] if absent. ScenarioData[s] returns the underlying Association.
+
+## scenarioQ
+
+scenarioQ[x] returns True if x is a typed scenario[assoc_Association] object, False otherwise.
+
+## SelectFlowAssociation
+
+SelectFlowAssociation[assoc] returns a sub-association with only flow (j) keys.
+
+## SolutionFlowPlot
+
+SolutionFlowPlot[d2e, solution] plots the network with edge labels and edge styling determined by the net edge flows implied by solution. An optional third argument sets the plot title. The input d2e should be the standardized DataToEquations association and solution should be an association of replacement rules or solved values compatible with its symbolic flow expressions.
+
+## SolveCriticalFictitiousPlayBackend
+
+SolveCriticalFictitiousPlayBackend[backendState] runs the FP iterative solver.
+
+## SolveCriticalJFirstBackend
+
+SolveCriticalJFirstBackend[Eqs, opts] runs the j-first numeric strategy.
+
+## SolveCriticalJFirstUtilities
+
+SolveCriticalJFirstUtilities[eqs, flowAssoc, uVars, tol] recovers node potentials from flows.
+
+## SolveMFG
+
+SolveMFG[input, opts] solves the critical congestion MFG and returns its standardized result association.
+
+input can be either raw data (association accepted by DataToEquations) or an already compiled equation association.
+
 ## SubstituteSolution
 
 SubstituteSolution[xp, sol] substitutes the Rule sol into the expression xp.
@@ -245,9 +416,9 @@ TripleClean[{{EE,NN,OR},Rules}] composes TripleStep until it reaches a fixed poi
 
 TripleStep[{{EE,NN,OR},Rules}] returns {{NewEE, NewNN, NewOR}, NewRules}, where NewRules contain the solutions to all the equalities found in the system after replacing Rules in {EE,NN,OR}.
 
-## U
+## u
 
-U[x, edge, Eqs, sol] computes the value function at position x on the given edge.
+u[v, e] represents a utility/potential variable.
 
 ## U1
 
@@ -261,17 +432,17 @@ Symbolic parameter: terminal cost at exit 2.
 
 Symbolic parameter: terminal cost at exit 3.
 
-## x
+## UseQuadraticCriticalBackendQ
 
-MFGraphs`x
+UseQuadraticCriticalBackendQ[d2e] returns True if the case is eligible for a quadratic shortcut.
 
-## xi
+## validateScenario
 
-MFGraphs`xi
+validateScenario[s] checks that the scenario s has all required Model keys and that the Model value is an Association. Returns s unchanged on success, or Failure["ScenarioValidation", <|"Message" -> msg, "MissingKeys" -> {...}|>] on failure.
 
-## x$
+## z
 
-MFGraphs`x$
+z[v] represents a vertex potential variable.
 
 ## $MFGraphsParallelReady
 
@@ -279,4 +450,4 @@ False is the symbol for the Boolean value false.
 
 ## $MFGraphsVerbose
 
-True is the symbol for the Boolean value true. 
+False is the symbol for the Boolean value false. 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ A Wolfram Language package for solving **Mean Field Games on networks** with con
 
 MFGraphs converts network topology (vertices, edges, entry/exit flows, switching costs) into systems of equations, then solves for equilibrium flow distributions and value functions using symbolic and numerical methods.
 
+The model keeps its Hamiltonian structure. The active runtime solver surface in this repository targets the critical specialization with edgewise \(\alpha=1\).
+
 ## Quick Navigation
 
 - [Installation](#installation)
 - [Quick start](#quick-start)
 - [Defining a network](#defining-a-network)
-- [Solvers](#solvers) — CriticalCongestionSolver, NonLinearSolver, MonotoneSolver
+- [Solvers](#solvers)
 - [Switching costs](#switching-costs)
 - [Built-in examples](#built-in-examples)
 - [Configuration](#configuration)
@@ -69,10 +71,9 @@ result = CriticalCongestionSolver[d2e];
 result["AssoCritical"]
 ```
 
-Stationary solver results are standardized by default. Each solver returns an association
+Stationary solver results are standardized. Each solver returns an association
 with keys such as `"Solver"`, `"ResultKind"`, `"Feasibility"`, `"Message"`,
-`"Solution"`, `"ComparableFlowVector"`, `"KirchhoffResidual"`, and the solver-specific
-payload key when available: `"AssoCritical"`, `"AssoNonCritical"`, or `"AssoMonotone"`.
+`"Solution"`, `"ComparableFlowVector"`, and `"KirchhoffResidual"`.
 
 ## Defining a network
 
@@ -102,68 +103,13 @@ Symbolic values (e.g., `I1`, `U1`, `S1`) can be used and substituted later with 
 
 ### Critical congestion solver
 
-Solves the special case where all edge flows are zero. This is typically the fastest solver and serves as the starting point for the non-linear solver.
+Solves the critical congestion specialization of the Hamiltonian model ($\alpha=1$ on every edge). This solver uses a combination of symbolic DNF reduction and numeric iterative backends (Fictitious Play) to find global equilibria.
 
 ```mathematica
 Data = GetExampleData[7] /. {I1 -> 50, U1 -> 0, U2 -> 0};
 d2e = DataToEquations[Data];
 result = CriticalCongestionSolver[d2e];
 result["AssoCritical"]
-```
-
-### Non-linear (general congestion) solver
-
-Iteratively solves the full non-linear problem using fixed-point iteration. Uses the critical congestion solution as an initial guess.
-
-```mathematica
-(* Define the potential function V and parameters before solving *)
-V = Function[{x, edge}, 0.5 Sin[2 Pi (x + 1/4)]^2];
-
-Data = GetExampleData[12] /. {I1 -> 100, U1 -> 0};
-d2e = DataToEquations[Data];
-
-(* Solve iteratively (default: up to 15 iterations) *)
-result = NonLinearSolver[d2e];
-
-(* Check the solution *)
-IsNonLinearSolution[result]
-
-(* Access the solution *)
-result["AssoNonCritical"]
-```
-
-Options:
-- `"MaxIterations"` (default `15`) — maximum number of fixed-point iterations
-
-```mathematica
-result = NonLinearSolver[d2e, "MaxIterations" -> 30];
-```
-
-### Monotone operator solver
-
-An ODE-based solver using gradient flow on the Kirchhoff matrix.
-
-```mathematica
-Data = GetExampleData[3] /. {I1 -> 80, U1 -> 0};
-solution = MonotoneSolverFromData[Data]
-```
-
-Standardized result envelope:
-
-```mathematica
-result = MonotoneSolverFromData[Data];
-result["AssoMonotone"]
-result["Convergence"]
-```
-
-Options:
-- `"ResidualTolerance"` (default `10^-6`) — convergence threshold on the reduced monotone flow residual
-- `"MaxTime"` (default `100`) — maximum pseudo-time horizon for the ODE integration
-- `"MaxSteps"` (default `5000`) — maximum `NDSolveValue` step budget
-- `"UseCachedProjection"` (default `True`) — reuse the projected linear solve when the state changes only slightly
-
-```mathematica
-solution = MonotoneSolverFromData[Data, "ResidualTolerance" -> 10^-6, "MaxTime" -> 20, "MaxSteps" -> 2000]
 ```
 
 ## Running tests
@@ -173,29 +119,20 @@ Use the suite runner for the common regression sets:
 ```bash
 wolframscript -file Scripts/RunTests.wls fast
 wolframscript -file Scripts/RunTests.wls slow
-wolframscript -file Scripts/RunTests.wls all
 ```
-
-Tests are currently intended to run locally via `wolframscript` commands above.
 
 ## Plotting
 
-After solving with the non-linear solver, plot mass densities and value functions on each edge:
+Visualize the network and the resulting flows:
 
 ```mathematica
-result = NonLinearSolver[d2e];
+result = CriticalCongestionSolver[d2e];
 
-(* Plot mass density M on a specific edge *)
-PlotMassDensity[result, "AssoNonCritical", {1, 2}]
+(* Plot net flows on the network graph *)
+SolutionFlowPlot[d2e, result["Solution"]]
 
-(* Plot all mass densities *)
-PlotMassDensities[result, "AssoNonCritical"]
-
-(* Plot value function U on a specific edge *)
-PlotValueFunction[result, "AssoNonCritical", {1, 2}]
-
-(* Plot all value functions *)
-PlotValueFunctions[result, "AssoNonCritical"]
+(* Plot exit flow distribution *)
+ExitFlowPlot[result["ExitFlows"]]
 ```
 
 ## Switching costs
@@ -215,43 +152,15 @@ IsSwitchingCostConsistent[Normal @ d2e["SwitchingCosts"]]
 
 ## Built-in examples
 
-Use `GetExampleData[key]` to load predefined test cases:
+Use `GetExampleData[key]` to load predefined test cases (34 available). Common keys include:
 
 | Key | Network |
 |---|---|
-| `1`–`6` | Linear chains (1 to 9 edges) |
 | `7`, `8` | Y-network, 1 entrance, 2 exits (without/with switching) |
-| `9`, `10` | Y-network, 2 entrances, 1 exit (without/with switching) |
 | `11`, `12` | Attraction problem (with/without switching) |
-| `13` | Attraction without middle edge (numerical) |
-| `14` | Triangle with switching |
-| `15` | Y-network, 3 vertices, 2 entrances, with switching |
-| `16` | Invalid switching-cost example |
-| `17`, `18` | 2-edge variants |
-| `19` | Y-network with 2 entrances and switching |
-| `20`–`23` | Larger multi-entrance, multi-exit networks |
-| `27` | Cycle (2 vertices, undirected) |
-| `104` | Triangle with 2 entrances and 3 exits |
-| `105` | Numeric alias for chain with two exits |
-| `"triangle with two exits"` | Triangle with 1 entrance and 2 exits |
-| `"chain with two exits"` | Chain with 1 entrance and 2 exits |
-| `"Braess split"` | Braess paradox — split variant |
 | `"Braess congest"` | Braess paradox — congestion variant |
-| `"New Braess"` | Braess with edge-dependent costs |
-| `"Big Braess split"` | Extended Braess — split variant |
-| `"Big Braess congest"` | Extended Braess — congestion variant |
 | `"Jamaratv9"` | Jamarat pilgrimage network (9 vertices) |
-| `"HRF Scenario 1"` | HRF reference scenario |
 | `"Paper example"` | 4-vertex network with 2 entrances, 2 exits, and switching |
-| `"Inconsistent Y shortcut"` | Y-network with deliberately inconsistent switching costs |
-| `"Inconsistent attraction shortcut"` | Attraction network with a deliberately inconsistent shortcut turn |
-| `"Grid0303"` | 3 x 3 grid graph |
-| `"Grid0404"` | 4 x 4 grid graph |
-| `"Grid0505"` | 5 x 5 grid graph |
-| `"Grid0707"` | 7 x 7 grid graph |
-| `"Grid0710"` | 7 x 10 grid graph |
-| `"Grid1010"` | 10 x 10 grid graph |
-| `"Grid1020"` | 10 x 20 grid graph |
 
 ## Configuration
 
@@ -263,21 +172,6 @@ Progress and timing messages are printed by default. Suppress them with:
 $MFGraphsVerbose = False;
 ```
 
-### Hamiltonian parameters
-
-The non-linear solver uses a Hamiltonian framework. Override these before calling `NonLinearSolver`:
-
-```mathematica
-(* Congestion exponent (default: 1) *)
-alpha[edge_] := 1
-
-(* Interaction potential (default: -1/m^2) *)
-g[m_, edge_] := -1/m^2
-
-(* Potential function (must be defined by the user for non-linear solving) *)
-V = Function[{x, edge}, 0.5 Sin[2 Pi (x + 1/4)]^2];
-```
-
 ## Package structure
 
 ```
@@ -285,13 +179,10 @@ MFGraphs/
   MFGraphs.wl             Package loader, SolveMFG unified entrypoint
   DNFReduce.wl            Boolean algebra (disjunctive normal form reduction)
   DataToEquations.wl      Network topology → equation converter
-  Solvers.wl              Critical-congestion solver suite (extracted Phase 3)
-  NonLinearSolver.wl      Iterative non-linear solver and Hamiltonian framework
-  Monotone.wl             Monotone operator (ODE-based) solver
-  TimeDependentSolver.wl  Time-dependent MFG solver
+  Solvers.wl              Critical-congestion solver suite
   Graphics.wl             Public visualization helpers (NetworkGraphPlot, SolutionFlowPlot, ExitFlowPlot)
   Examples/
-    ExamplesData.wl        34 built-in test cases via GetExampleData[key]
+    ExamplesData.wl        Built-in test cases via GetExampleData[key]
   Tests/
     *.mt                   MUnit test files
   Kernel/
@@ -303,47 +194,20 @@ Scripts/
   GenerateDocs.wls         Automated API documentation generator
 ```
 
-### Maintenance
+## Archived non-critical solvers
 
-To regenerate the API documentation:
+Non-critical solver families are archived from active runtime paths, but recoverable from tags:
+
+- `archive/non-critical-solvers`
+- `archive/non-critical-solvers-full`
+
+Useful retrieval commands:
+
 ```bash
-wolframscript -file Scripts/GenerateDocs.wls
-```
-```
-
-## Examples
-
-All examples are reproducible by running the code in this README using the `GetExampleData[key]` function, which provides 34 built-in test cases. See the [Built-in examples](#built-in-examples) table for available keys.
-
-## End-to-end example
-
-A complete workflow for a Braess-paradox network with congestion:
-
-```mathematica
-<< MFGraphs`
-
-(* Load the Braess congestion example *)
-Data = GetExampleData["Braess congest"];
-
-(* Convert to equations *)
-d2e = DataToEquations[Data];
-
-(* View the constructed graph *)
-d2e["auxiliaryGraph"]
-
-(* Solve the critical congestion case *)
-critical = CriticalCongestionSolver[d2e];
-critical["AssoCritical"]
-
-(* Define potential and solve the non-linear case *)
-V = Function[{x, edge}, 0];
-
-nonlinear = NonLinearSolver[critical];
-IsNonLinearSolution[nonlinear]
-
-(* Plot the results *)
-GraphicsGrid[Partition[PlotMassDensities[nonlinear, "AssoNonCritical"], 3]]
-GraphicsGrid[Partition[PlotValueFunctions[nonlinear, "AssoNonCritical"], 3]]
+git show archive/non-critical-solvers:MFGraphs/NonLinearSolver.wl
+git checkout archive/non-critical-solvers -- MFGraphs/NonLinearSolver.wl
+git show archive/non-critical-solvers-full:MFGraphs/Monotone.wl
+git checkout archive/non-critical-solvers-full -- MFGraphs/Monotone.wl
 ```
 
 ## License


### PR DESCRIPTION
Summary\n- preserve underdetermined critical solutions as symbolic feasible regions instead of demoting to infeasible\n- add and propagate UnresolvedEquations in critical result envelopes and validation flow\n- keep Hamiltonian model wording explicit while documenting active runtime specialization at edgewise alpha=1\n- finalize archive discoverability for removed non-critical solver families via archive/non-critical-solvers-full\n- regenerate API reference from package usage metadata\n\nValidation\n- wolframscript -file Scripts/RunTests.wls fast\n- Tests run: 50\n- Passed: 50\n- Failed: 0\n\nNotes\n- non-critical solver source, test, and script artifacts remain retrievable via archive tags