### PR TITLE
Add Data2Equations deprecation updates and test helper scripts

### DIFF
--- a/Scripts/RunSingleTest.wls
+++ b/Scripts/RunSingleTest.wls
@@ -1,0 +1,31 @@
+#!/usr/bin/env wolframscript
+(* Run a single MUnit .mt file and print TestReport summary.
+   Usage: wolframscript -file Scripts/RunSingleTest.wls MFGraphs/Tests/<name>.mt *)
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
+
+PrependTo[$Path, Directory[]];
+Needs["MFGraphs`"];
+$MFGraphsVerbose = False;
+
+args = Select[Rest[$ScriptCommandLine], !StringEndsQ[#, ".wls"] &];
+If[args === {}, Print["Missing test file argument"]; Exit[1]];
+testFile = First[args];
+
+Print["Running: ", testFile];
+report = TestReport[testFile];
+
+Print["Passed: ", report["TestsSucceededCount"]];
+Print["Failed: ", report["TestsFailedCount"]];
+If[report["TestsFailedCount"] > 0,
+    Print["\nFailed tests:"];
+    KeyValueMap[
+        Print["  [", #2["Outcome"], "] ", #2["TestID"]] &,
+        Select[report["TestResults"], !MatchQ[#["Outcome"], "Success"] &]
+    ];
+    Exit[1]
+];
+Exit[0];
+
+(* :!CodeAnalysis::EndBlock:: *)

--- a/Scripts/SmokeTestExactMode.wls
+++ b/Scripts/SmokeTestExactMode.wls
@@ -1,0 +1,45 @@
+#!/usr/bin/env wolframscript
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
+
+(* ExactMode smoke test: verify that the new "ExactMode" -> True path on
+   CriticalCongestionSolver returns determined rules in "AssoCritical" and
+   the symbolic residual (when present) in "SymbolicRegion". *)
+
+Needs["MFGraphs`"];
+
+runCase[label_, dataExpr_, expectSymbolic_] :=
+    Module[{data, d2e, res, asso, region},
+        Print["--- ", label, " ---"];
+        data = dataExpr;
+        d2e = DataToEquations[data];
+        res = CriticalCongestionSolver[d2e, "ExactMode" -> True];
+        If[!AssociationQ[res],
+            Print["  FAIL: result not an Association: ", res];
+            Return[False, Module]
+        ];
+        Print["  IsFeasible      : ", IsFeasible[res]];
+        Print["  Status          : ", Lookup[res, "Status", Missing["absent"]]];
+        Print["  NumericBackend  : ", Lookup[res, "NumericBackendUsed", Missing["absent"]]];
+        Print["  JFirstBackend   : ", Lookup[res, "JFirstBackendUsed", Missing["absent"]]];
+        region = Lookup[res, "SymbolicRegion", Missing["absent"]];
+        asso = Lookup[res, "AssoCritical", Missing["absent"]];
+        Print["  SymbolicRegion  : ", region];
+        Print["  AssoCritical    : ", asso];
+        If[expectSymbolic,
+            Print[If[region =!= None && !MissingQ[region], "  OK: SymbolicRegion present", "  WARN: expected SymbolicRegion"]],
+            Print[If[region === None || MissingQ[region], "  OK: fully determined", "  WARN: unexpected SymbolicRegion"]]
+        ];
+        True
+    ];
+
+runCase["Case 12 / I1=100 (expected: fully determined)",
+    GetExampleData[12] /. {I1 -> 100, U1 -> 0},
+    False];
+runCase["triangle with two exits (expected: symbolic region)",
+    GetExampleData["triangle with two exits"] /. {I1 -> 100, U1 -> 0, S1 -> 1},
+    True];
+
+Print["Done."];
+
+(* :!CodeAnalysis::EndBlock:: *)

--- a/repro/quick/quick_readme_smoke.wls
+++ b/repro/quick/quick_readme_smoke.wls
@@ -1,0 +1,33 @@
+#!/usr/bin/env wolframscript
+
+PrependTo[$Path, Directory[]];
+Needs["MFGraphs`"];
+
+failures = {};
+
+assert[cond_, label_] := If[TrueQ[cond], Null, AppendTo[failures, label]];
+
+(* README quick start smoke *)
+data = MFGraphs`GetExampleData[12] /. {MFGraphs`I1 -> 100, MFGraphs`U1 -> 0};
+d2e = MFGraphs`DataToEquations[data];
+result = MFGraphs`CriticalCongestionSolver[d2e];
+
+assert[AssociationQ[d2e], "DataToEquations returns an association"];
+assert[AssociationQ[result], "CriticalCongestionSolver returns an association"];
+assert[KeyExistsQ[result, "Feasibility"], "Result contains Feasibility key"];
+assert[KeyExistsQ[result, "Solution"], "Result contains Solution key"];
+
+(* README plotting snippet smoke *)
+networkPlot = MFGraphs`NetworkGraphPlot[d2e];
+flowPlot = MFGraphs`SolutionFlowPlot[d2e, result["Solution"]];
+
+assert[Head[networkPlot] === Graph, "NetworkGraphPlot returns Graph"];
+assert[Head[flowPlot] === Graph, "SolutionFlowPlot returns Graph"];
+
+If[failures === {},
+  Print["README smoke check: PASS"];
+  Exit[0],
+  Print["README smoke check: FAIL"];
+  Scan[Print["  - ", #] &, failures];
+  Exit[1]
+];


### PR DESCRIPTION
## Summary
- add Data2Equations deprecation wrapper and related package-loading checks
- refresh README for the current critical-only repository surface
- add ExactMode regression coverage and docs sync from usage metadata
- add helper scripts for single-test runs and quick smoke checks

## Notes
- branch also includes local developer helper scripts under Scripts/ and repro/quick/
- local lockfile .claude/scheduled_tasks.lock remains untracked and is not included