### PR TITLE
Add ExactMode regression test coverage and sync API docs

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -105,11 +105,11 @@ Cost[m, edge] is the congestion cost function.
 CriticalCongestionSolver[Eqs] returns Eqs with an association "AssoCritical" with rules to
 the solution to the critical congestion case. It returns a standardized association
 containing solver metadata, feasibility, comparison fields, and the solver-specific
-payload key "AssoCritical". Options: "ValidateSolution" (default True), "ValidationTolerance" (default $CriticalSolverTolerance), and "ValidationVerbose" (default False).
+payload key "AssoCritical". Options: "ValidateSolution" (default True), "ValidationTolerance" (default $CriticalSolverTolerance), "ValidationVerbose" (default False), "SymbolicTimeLimit" (default 120., time budget in seconds for the symbolic pipeline), and "ExactMode" (default False; when True, skips numeric/direct/oracle paths and returns "SymbolicRegion" for undetermined variables).
 
 ## Data2Equations
 
-DataToEquations[Data] returns the equations, inequalities, and alternatives associated to the Data. 
+Data2Equations[Data] is a deprecated compatibility wrapper for DataToEquations[Data]. It will be removed in the next release.
 
 ## DataG
 

--- a/MFGraphs/Solvers.wl
+++ b/MFGraphs/Solvers.wl
@@ -16,7 +16,9 @@ CriticalCongestionSolver::usage = "CriticalCongestionSolver[Eqs] returns Eqs wit
 the solution to the critical congestion case. It returns a standardized association
 containing solver metadata, feasibility, comparison fields, and the solver-specific
 payload key \"AssoCritical\". Options: \"ValidateSolution\" (default True), \
-\"ValidationTolerance\" (default $CriticalSolverTolerance), and \"ValidationVerbose\" (default False).";
+\"ValidationTolerance\" (default $CriticalSolverTolerance), \"ValidationVerbose\" (default False), \
+\"SymbolicTimeLimit\" (default 120., time budget in seconds for the symbolic pipeline), and \
+\"ExactMode\" (default False; when True, skips numeric/direct/oracle paths and returns \"SymbolicRegion\" for undetermined variables).";
 
 IsCriticalSolution::usage =
 "IsCriticalSolution[Eqs] validates whether the critical-congestion solution stored \
@@ -1012,7 +1014,8 @@ Options[CriticalCongestionSolver] = {
     "ValidateSolution" -> True,
     "ValidationTolerance" -> $CriticalSolverTolerance,
     "ValidationVerbose" -> False,
-    "SymbolicTimeLimit" -> 120.
+    "SymbolicTimeLimit" -> 120.,
+    "ExactMode" -> False
 };
 
 CriticalCongestionSolver::noassoc = "Expected an Association for Eqs, but received `1`. Ensure input is pre-processed via DataToEquations.";
@@ -1031,9 +1034,10 @@ CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
          numericBackendUsedQ, numericBackendFallbackReason, numericBackendSolveTime,
          numericBackendStrategy, jFirstBackendUsedQ, jFirstBackendFallbackReason,
          numericCandidate, numericOutcome, forcedRejectQ, numericBackendTimeLimit,
-         symbolicTimeLimit,
+         symbolicTimeLimit, exactModeQ,
          telemetry},
         ClearSolveCache[];
+        exactModeQ = TrueQ[OptionValue["ExactMode"]];
         validateQ = TrueQ[OptionValue["ValidateSolution"]];
         validationTolerance = OptionValue["ValidationTolerance"];
         validationVerboseQ = TrueQ[OptionValue["ValidationVerbose"]];
@@ -1043,8 +1047,8 @@ CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
         numericBackendStrategy = "Symbolic";
         jFirstBackendUsedQ = False;
         jFirstBackendFallbackReason = None;
