### PR TITLE
Remove FindInstance fallback from MFGSystemSolver

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -105,7 +105,7 @@ Cost[m, edge] is the congestion cost function.
 CriticalCongestionSolver[Eqs] returns Eqs with an association "AssoCritical" with rules to
 the solution to the critical congestion case. It returns a standardized association
 containing solver metadata, feasibility, comparison fields, and the solver-specific
-payload key "AssoCritical". Options: "ValidateSolution" (default True), "ValidationTolerance" (default $CriticalSolverTolerance), "ValidationVerbose" (default False), "SymbolicTimeLimit" (default 120., time budget in seconds for the symbolic pipeline), and "ExactMode" (default False; when True, skips numeric/direct/oracle paths and returns "SymbolicRegion" for undetermined variables).
+payload key "AssoCritical". Options: "ValidateSolution" (default True), "ValidationTolerance" (default $CriticalSolverTolerance), "ValidationVerbose" (default False), "SymbolicTimeLimit" (default 120., time budget in seconds for the symbolic pipeline), and "ExactMode" (default False; when True, skips numeric/direct/oracle paths).
 
 ## Data2Equations
 

--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -999,11 +999,10 @@ BuildOraclePrunedSystem[system_, flowAssoc_Association, oracleState_Association,
 (* --- MFGSystemSolver --- *)
 
 MFGSystemSolver[Eqs_][approxJs_] :=
-    Module[{NewSystem, InitRules, pickOne, pickOneFlowOnly, vars, System, Ncpc, costpluscurrents,
-         us, js, jts, jjtsR, time, ineqsByTransition, uResidual,
-         ineqsWithoutTransition = {}, exactModeQ},
+    Module[{NewSystem, InitRules, System, Ncpc, costpluscurrents,
+         us, js, jts, time, ineqsByTransition,
+         ineqsWithoutTransition = {}},
         ClearSolveCache[];
-        exactModeQ = TrueQ[Lookup[Eqs, "ExactMode", False]];
         us = Lookup[Eqs, "us", $Failed];
         js = Lookup[Eqs, "js", $Failed];
         jts = Lookup[Eqs, "jts", $Failed];
@@ -1102,69 +1101,22 @@ MFGSystemSolver[Eqs_][approxJs_] :=
                 Return[<|"Solution" -> Null, "UnresolvedConstraints" -> None|>, Module]
             ,
             System =!= True,
-                MFGPrint["MFGSS: (Possibly) Multiple solutions:\n", System
+                MFGPrint["MFGSS: Multiple solutions; returning symbolic region"];
+                InitRules = Expand /@
+                    FixedPoint[
+                        Function[r, ReplaceAll[r] /@ r],
+                        InitRules,
+                        10
                     ];
-                (* Exact mode: skip FindInstance and return the determined rules
-                   alongside the unresolved constraint region. *)
-                If[exactModeQ,
-                    InitRules = Expand /@ FixedPoint[Function[r, ReplaceAll[r] /@ r], InitRules, 10];
-                    InitRules = Join[KeyTake[InitRules, us], KeyTake[InitRules, js], KeyTake[InitRules, jts]];
-                    Return[<|
-                        "Solution" -> InitRules,
-                        "SymbolicRegion" -> System,
-                        "UnresolvedConstraints" -> System
-                    |>, Module]
+                InitRules = Join[
+                    KeyTake[InitRules, us],
+                    KeyTake[InitRules, js],
+                    KeyTake[InitRules, jts]
                 ];
-                (* Extract all unsolved variables from System *)
-                vars = Select[Variables[System], MatchQ[#, j[_, _, _]
-                     | j[_, _] | u[_, _] | u[_, _, _]]&];
-                vars = Complement[vars, Keys[InitRules]];
-                jjtsR = Select[vars, MatchQ[#, j[_, _, _] | j[_, _]]&
-                    ];
-
-(* Pick one solution so that all the currents have numerical values
-    *)
-                If[Length[vars] > 0,
-                    (* Attempt to find a solution *)
-                    pickOne = FindInstance[System && And @@ ((# > 0)&
-                         /@ jjtsR), vars, Reals];
-                    If[pickOne === {},
-                        pickOne = FindInstance[System && And @@ ((# >=
-                             0)& /@ jjtsR), vars, Reals]
-                    ];
-                    If[pickOne =!= {},
-                        pickOne = Association @ First @ pickOne;
-                        MFGPrint["MFGSS: Picked one solution: ", pickOne
-                            ];
-                        InitRules = Expand /@ Join[InitRules /. pickOne,
-                             pickOne]
-                        ,
-                        (* Both full-variable attempts failed. Try flows-only: WL existentially
-                           quantifies over u vars, finding j values for which some u satisfies System. *)
-                        pickOneFlowOnly = If[jjtsR =!= {},
-                            FindInstance[System && And @@ ((# >= 0)& /@ jjtsR), jjtsR, Reals],
-                            {}
-                        ];
-                        If[pickOneFlowOnly =!= {},
-                            pickOneFlowOnly = Association @ First @ pickOneFlowOnly;
-                            MFGPrint["MFGSS: Flow-only solution found (u underdetermined): ", pickOneFlowOnly];
-                            InitRules = Expand /@ Join[InitRules /. pickOneFlowOnly, pickOneFlowOnly];
-                            uResidual = Simplify[System /. pickOneFlowOnly];
-                            (* Resolve transitive chains early so the result is usable downstream *)
-                            InitRules = Expand /@ FixedPoint[Function[r, ReplaceAll[r] /@ r], InitRules, 10];
-                            InitRules = Join[KeyTake[InitRules, us], KeyTake[InitRules, js], KeyTake[InitRules, jts]];
-                            Return[<|"Solution" -> InitRules, "UnresolvedConstraints" -> uResidual|>, Module]
-                            ,
-                            MFGPrint["MFGSS: No feasible solution found"];
-                            Return[<|"Solution" -> Null, "UnresolvedConstraints" -> None|>, Module]
-                        ]
-                    ]
-                    ,
-(* All variables already solved — nothing to pick 
-    *)
-                    MFGPrint["MFGSS: All variables already determined in InitRules"
-                        ]
-                ]
+                Return[<|
+                    "Solution" -> InitRules,
+                    "UnresolvedConstraints" -> System
+                |>, Module]
             ,
             True,
                 MFGPrint["MFGSS: System is ", System]

--- a/MFGraphs/Solvers.wl
+++ b/MFGraphs/Solvers.wl
@@ -18,7 +18,7 @@ containing solver metadata, feasibility, comparison fields, and the solver-speci
 payload key \"AssoCritical\". Options: \"ValidateSolution\" (default True), \
 \"ValidationTolerance\" (default $CriticalSolverTolerance), \"ValidationVerbose\" (default False), \
 \"SymbolicTimeLimit\" (default 120., time budget in seconds for the symbolic pipeline), and \
-\"ExactMode\" (default False; when True, skips numeric/direct/oracle paths and returns \"SymbolicRegion\" for undetermined variables).";
+\"ExactMode\" (default False; when True, skips numeric/direct/oracle paths).";
 
 IsCriticalSolution::usage =
 "IsCriticalSolution[Eqs] validates whether the critical-congestion solution stored \
@@ -1213,9 +1213,6 @@ CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
         ];
         (* Standard symbolic solver path *)
         PreEqs = EnsurePreprocessed[If[AssociationQ[PreEqs], PreEqs, Eqs]];
-        If[exactModeQ,
-            PreEqs = Append[PreEqs, "ExactMode" -> True]
-        ];
         (* Oracle Bridge: if the numeric backend produced a candidate that failed validation,
            use it to prune the symbolic Or-branches before the full symbolic solve. *)
         If[!exactModeQ &&
@@ -1241,12 +1238,11 @@ CriticalCongestionSolver[Eqs_Association, OptionsPattern[]] :=
             symbolicResult = TimeConstrained[
                 Module[{localAssoCritical, localStatus, localValidationFailedQ = False,
                         localResultKind, localMessage, mfgssResult, unresolvedUConstraints, valReport,
-                        symbolicRegion, symbolicTelemetry},
+                        symbolicTelemetry},
                     mfgssResult = MFGSystemSolver[PreEqs][AssociationThread[js, ConstantArray[0, Length[js]]]];
                     localAssoCritical = mfgssResult["Solution"];
                     unresolvedUConstraints = mfgssResult["UnresolvedConstraints"];
-                    symbolicRegion = Lookup[mfgssResult, "SymbolicRegion", None];
-                    symbolicTelemetry = Append[telemetry, "SymbolicRegion" -> symbolicRegion];
+                    symbolicTelemetry = Append[telemetry, "SymbolicRegion" -> unresolvedUConstraints];
                     localStatus = CheckFlowFeasibility[localAssoCritical];
                     If[validateQ && AssociationQ[localAssoCritical] && localStatus === "Feasible",
                         valReport = IsCriticalSolution[

--- a/MFGraphs/Tests/exact-mode.mt
+++ b/MFGraphs/Tests/exact-mode.mt
@@ -13,16 +13,17 @@ If[!MemberQ[$Packages, "MFGraphs`"],
 ];
 
 Test[
-    Module[{data, d2e, result, region, asso},
+    Module[{data, d2e, result, asso, region},
         data = GetExampleData[12] /. {I1 -> 100, U1 -> 0};
         d2e = DataToEquations[data];
         result = Quiet[CriticalCongestionSolver[d2e, "ExactMode" -> True]];
-        region = Lookup[result, "SymbolicRegion", Missing["NotAvailable"]];
         asso = Lookup[result, "AssoCritical", Missing["NotAvailable"]];
+        region = Lookup[result, "SymbolicRegion", Missing["NotAvailable"]];
         AssociationQ[result] &&
         TrueQ[IsFeasible[result]] &&
         AssociationQ[asso] &&
         Length[asso] > 0 &&
+        region =!= None &&
         !MissingQ[region] &&
         Lookup[result, "NumericBackendUsed", Missing["NotAvailable"]] === False &&
         Lookup[result, "JFirstBackendUsed", Missing["NotAvailable"]] === False
@@ -30,7 +31,7 @@ Test[
     ,
     True
     ,
-    TestID -> "ExactMode: fully determined case yields no SymbolicRegion"
+    TestID -> "ExactMode: case 12 returns symbolic feasible envelope without numeric backends"
 ]
 
 Test[
@@ -43,7 +44,8 @@ Test[
         TrueQ[IsFeasible[result]] &&
         region =!= None &&
         !MissingQ[region] &&
-        Lookup[result, "NumericBackendUsed", Missing["NotAvailable"]] === False
+        Lookup[result, "NumericBackendUsed", Missing["NotAvailable"]] === False &&
+        Lookup[result, "JFirstBackendUsed", Missing["NotAvailable"]] === False
     ]
     ,
     True


### PR DESCRIPTION
## Summary
- remove the `FindInstance` point-picking fallback from `MFGSystemSolver` in underdetermined symbolic cases
- make underdetermined symbolic outcomes deterministic by always returning:
  - `"Solution" -> InitRules`
  - `"UnresolvedConstraints" -> System`
- stop threading inner symbolic-region extraction through ad-hoc keys and use `UnresolvedConstraints` as source of truth in `CriticalCongestionSolver` telemetry (`"SymbolicRegion"`)
- keep outer `"ExactMode"` as numeric/direct/oracle gating and update usage/docs accordingly
- add committed regression tests in `MFGraphs/Tests/exact-mode.mt` and include them in the fast suite

## Files
- `MFGraphs/DataToEquations.wl`
- `MFGraphs/Solvers.wl`
- `MFGraphs/Tests/exact-mode.mt` (new)
- `Scripts/RunTests.wls`
- `API_REFERENCE.md` (regenerated)

## Verification
- `wolframscript -file MFGraphs/Tests/exact-mode.mt` (pass)
- `wolframscript -file Scripts/RunTests.wls fast` (fails with broad pre-existing baseline in this branch snapshot; exact-mode tests are included)
- `wolframscript -file Scripts/GenerateDocs.wls`