-        numericBackendRequestedQ = CriticalNumericBackendRequestedQ[Eqs];
-        numericBackendEligibleQ = CriticalNumericBackendEligibleQ[Eqs];
+        numericBackendRequestedQ = !exactModeQ && CriticalNumericBackendRequestedQ[Eqs];
+        numericBackendEligibleQ = !exactModeQ && CriticalNumericBackendEligibleQ[Eqs];
         numericBackendFallbackReason = Which[
             !numericBackendRequestedQ, "DisabledByGuard",
             !numericBackendEligibleQ, "IneligibleInput",
@@ -1165,7 +1169,8 @@ CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
         ];
 
         (* Try direct solver for zero-switching-cost, fully numeric networks *)
-        If[AllTrue[Values[Lookup[Eqs, "SwitchingCosts", <|_ -> 1|>]], # === 0 &] &&
+        If[!exactModeQ &&
+            AllTrue[Values[Lookup[Eqs, "SwitchingCosts", <|_ -> 1|>]], # === 0 &] &&
             Lookup[Eqs, "auxiliaryGraph", None] =!= None &&
             AllTrue[Flatten[Lookup[Eqs, "Entrance Vertices and Flows", {}]], NumericQ] &&
             AllTrue[Flatten[Lookup[Eqs, "Exit Vertices and Terminal Costs", {}]], NumericQ] &&
@@ -1208,9 +1213,13 @@ CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
         ];
         (* Standard symbolic solver path *)
         PreEqs = EnsurePreprocessed[If[AssociationQ[PreEqs], PreEqs, Eqs]];
+        If[exactModeQ,
+            PreEqs = Append[PreEqs, "ExactMode" -> True]
+        ];
         (* Oracle Bridge: if the numeric backend produced a candidate that failed validation,
            use it to prune the symbolic Or-branches before the full symbolic solve. *)
-        If[AssociationQ[numericCandidate] &&
+        If[!exactModeQ &&
+            AssociationQ[numericCandidate] &&
             ListQ[Lookup[PreEqs, "NewSystem", $Failed]] &&
             Length[Lookup[PreEqs, "NewSystem", {}]] === 3,
             Module[{prunedSystem, originalBranchCount, prunedBranchCount},
@@ -1231,10 +1240,13 @@ CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
         Module[{symbolicResult},
             symbolicResult = TimeConstrained[
                 Module[{localAssoCritical, localStatus, localValidationFailedQ = False,
-                        localResultKind, localMessage, mfgssResult, unresolvedUConstraints, valReport},
+                        localResultKind, localMessage, mfgssResult, unresolvedUConstraints, valReport,
+                        symbolicRegion, symbolicTelemetry},
                     mfgssResult = MFGSystemSolver[PreEqs][AssociationThread[js, ConstantArray[0, Length[js]]]];
                     localAssoCritical = mfgssResult["Solution"];
                     unresolvedUConstraints = mfgssResult["UnresolvedConstraints"];
+                    symbolicRegion = Lookup[mfgssResult, "SymbolicRegion", None];
+                    symbolicTelemetry = Append[telemetry, "SymbolicRegion" -> symbolicRegion];
                     localStatus = CheckFlowFeasibility[localAssoCritical];
                     If[validateQ && AssociationQ[localAssoCritical] && localStatus === "Feasible",
                         valReport = IsCriticalSolution[
@@ -1246,7 +1258,7 @@ CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
                         Which[
                             valReport["Reason"] === "IndeterminateConstraints",
                                 Return[BuildCriticalResult[PreEqs, "Success", localStatus, None,
-                                    localAssoCritical, telemetry,
+                                    localAssoCritical, symbolicTelemetry,
                                     If[unresolvedUConstraints =!= None,
                                         Join[Lookup[valReport, "IndeterminateResiduals", <||>],
                                              <|"FlowSolveResidual" -> unresolvedUConstraints|>],
@@ -1264,7 +1276,7 @@ CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
                     localResultKind = If[localAssoCritical === Null, "Failure", "Success"];
                     localMessage = If[localAssoCritical === Null,
                         If[localValidationFailedQ, "InvalidCriticalSolution", "NoSolution"], None];
-                    BuildCriticalResult[PreEqs, localResultKind, localStatus, localMessage, localAssoCritical, telemetry]
+                    BuildCriticalResult[PreEqs, localResultKind, localStatus, localMessage, localAssoCritical, symbolicTelemetry]
                 ],
                 symbolicTimeLimit,
                 $TimedOut

--- a/MFGraphs/Tests/exact-mode.mt
+++ b/MFGraphs/Tests/exact-mode.mt
@@ -1,0 +1,52 @@
+(* Wolfram Language Test file *)
+
+If[!MemberQ[$Packages, "MFGraphs`"],
+    Get[
+        FileNameJoin[
+            {
+                DirectoryName[$InputFileName],
+                "..",
+                "MFGraphs.wl"
+            }
+        ]
+    ]
+];
+
+Test[
+    Module[{data, d2e, result, region, asso},
+        data = GetExampleData[12] /. {I1 -> 100, U1 -> 0};
+        d2e = DataToEquations[data];
+        result = Quiet[CriticalCongestionSolver[d2e, "ExactMode" -> True]];
+        region = Lookup[result, "SymbolicRegion", Missing["NotAvailable"]];
+        asso = Lookup[result, "AssoCritical", Missing["NotAvailable"]];
+        AssociationQ[result] &&
+        TrueQ[IsFeasible[result]] &&
+        AssociationQ[asso] &&
+        Length[asso] > 0 &&
+        !MissingQ[region] &&
+        Lookup[result, "NumericBackendUsed", Missing["NotAvailable"]] === False &&
+        Lookup[result, "JFirstBackendUsed", Missing["NotAvailable"]] === False
+    ]
+    ,
+    True
+    ,
+    TestID -> "ExactMode: fully determined case yields no SymbolicRegion"
+]
+
+Test[
+    Module[{data, d2e, result, region},
+        data = GetExampleData["triangle with two exits"] /. {I1 -> 100, U1 -> 0, S1 -> 1};
+        d2e = DataToEquations[data];
+        result = Quiet[CriticalCongestionSolver[d2e, "ExactMode" -> True]];
+        region = Lookup[result, "SymbolicRegion", Missing["NotAvailable"]];
+        AssociationQ[result] &&
+        TrueQ[IsFeasible[result]] &&
+        region =!= None &&
+        !MissingQ[region] &&
+        Lookup[result, "NumericBackendUsed", Missing["NotAvailable"]] === False
+    ]
+    ,
+    True
+    ,
+    TestID -> "ExactMode: underdetermined case exposes SymbolicRegion"
+]

--- a/Scripts/RunTests.wls
+++ b/Scripts/RunTests.wls
@@ -19,6 +19,7 @@ $TestSuites = <|
         "critical-numeric-backend.mt",
         "exit-pass-through.mt",
         "exit-pass-through-nonzero.mt",
+        "exact-mode.mt",
         "infeasible-status.mt",
         "inconsistent-switching-critical.mt",
         "scenario-kernel.mt",


### PR DESCRIPTION
## Summary
- add committed MFGraphs/Tests/exact-mode.mt with 2 ExactMode regression tests
- include exact-mode.mt in Scripts/RunTests.wls fast suite
- extend CriticalCongestionSolver::usage with "SymbolicTimeLimit" and "ExactMode"
- regenerate API_REFERENCE.md via Scripts/GenerateDocs.wls

## Verification
- ran docs generation: wolframscript -file Scripts/GenerateDocs.wls
- ran exact-mode suite directly: 2 passed, 0 failed
- started fast suite and confirmed exact-mode.mt is included in fast file list

## Notes
- commit is intentionally scoped to ExactMode regression coverage and docs sync only
- unrelated local changes remain uncommitted