### PR TITLE
Remove deprecated nonlinear/monotone solver residue from active surfaces

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-This document describes the benchmarking and profiling infrastructure for the MFGraphs package, along with the algorithmic optimizations implemented to address identified bottlenecks.
+This document describes the active benchmarking flow for the MFGraphs package.
+The benchmark suite now targets the critical solver path only.
 
 ## Running benchmarks
 
@@ -29,20 +30,13 @@ wolframscript -file Scripts/BenchmarkSuite.wls large
 wolframscript -file Scripts/BenchmarkSuite.wls vlarge
 ```
 
-**Backward compatibility:** `medium` is kept as an alias for `core` but `core` is preferred in new scripts.
-
 Run a specific case with a custom timeout:
 
 ```bash
 wolframscript -file Scripts/BenchmarkSuite.wls core case=7 timeout=3600
-wolframscript -file Scripts/BenchmarkSuite.wls core case=8 timeout=3600
 ```
 
-Results are exported to `Results/benchmark_latest.csv` and `Results/benchmark_latest.json`, plus timestamped copies. Timestamped benchmark filenames now include seconds, and the suite rewrites the current run's exports after each completed case so partial progress is preserved if a later case is interrupted.
-
-`NonLinearSolver` and `MonotoneSolver` are benchmarked with a critical seed from the same case when available (to reduce wall-clock benchmark time and isolate incremental post-critical cost). The exported rows include:
-- `IncrementalSolveTime`: measured runtime of the seeded post-critical solver (NonLinear or Monotone)
-- `EstimatedStandaloneSolveTime`: `CriticalCongestion SolveTime + IncrementalSolveTime` (estimate of standalone timing for that solver)
+Results are exported to `Results/benchmark_latest.csv` and `Results/benchmark_latest.json`, plus timestamped copies.
 
 ### Bottleneck profiling
 
@@ -64,15 +58,9 @@ This generates `Results/bottleneck_report.md` with detailed call counts and timi
 | large | 13, 19-23, Braess variants, Jamaratv9, Grid0303 | 900s | Multi-entrance/exit, larger graphs |
 | vlarge | Grid1020 | 1800s | 200-vertex grid; stress test designed to hit RecursionLimit |
 
-**Note on vlarge tier:** `Grid1020` is a deliberate stress test with 200 vertices and 220 edges. Symbolic solvers may not terminate or may exceed `RecursionLimit` by design. Run this tier to validate solver behavior under resource constraints, not for performance measurement.
-
-## Solvers benchmarked
+## Solver benchmarked
 
 1. **CriticalCongestionSolver** -- Symbolic solver for the zero-flow case. Uses `Solve`, `Reduce`, `DNFReduce` (disjunctive normal form), and `TripleClean` (fixed-point simplification).
-
-2. **NonLinearSolver** -- Iterative fixed-point solver for general congestion. Calls `MFGSystemSolver` up to 15 times per solve, with `FindRoot`/`NIntegrate` for Hamiltonian cost evaluation.
-
-3. **MonotoneSolver** -- Reduced-coordinate Hessian Riemannian Flow using `NDSolveValue`, explicit convergence metadata, and a cached projected linear solve.
 
 ## Identified bottlenecks
 
@@ -80,25 +68,9 @@ This generates `Results/bottleneck_report.md` with detailed call counts and timi
 
 `DNFReduce` in `DNFReduce.wl` recursively converts boolean expressions to disjunctive normal form. For `Or` expressions with N branches, this creates up to 2^N recursive paths. Each path calls `Solve` (via `ReDNFReduce`) and `Reduce`, with no caching of results across branches.
 
-**Impact**: Dominates CriticalCongestionSolver runtime for cases with switching costs (keys 8, 10, 11, 14, Braess variants).
-
 ### 2. TripleClean fixed-point iteration
 
 `TripleClean` in `DataToEquations.wl` repeatedly calls `TripleStep` until convergence. Each step calls `Solve` on the equality subsystem. Called multiple times per solver invocation (once in `MFGPreprocessing`, again in `MFGSystemSolver`).
-
-**Impact**: 5-10 iterations typical; each iteration involves symbolic solve of increasing complexity.
-
-### 3. Projected linear solve in MonotoneSolver
-
-`GradientProjection` in `Monotone.wl` builds the Hessian projection operator at every ODE evaluation step. Even with caching, this remains one of the dominant Monotone costs on larger graphs because the projected linear system must be refactorized whenever the state changes materially.
-
-**Impact**: Still dominates MonotoneSolver runtime for larger graphs (Grid0303+), even after switching the implementation away from unconditional `PseudoInverse`.
-
-### 4. Per-point FindRoot/NIntegrate
-
-`M[j, x, edge]` in `NonLinearSolver.wl` calls `FindRoot` for every (j, x) evaluation point. `IntegratedMass` wraps this in `NIntegrate`, which samples M at many points. Called per-edge, per-iteration of `NonLinearSolver`.
-
-**Impact**: Significant for problems with many edges and many `NonLinearSolver` iterations.
 
 ## Optimizations implemented
 
@@ -106,79 +78,28 @@ This generates `Results/bottleneck_report.md` with detailed call counts and timi
 
 **File**: `MFGraphs/DNFReduce.wl`
 
-Added a hash-based cache (`$SolveCache`) for `Solve` results within `ReDNFReduce`. The same equality often appears across multiple branches of an `Or` expression; memoization avoids redundant symbolic solves.
-
-- `CachedSolve[eq]` -- hash-based lookup/store wrapper around `Solve`
-- `ClearSolveCache[]` -- called at solver entry points to prevent stale results
-
-**Expected impact**: 30-70% fewer `Solve` calls on cases with switching costs.
+Added a hash-based cache (`$SolveCache`) for `Solve` results within `ReDNFReduce`.
 
 ### Optimization 2: DNFReduce branch pruning
 
 **File**: `MFGraphs/DNFReduce.wl`
 
-Added early-exit checks:
-- `DNFReduce[xp, And[fst, rst]]` returns `False` immediately when `xp === False`
-- `DNFReduce[xp, Or[fst, scd]]` skips `False` branches in the result instead of creating trivial Or expressions
+Added early-exit checks and reduced branching work for trivial false branches.
 
-**Expected impact**: Avoids exponential blowup on inconsistent branches.
-
-### Optimization 3: Projection-solve caching in MonotoneSolver
-
-**File**: `MFGraphs/Monotone.wl`
-
-Added `CachedGradientProjection` that caches the projected linear solve data and reuses it when the flow vector `x` hasn't changed beyond a tolerance threshold (default 10^-6).
-
-- Controlled by `"UseCachedProjection" -> True` option (default)
-- Set `"UseCachedProjection" -> False` to force a fresh projection solve each time
-
-**Expected impact**: Significant speedup for larger graphs where the projection build dominates.
-
-### Optimization 4: M interpolation for NonLinearSolver
-
-**File**: `MFGraphs/NonLinearSolver.wl`
-
-Added `PrecomputeM[jMin, jMax, edge, nPoints]` that builds an `InterpolatingFunction` from a grid of `FindRoot` evaluations. `FastIntegratedMass` and `FastIntegratedMass` use this interpolation instead of per-point `FindRoot` calls.
-
-- `nPoints` controls grid resolution (default 50)
-- Users can switch between exact (`Cost`/`IntegratedMass`) and fast (`FastIntegratedMass`/`FastIntegratedMass`) versions
-
-**Expected impact**: Large speedup for NIntegrate-heavy iterations; slight numerical approximation controlled by grid resolution.
-
-### Optimization 5: DNFReduce sequential And-Or with early exit
-
-**File**: `MFGraphs/DNFReduce.wl`
-
-The And-Or distribution case (`DNFReduce[xp_, And[fst_Or, rst_]]`) previously evaluated all disjuncts of `fst` unconditionally using `Map`. Replaced with a sequential `Do` loop and `Catch/Throw` that exits as soon as any branch returns `r === xp` — the same short-circuit condition used in the existing 2-arg Or case. When a branch leaves `xp` unchanged, it means the Or constraint is already satisfied, so remaining branches cannot contribute new information.
-
-**Expected impact**: Fewer branch evaluations for And-Or patterns in well-constrained systems; symmetric to the existing Or short-circuit which showed dramatic speedup on cases 11 and 12.
-
-### Optimization 6: TripleStep Solve memoization
+### Optimization 3: TripleStep Solve memoization
 
 **File**: `MFGraphs/DataToEquations.wl`
 
-Both overloads of `TripleStep` called `Solve` directly. Replaced with `CachedSolve` (already defined in `DNFReduce.wl`) so that identical equality systems encountered within a single `MFGSystemSolver` invocation (between `ClearSolveCache` calls) are solved only once.
-
-**Expected impact**: Modest reduction in `Solve` calls during multi-step `TripleClean` fixed-point iteration.
-
-### Optimization 7: NonLinearSolver tolerance-based early stopping
-
-**File**: `MFGraphs/NonLinearSolver.wl`
-
-Added `"Tolerance" -> 0` option to `NonLinearSolver`. When `Tolerance > 0`, iteration switches from `FixedPointList` (exact equality on Associations, rarely fires for floating-point results) to `NestWhileList` with a norm-based stopping condition: stops when the infinity-norm change in flow variables between consecutive iterations is below the tolerance.
-
-**Usage**: `NonLinearSolver[d2e, "Tolerance" -> 10^-6]`
-
-**Expected impact**: Significant savings when problems converge in fewer than `MaxIterations` steps; previously all 15 iterations ran regardless of numerical convergence.
+`TripleStep` now uses cached solve results for repeated equality systems.
 
 ## Profiling scripts
 
 | Script | Purpose |
 |--------|---------|
-| `Scripts/BenchmarkSuite.wls` | Full benchmark across all tiers and solvers |
+| `Scripts/BenchmarkSuite.wls` | Full benchmark across all tiers for `CriticalCongestion` |
 | `Scripts/BenchmarkHelpers.wls` | Helper functions (SafeExecute, GraphMetadata, parameter tables) |
 | `Scripts/ProfileInstrument.wls` | Non-invasive DownValues-based profiling wrappers |
-| `Scripts/BottleneckReport.wls` | Runs profiled solvers on representative cases |
+| `Scripts/BottleneckReport.wls` | Runs profiled solver on representative cases |
 
 ## Results format
 
@@ -188,21 +109,20 @@ Benchmark results are exported as CSV and JSON with these fields:
 |-------|-------------|
 | Key | Test case identifier |
 | Tier | small/core/stress/large/vlarge |
-| Solver | CriticalCongestion/NonLinearSolver/Monotone |
+| Solver | CriticalCongestion |
 | NumVertices | Graph vertex count |
 | NumEdges | Graph edge count |
 | D2ETime | DataToEquations wall time (seconds) |
 | SolveTime | Solver wall time (seconds) |
 | SolveMemory | Peak memory delta (bytes) |
 | Status | OK/TIMEOUT/FAILED/SKIPPED |
-| Residual | Infinity-norm of the shared Kirchhoff residual (comparable across all stationary solvers) |
+| Residual | Infinity-norm of the shared Kirchhoff residual |
 | EquationResidual | Infinity-norm of the equation residual, computed on the public solver result |
-| StopReason | Convergence stop reason for iterative solvers (`ToleranceMet`, `MaxTimeReached`, etc.) |
-| ConvergenceResidual | Iterative solver convergence residual (separate from Kirchhoff feasibility) |
+| StopReason | Convergence stop reason when reported |
+| ConvergenceResidual | Reported convergence residual when present |
 | Iterations | Iteration or accepted-step count reported by the solver |
 
 ## Recommendations for future work
 
-1. **Parallel DNFReduce branches**: `Or` branches in `DNFReduce` are independent and could be evaluated in parallel using `ParallelMap`. Note: parallel kernels do not share `$SolveCache`/`$ReduceCache`, so cache benefits would be per-branch only.
-2. **Compiled Hamiltonian**: Use `Compile` or `FunctionCompile` for the Hamiltonian `H` and mass function `M` to reduce per-evaluation overhead (feasible for the default `alpha`, `g` but not user-overridden versions).
-3. **Sparse matrix operations**: For large graphs (Grid1020), switch from dense `PseudoInverse` to sparse `LinearSolve` with pre-factorization.
+1. **Parallel DNFReduce branches**: `Or` branches in `DNFReduce` are independent and could be evaluated in parallel.
+2. **Sparse matrix operations**: For large graphs, prioritize sparse `LinearSolve` paths when possible.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,7 +210,7 @@ wolframscript -file Scripts/BenchmarkSuite.wls --tag "description of change" --r
 
 The package follows a linear pipeline: **network data → equations → solver**.
 
-**Unified entrypoint** — `SolveMFG[data, Method -> m, opts]` accepts raw data or compiled equations and dispatches to the appropriate solver. With `Method -> "Automatic"`, it cascades: CriticalCongestion → Monotone → NonLinear, falling back on infeasibility or failure. When `"CongestionExponentFunction"` specifies alpha != 1 (scalar, Association, or Function), CriticalCongestion is skipped since it only handles alpha=1. Hamiltonian options (`"PotentialFunction"`, `"CongestionExponentFunction"`, `"InteractionFunction"`) and all downstream solver options are declared in `Options[SolveMFG]` and forwarded via `FilterRules`. `"CongestionExponentFunction"` accepts a scalar, `Function[edge, ...]`, or an `Association` mapping edges to exponents (unlisted edges default to 1); all forms are normalized by `NormalizeEdgeFunction`. Returns a standardized result envelope plus `"MethodUsed"` and `"MethodTrace"` keys.
+**Unified entrypoint** — `SolveMFG[data, Method -> m, opts]` accepts raw data or compiled equations. `Method -> "Automatic"` and `Method -> "CriticalCongestion"` both route to the critical solver path and return the standardized result envelope. Unknown methods return a failure envelope with `"Message" -> "UnknownMethod"`.
 
 **Individual solvers** can also be called directly:
 
@@ -222,13 +222,9 @@ DataToEquations[data]                    (DataToEquations.wl)
 CriticalCongestionSolver[d2e]           (Solvers.wl, uses DNFReduce.wl)
   ├─ DirectCriticalSolver[d2e]           (fast path for zero-switching-cost networks)
   └─ MFGSystemSolver + DNFSolveStep      (general case with switching costs)
-  ↓
-NonLinearSolver[criticalResult]  or  MonotoneSolverFromData[data]
 ```
 
 **Solver selection**: `CriticalCongestionSolver` automatically dispatches to `DirectCriticalSolver` for networks with no switching costs (much faster); otherwise uses the full symbolic pipeline.
-
-**MonotoneSolver vs MonotoneSolverFromData**: `MonotoneSolverFromData[data]` accepts raw data and calls `DataToEquations` internally. `MonotoneSolver[d2e]` accepts pre-compiled equations. `SolveMFG` uses `MonotoneSolver` when given compiled input, `MonotoneSolverFromData` otherwise.
 
 ### Module load order
 
@@ -238,10 +234,8 @@ Defined in `MFGraphs.wl`:
 3. `DNFReduce.wl` — Boolean algebra solver (disjunctive normal form reduction with Solve/Reduce memoization, branch pruning, and post-reduction via `ReduceDisjuncts`/`SubsumptionPrune`)
 4. `DataToEquations.wl` — Core converter: network topology → equations; implements `DataToEquations`, `MFGSystemSolver`, `MFGPreprocessing`, `TripleClean`
 5. `Solvers.wl` — Critical-congestion solver suite extracted from `DataToEquations.wl` (Phase 3 refactor); implements `CriticalCongestionSolver`, `DirectCriticalSolver`, `IsCriticalSolution`
-6. `NonLinearSolver.wl` — Iterative fixed-point solver (`NonLinearSolver`) using Hamiltonian framework (up to 15 iterations)
-7. `Monotone.wl` — ODE-based gradient flow solver on Kirchhoff matrix using `NDSolve`
-8. `TimeDependentSolver.wl` — Time-dependent MFG solver using backward-forward sweep on discretized time grid
-9. `Graphics.wl` — Public visualization helpers: `NetworkGraphPlot`, `SolutionFlowPlot`, `ExitFlowPlot`
+6. `TimeDependentSolver.wl` — Time-dependent MFG solver using backward-forward sweep on discretized time grid
+7. `Graphics.wl` — Public visualization helpers: `NetworkGraphPlot`, `SolutionFlowPlot`, `ExitFlowPlot`
 
 After submodule loading, `MFGraphs.wl` defines `SolveMFG` — the unified entrypoint (see Pipeline overview).
 
@@ -275,41 +269,34 @@ System decomposition (triple `{EE, NN, OR}`):
 
 ### Solver chain & return formats
 
-`NonLinearSolver` expects the output of `CriticalCongestionSolver` (reads `"AssoCritical"` key). Benchmark suite follows: `DataToEquations → CriticalCongestionSolver → NonLinearSolver`.
-
-All stationary solvers now return a **standardized result envelope** by default:
+Critical solver outputs return a **standardized result envelope**:
 
 ```mathematica
-<| "Solver" -> "NonLinearSolver",
+<| "Solver" -> "CriticalCongestion",
    "ResultKind" -> "Success"|"Failure"|"Degenerate"|"NonConverged",
    "Feasibility" -> "Feasible"|"Infeasible",
    "Message" -> "...",
    "Solution" -> {...},
    "ComparableFlowVector" -> {...},
    "KirchhoffResidual" -> ...,
-   "AssoNonCritical" -> {...}  (* solver-specific payload key *)
+   "AssoCritical" -> {...}
 |>
 ```
-
-Solver-specific payload keys: `"AssoCritical"`, `"AssoNonCritical"`, `"AssoMonotone"`.
 
 `SolveMFG` results additionally include `"MethodUsed"` and `"MethodTrace"`.
 
 **Checking solutions**:
 - `IsFeasible[result]` — accepts both legacy `"Status"` and standard `"Feasibility"`
-- `IsNonLinearSolution[result]` — validates solution structure
 - When `"Status"` is `"Infeasible"`, flow variables (`j[...]`) contain negative values (indicates no feasible solution)
 
 ### Choosing the right solver
 
 | Solver | Best For | Speed | Notes |
 |--------|----------|-------|-------|
-| **CriticalCongestionSolver** | Symbolic, congestion exponent α=1, understanding structure | Seconds–minutes | Always try this first; serves as initial guess for other solvers. Fast path for zero-switching-cost networks. |
-| **NonLinearSolver** | General non-linear (α≠1), fixed-point iteration | Minutes–hours | Requires potential function `V` defined. Starts from critical congestion seed. Up to 15 iterations. |
-| **MonotoneSolver** | Gradient flow, ODE-based alternative | Minutes–hours | Uses Kirchhoff matrix. Good for comparison/validation. Slower but sometimes finds solutions NonLinear misses. |
-| **SolveMFG with Method→"Automatic"** | Auto-routing, fallback cascades | Varies | Cascades: CriticalCongestion → Monotone → NonLinear. Adds `"MethodUsed"` and `"MethodTrace"` to results. |
+| **CriticalCongestionSolver** | Symbolic critical-congestion solves and structure analysis | Seconds–minutes | Fast path for zero-switching-cost networks. |
+| **SolveMFG with Method→"Automatic"** | Standardized public entrypoint | Varies | Routes to critical solver and adds `"MethodUsed"`/`"MethodTrace"`. |
 
-**When you'll use Phase 5/6 (Fictitious Play backend):** If you add support for non-linear congestion exponents (α ≠ 1) to `CriticalCongestionSolver`, the symbolic `DNFReduce` pipeline may timeout or fail, triggering the numeric backend as fallback. Phase 5/6 prepares this handoff (currently internal-only pending issue resolution).
+**When you'll use Phase 5/6 (Fictitious Play backend):** for internal numeric experiments and support discovery when symbolic critical workflows struggle on hard instances.
 
 ### Phase 5 & 6: Fictitious Play Backend (Internal v1)
 
@@ -320,7 +307,7 @@ Solver-specific payload keys: `"AssoCritical"`, `"AssoNonCritical"`, `"AssoMonot
 - Pure functional state machine with immutable compound state Association
 - Returns standardized backend result envelope with History, IterationLog, and full state snapshots
 - Options: `MaxIterations` (20), `Temperature` (0.1), `Damping` (0.5), plus all Phase 4 thresholds
-- **Use case**: Future support discovery for non-linear cases (α ≠ 1) when exact symbolic path fails
+- **Use case**: Future support discovery and internal numeric experimentation when exact symbolic paths fail
 
 **Phase 6: `BuildOraclePrunedSystem`** (`DataToEquations.wl` line ~1922)
 - Two-step Oracle pruning bridge translating `OracleState` from Phase 4 into a partially pruned `{EE, NN, OR}` triple
@@ -499,7 +486,7 @@ $MFGraphsParallelReady = True;
 
 (* Run solver and check parallel execution *)
 $MFGraphsVerbose = True;
-result = NonLinearSolver[d2e];
+result = CriticalCongestionSolver[d2e];
 ```
 
 If parallel dispatch doesn't trigger, check:

--- a/MFGraphs/Getting started.wl
+++ b/MFGraphs/Getting started.wl
@@ -53,8 +53,6 @@ ClearMFGraphsNotebookShadows[] :=
             "GetExampleData",
             "DataToEquations",
             "CriticalCongestionSolver",
-            "NonLinearSolver",
-            "MonotoneSolverFromData",
             "IsSwitchingCostConsistent",
             "PlotMassDensity",
             "PlotValueFunction",
@@ -228,28 +226,6 @@ DensityNetworkGraphic[d2e_Association, solution_Association, title_: Automatic, 
         ]
     ];
 
-MassDensityCurve[result_Association, pair_List] :=
-    Show[
-        MFGraphs`Private`PlotMassDensity[result, "AssoNonCritical", pair],
-        PlotLabel -> Style[
-            Row[{"Mass density along edge ", pair}],
-            14,
-            Bold
-        ],
-        AxesLabel -> {"Position on edge", "Density"}
-    ];
-
-ValueFunctionCurve[result_Association, pair_List] :=
-    Show[
-        MFGraphs`Private`PlotValueFunction[result, "AssoNonCritical", pair],
-        PlotLabel -> Style[
-            Row[{"Value function along edge ", pair}],
-            14,
-            Bold
-        ],
-        AxesLabel -> {"Position on edge", "Value"}
-    ];
-
 (* ExitFlowPlot now lives in Graphics.wl. *)
 
 (* Jamarat helper: solve one release/cost scenario and summarize exit usage. *)
@@ -388,141 +364,7 @@ DescribeOutput[
 ]
 
 
-(* --- 5. Non-linear congestion solver and plots --- *)
-
-Module[{potentialFunction, congestionExponentFunction, interactionFunction},
-    potentialFunction = Function[{x, edge},
-        Which[
-            edge === UndirectedEdge[1, 2], 0.25 x,
-            edge === UndirectedEdge[2, 4], 0.5,
-            True, 0
-        ]
-    ];
-    congestionExponentFunction = Function[edge,
-        If[edge === UndirectedEdge[2, 4], 1.3, 1.0]
-    ];
-    interactionFunction = Function[{m, edge},
-        -If[edge === UndirectedEdge[2, 4], 1.5, 1.0] / m^2
-    ];
-    nonlinearData = GetExampleData[12] /. {
-        I1 -> 2,
-        U1 -> 0
-    };
-    nonlinearD2E = DataToEquations[nonlinearData];
-    nonlinearResult = NonLinearSolver[
-        nonlinearD2E,
-        "MaxIterations" -> 5,
-        "Tolerance" -> 10^-8,
-        "PotentialFunction" -> potentialFunction,
-        "CongestionExponentFunction" -> congestionExponentFunction,
-        "InteractionFunction" -> interactionFunction
-    ];
-    Column[{
-        DescribeOutput[
-            "Non-linear solver solution",
-            "This fixed-point solve includes the edge Hamiltonian and congestion interaction, so densities and values respond to the chosen V, alpha, and g.",
-            nonlinearResult["Solution"]
-        ],
-        DescribeOutput[
-            "Non-linear equilibrium net flows",
-            "Thickness and labels summarize the net current on each edge after the non-linear congestion update converges.",
-            SolutionFlowPlot[
-                nonlinearD2E,
-                nonlinearResult["Solution"],
-                "Non-linear equilibrium net flows"
-            ]
-        ],
-        DescribeOutput[
-            "Non-linear edge densities",
-            "Warm colors mark locally denser parts of the network. The legend is pointwise density, not total edge flow.",
-            WithHamiltonianFunctions[
-                potentialFunction,
-                congestionExponentFunction,
-                interactionFunction,
-                DensityNetworkGraphic[
-                    nonlinearD2E,
-                    nonlinearResult["Solution"],
-                    "Non-linear density map"
-                ]
-            ]
-        ],
-        DescribeOutput[
-            "Mass density on edge {1, 2}",
-            "This one-dimensional slice shows how density changes with normalized position along a selected edge.",
-            WithHamiltonianFunctions[
-                potentialFunction,
-                congestionExponentFunction,
-                interactionFunction,
-                MassDensityCurve[nonlinearResult, {1, 2}]
-            ]
-        ],
-        DescribeOutput[
-            "Value function on edge {1, 2}",
-            "This plot shows the value perceived by agents as they move along the same edge under the non-linear equilibrium.",
-            WithHamiltonianFunctions[
-                potentialFunction,
-                congestionExponentFunction,
-                interactionFunction,
-                ValueFunctionCurve[nonlinearResult, {1, 2}]
-            ]
-        ]
-    }]
-]
-
-
-(* --- 6. Monotone solver --- *)
-
-Module[{potentialFunction, congestionExponentFunction, interactionFunction},
-    potentialFunction = Function[{x, edge}, 0];
-    congestionExponentFunction = Function[edge, 1];
-    interactionFunction = Function[{m, edge}, -1 / m^2];
-    monotoneData = GetExampleData[3] /. {
-        I1 -> 80,
-        U1 -> 0
-    };
-    monotoneResult = MonotoneSolverFromData[
-        monotoneData,
-        "ResidualTolerance" -> 10^-6,
-        "MaxTime" -> 10,
-        "MaxSteps" -> 2000,
-        "PotentialFunction" -> potentialFunction,
-        "CongestionExponentFunction" -> congestionExponentFunction,
-        "InteractionFunction" -> interactionFunction
-    ];
-    Column[{
-        DescribeOutput[
-            "Monotone solver solution",
-            "The Hessian-Riemannian flow evolves the Kirchhoff variables until it reaches a monotone equilibrium.",
-            monotoneResult["Solution"]
-        ],
-        DescribeOutput[
-            "Monotone solver net flows",
-            "This graph shows the final net currents produced by the monotone solver on the simple path example.",
-            SolutionFlowPlot[
-                DataToEquations[monotoneData],
-                monotoneResult["Solution"],
-                "Monotone solver net flows"
-            ]
-        ],
-        DescribeOutput[
-            "Monotone edge densities",
-            "With the same baseline Hamiltonian, the edge color gradient shows how density varies along the path under the monotone solution.",
-            WithHamiltonianFunctions[
-                potentialFunction,
-                congestionExponentFunction,
-                interactionFunction,
-                DensityNetworkGraphic[
-                    DataToEquations[monotoneData],
-                    monotoneResult["Solution"],
-                    "Monotone density map"
-                ]
-            ]
-        ]
-    }]
-]
-
-
-(* --- 7. Jamarat / pilgrimage crowd routing --- *)
+(* --- 5. Jamarat / pilgrimage crowd routing --- *)
 
 (* The built-in Jamarat network has two entrances and three exits. *)
 jamaratTemplate = GetExampleData["Jamaratv9"];
@@ -629,7 +471,6 @@ Column[{
    ];
 
    Once you have calibrated edge classes for wide corridors, ramps, and merges,
-   reuse the same pattern from the non-linear section above on the Jamarat graph.
+   reuse the same visualization and comparison pattern on the Jamarat graph.
    In practice, start with the critical-congestion symbolic solve to screen release
-   plans and destination costs, then move to NonLinearSolver only after the graph
-   geometry and demand windows are calibrated. *)
+   plans and destination costs, then iterate on graph geometry and demand windows. *)

--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -1593,30 +1593,23 @@ SolveMFGRunStage[
 
 SolveMFGAutomaticDispatch[input_Association, opts_List] :=
     Module[{d2e, result = Missing["NotAvailable"], decision, trace = {}, methodUsed = "Automatic",
-            attempts},
+            attempt = "CriticalCongestion"},
         d2e = If[SolveMFGCompiledInputQ[input], input, Quiet @ SolveMFGCompileInput[input, opts]];
         If[!AssociationQ[d2e],
             Return[SolveMFGAbortResult["DataToEquationsFailed", methodUsed, trace], Module]
         ];
-        attempts = {"CriticalCongestion"};
-        Do[
-            result = SolveMFGRunStage[attempt, d2e, opts, "Automatic"];
-            decision = SolveMFGClassifyOutcome[result];
-            methodUsed = attempt;
-            trace = Append[trace, SolveMFGBuildTraceEntry[methodUsed, result, decision]];
-            Switch[decision,
-                "Done",
-                    Return[SolveMFGFinalizeWithTrace[result, methodUsed, trace], Module],
-                "Fallback",
-                    Null,
-                _,
-                    Return[SolveMFGAbortResult["InvalidSolverReturnShape", methodUsed, trace], Module]
-            ],
-            {attempt, attempts}
-        ];
-        If[AssociationQ[result],
-            SolveMFGFinalizeWithTrace[result, methodUsed, trace],
-            SolveMFGAbortResult["InvalidSolverReturnShape", methodUsed, trace]
+        result = SolveMFGRunStage[attempt, d2e, opts, "Automatic"];
+        decision = SolveMFGClassifyOutcome[result];
+        methodUsed = attempt;
+        trace = Append[trace, SolveMFGBuildTraceEntry[methodUsed, result, decision]];
+        Switch[decision,
+            "Done" | "Fallback",
+                If[AssociationQ[result],
+                    SolveMFGFinalizeWithTrace[result, methodUsed, trace],
+                    SolveMFGAbortResult["InvalidSolverReturnShape", methodUsed, trace]
+                ],
+            _,
+                SolveMFGAbortResult["InvalidSolverReturnShape", methodUsed, trace]
         ]
     ];
 

--- a/Scripts/BenchmarkHelpers.wls
+++ b/Scripts/BenchmarkHelpers.wls
@@ -220,9 +220,9 @@ SafeExecute[expr_, timeout_:300] :=
 
 ComputeResidual::usage =
 "ComputeResidual[eqs, solKey] computes the infinity-norm residual from the solver output.
-solKey should be \"AssoCritical\", \"AssoNonCritical\", or \"AssoMonotone\".";
+solKey defaults to \"AssoCritical\".";
 
-ComputeResidual[eqs_Association, solKey_String:"AssoNonCritical"] :=
+ComputeResidual[eqs_Association, solKey_String:"AssoCritical"] :=
   Module[{sol, nlhs, nrhs, diff},
     sol = Lookup[eqs, solKey, <||>];
     nlhs = Lookup[eqs, "Nlhs", {}];
@@ -473,13 +473,13 @@ $BenchmarkProfiles = <|
     "Tiers" -> {"small", "core"},
     "Solvers" -> {"critical"}
   |>,
-  "nonlinear-kkt" -> <|
+  "kkt-stress" -> <|
     "Tiers" -> {"core", "stress", "paper"},
-    "Solvers" -> {"nonlinear"}
+    "Solvers" -> {"critical"}
   |>,
   "dnf-paper" -> <|
     "Tiers" -> {"paper", "inconsistent-switching"},
-    "Solvers" -> {"all"}
+    "Solvers" -> {"critical"}
   |>
 |>;
 
@@ -489,8 +489,6 @@ DisplaySolverName[r_Association] :=
   Module[{base, details = {}},
     base = Switch[r["Solver"],
       "CriticalCongestion", "Critical",
-      "NonLinearSolver", "NonLinear",
-      "Monotone", "Monotone",
       "ALL", "Combined",
       "DataToEquations", "Preprocessing",
       _, r["Solver"]

--- a/Scripts/BenchmarkSuite.wls
+++ b/Scripts/BenchmarkSuite.wls
@@ -1,7 +1,7 @@
 #!/usr/bin/env wolframscript
 (* Usage: wolframscript -file Scripts/BenchmarkSuite.wls [tier] [case=key] [timeout=seconds] [isolation=mode] [solver=name] [tag=label] [rationale=...] [changes=...] [interpretation=...] *)
 (* tier: "small", "core", "stress", "paper", "inconsistent-switching", "large", "vlarge", legacy "medium", or "all" (default: "all") *)
-(* solver: "critical" (default), "nonlinear", "monotone", "all" *)
+(* solver: "critical" (default) *)
 
 (* :!CodeAnalysis::Disable::SuspiciousSessionSymbol::Print *)
 
@@ -136,9 +136,7 @@ If[$SelectedProfile =!= None,
       $SolversToRun = Lookup[profileData, "Solvers", {"critical"}];
       $SolversToRun = Switch[#,
         "critical" | "criticalcongestion", "CriticalCongestion",
-        "nonlinear" | "nl",               "NonLinearSolver",
-        "monotone" | "mono",              "Monotone",
-        "all",                            {"CriticalCongestion", "NonLinearSolver", "Monotone"},
+        "all",                            "CriticalCongestion",
         s_String, s,
         l_List, l,
         _, "CriticalCongestion"
@@ -158,12 +156,10 @@ If[$SelectedProfile =!= None,
   (* Resolve solver selection *)
   $SolversToRun = Switch[$SelectedSolverArg,
     "critical" | "criticalcongestion", {"CriticalCongestion"},
-    "nonlinear" | "nl",               {"CriticalCongestion", "NonLinearSolver"},
-    "monotone" | "mono",              {"CriticalCongestion", "Monotone"},
-    "all",                            {"CriticalCongestion", "NonLinearSolver", "Monotone"},
+    "all",                            {"CriticalCongestion"},
     _,
       Print["Unknown solver argument: ", $SelectedSolverArg,
-            ". Valid values: critical, nonlinear, monotone, all."];
+            ". Valid values: critical, all."];
       Exit[2]
   ];
 
@@ -180,7 +176,7 @@ If[$SelectedProfile =!= None,
   ];
 ];
 
-(* When only CriticalCongestion is requested, suppress the seed-only runs *)
+(* Critical-only benchmark suite *)
 $CriticalOnlyMode = $SolversToRun === {"CriticalCongestion"};
 
 Print["Selected profile: ", If[$SelectedProfile === None, "None", $SelectedProfile]];
@@ -222,31 +218,18 @@ BenchmarkOneSolver[key_, tier_String, solverName_String, d2e_Association, timeou
       solveMemory = Missing["N/A"], executionMode = Missing["N/A"],
       rawResult = Missing["NotAvailable"], resultKind = Missing["NotAvailable"],
       feasibility = Missing["NotAvailable"], solverMessage = Missing["NotAvailable"],
-      runContext, returnExecution, solverInput,
-      criticalSeedUsed = False, criticalSolveTime = Missing["N/A"],
-      estimatedStandaloneSolveTime = Missing["N/A"], verification = "N/A",
+      runContext, returnExecution, solverInput, verification = "N/A",
       row},
     runContext = OptionValue["RunContext"];
     returnExecution = TrueQ[OptionValue["ReturnExecution"]];
     meta = GraphMetadata[d2e];
     solverInput = d2e;
 
-    If[MemberQ[{"NonLinearSolver", "Monotone"}, solverName],
-      criticalSeedUsed = TrueQ[Lookup[runContext, "UsedCriticalSeed", False]];
-      criticalSolveTime = Lookup[runContext, "CriticalSolveTime", Missing["N/A"]];
-    ];
-
-    Print["  Solver: ", solverName,
-          If[criticalSeedUsed, " (seeded from critical)", ""],
-          " (timeout: ", timeout, "s)"];
+    Print["  Solver: ", solverName, " (timeout: ", timeout, "s)"];
 
     result = Switch[solverName,
       "CriticalCongestion",
         SafeExecute[CriticalCongestionSolver[solverInput], timeout],
-      "NonLinearSolver",
-        SafeExecute[NonLinearSolver[solverInput], timeout],
-      "Monotone",
-        SafeExecute[MonotoneSolver[solverInput], timeout],
       _,
         <|"Time" -> 0, "Memory" -> 0, "Status" -> "SKIPPED", "Result" -> "Unknown solver"|>
     ];
@@ -281,8 +264,6 @@ BenchmarkOneSolver[key_, tier_String, solverName_String, d2e_Association, timeou
       ];
       equationResidual = Switch[solverName,
         "CriticalCongestion", ComputeResidual[Join[d2e, rawResult], "AssoCritical"],
-        "NonLinearSolver", ComputeResidual[Join[d2e, rawResult], "AssoNonCritical"],
-        "Monotone", ComputeResidual[Join[d2e, rawResult], "AssoMonotone"],
         _, Missing["N/A"]
       ]
     ];
@@ -293,21 +274,9 @@ BenchmarkOneSolver[key_, tier_String, solverName_String, d2e_Association, timeou
         Lookup[rawResult, "AssoCritical", Null]];
     ];
 
-    If[MemberQ[{"NonLinearSolver", "Monotone"}, solverName],
-      estimatedStandaloneSolveTime =
-        If[criticalSeedUsed && NumericQ[criticalSolveTime] && NumericQ[result["Time"]],
-          criticalSolveTime + result["Time"],
-          result["Time"]
-        ]
-    ];
-
     Print["    Status: ", result["Status"],
           " | Time: ", FormatTime[solveTime], "s",
           " | Memory: ", FormatMemoryMB[solveMemory], " MB",
-          If[MemberQ[{"NonLinearSolver", "Monotone"}, solverName] && NumericQ[estimatedStandaloneSolveTime],
-            " | Standalone est.: " <> FormatTime[estimatedStandaloneSolveTime] <> "s",
-            ""
-          ],
           If[verification =!= "N/A", " | Ref: " <> verification, ""]];
 
     row = <|
@@ -332,13 +301,10 @@ BenchmarkOneSolver[key_, tier_String, solverName_String, d2e_Association, timeou
       "Message" -> solverMessage,
       "Residual" -> residual,
       "EquationResidual" -> equationResidual,
-      "UsedCriticalSeed" -> If[MemberQ[{"NonLinearSolver", "Monotone"}, solverName], criticalSeedUsed, Missing["N/A"]],
       "NumericBackendUsed" -> If[solverName === "CriticalCongestion",
         TrueQ[Lookup[rawResult, "NumericBackendUsed", False]],
         Missing["N/A"]
       ],
-      "IncrementalSolveTime" -> If[MemberQ[{"NonLinearSolver", "Monotone"}, solverName], result["Time"], Missing["N/A"]],
-      "EstimatedStandaloneSolveTime" -> If[MemberQ[{"NonLinearSolver", "Monotone"}, solverName], estimatedStandaloneSolveTime, Missing["N/A"]],
       "StopReason" -> stopReason,
       "ConvergenceResidual" -> convergenceResidual,
       "Iterations" -> iterations,
@@ -367,8 +333,7 @@ CaseStatusSummary[caseRows_List] :=
 
 BenchmarkCase[key_] :=
   Module[{tier, timeout, data, d2eResult, d2e, results = {}, params, d2eTime, caseIsolationMode,
-      criticalRun, criticalExec, criticalSolveTime, nonlinearInput,
-      monotoneInput, criticalSeedAvailable},
+      criticalRun},
     tier = GetTier[key];
     timeout = If[NumericQ[$TimeoutOverride], $TimeoutOverride, Lookup[$TierTimeouts, tier, 300]];
     params = GetParams[key];
@@ -420,35 +385,6 @@ BenchmarkCase[key_] :=
       "ReturnExecution" -> True
     ];
     AppendTo[results, criticalRun["Row"]];
-    criticalExec = Lookup[criticalRun, "Execution", <||>];
-    criticalSeedAvailable =
-      Lookup[criticalExec, "Status", "FAILED"] === "OK" &&
-      AssociationQ[Lookup[criticalExec, "Result", Missing["NotAvailable"]]];
-    nonlinearInput = If[criticalSeedAvailable, criticalExec["Result"], d2e];
-    monotoneInput = If[criticalSeedAvailable, criticalExec["Result"], d2e];
-    criticalSolveTime = Lookup[criticalExec, "Time", Missing["N/A"]];
-
-    If[MemberQ[$SolversToRun, "NonLinearSolver"],
-      AppendTo[results,
-        BenchmarkOneSolver[
-          key, tier, "NonLinearSolver", nonlinearInput, timeout,
-          "RunContext" -> <|
-            "UsedCriticalSeed" -> criticalSeedAvailable,
-            "CriticalSolveTime" -> criticalSolveTime
-          |>
-        ]]
-    ];
-
-    If[MemberQ[$SolversToRun, "Monotone"],
-      AppendTo[results,
-        BenchmarkOneSolver[
-          key, tier, "Monotone", monotoneInput, timeout,
-          "RunContext" -> <|
-            "UsedCriticalSeed" -> criticalSeedAvailable,
-            "CriticalSolveTime" -> criticalSolveTime
-          |>
-        ]]
-    ];
 
     (* Store D2E time in all results *)
     results = Map[Append[#, "D2ETime" -> d2eTime] &, results];
@@ -510,38 +446,28 @@ If[$HistoryTag =!= None,
       tierRows2 = Select[$AllResults, #["Tier"] === tierName &];
       If[Length[tierRows2] === 0, Return[""]];
       caseKeys = DeleteDuplicates[#["Key"] & /@ tierRows2];
-      Module[{hCrit, hNL, hMono},
+      Module[{hCrit},
         hCrit = DisplaySolverName[<|"Solver" -> "CriticalCongestion", "NumericBackendUsed" -> True|>]; (* Generic numeric as placeholder header *)
-        hNL = DisplaySolverName[<|"Solver" -> "NonLinearSolver", "UsedCriticalSeed" -> True|>];
-        hMono = DisplaySolverName[<|"Solver" -> "Monotone", "UsedCriticalSeed" -> True|>];
         tableLines = {"#### Tier: " <> tierName, "",
-          "| Case | D2E (s) | " <> hCrit <> " (s) | " <> hNL <> " inc (s) | NL standalone est (s) | " <> hMono <> " inc (s) | Mono standalone est (s) | Total (s) | Case Status |",
-          "|------|---------|---------------|------------------|----------------------------|------------------|-----------------------------|-----------|-------------|"}
+          "| Case | D2E (s) | " <> hCrit <> " (s) | Total (s) | Case Status |",
+          "|------|---------|---------------|-----------|-------------|"}
       ];
       Do[
-        Module[{caseRows, d2eT, critT, nlT, monoT, totalT, caseStatus, nlEstST, monoEstST},
+        Module[{caseRows, d2eT, critT, totalT, caseStatus},
           caseRows = Select[tierRows2, #["Key"] === k &];
           d2eT = SelectFirst[caseRows, True&, <||>]["D2ETime"];
           critT = SelectFirst[Select[caseRows, #["Solver"] === "CriticalCongestion"&], True&, <||>];
-          nlT  = SelectFirst[Select[caseRows, #["Solver"] === "NonLinearSolver"&], True&, <||>];
-          monoT = SelectFirst[Select[caseRows, #["Solver"] === "Monotone"&], True&, <||>];
           fmtT[t_] := If[NumericQ[t], ToString[CForm[N[t]]], "—"];
           d2eT   = fmtT[d2eT];
           critST = fmtT[If[KeyExistsQ[critT, "SolveTime"], critT["SolveTime"], Missing[]]];
-          nlST   = fmtT[If[KeyExistsQ[nlT, "SolveTime"], nlT["SolveTime"], Missing[]]];
-          nlEstST = fmtT[If[KeyExistsQ[nlT, "EstimatedStandaloneSolveTime"], nlT["EstimatedStandaloneSolveTime"], Missing[]]];
-          monoST = fmtT[If[KeyExistsQ[monoT, "SolveTime"], monoT["SolveTime"], Missing[]]];
-          monoEstST = fmtT[If[KeyExistsQ[monoT, "EstimatedStandaloneSolveTime"], monoT["EstimatedStandaloneSolveTime"], Missing[]]];
           totalN = Plus @@ Select[{
-            If[KeyExistsQ[critT, "SolveTime"] && NumericQ[critT["SolveTime"]], critT["SolveTime"], 0],
-            If[KeyExistsQ[nlT, "SolveTime"] && NumericQ[nlT["SolveTime"]], nlT["SolveTime"], 0],
-            If[KeyExistsQ[monoT, "SolveTime"] && NumericQ[monoT["SolveTime"]], monoT["SolveTime"], 0]
+            If[KeyExistsQ[critT, "SolveTime"] && NumericQ[critT["SolveTime"]], critT["SolveTime"], 0]
           }, NumericQ];
           totalT = If[totalN > 0, fmtT[totalN], "—"];
           caseStatus = CaseStatusSummary[caseRows];
           AppendTo[tableLines,
             "| " <> k <> " | " <> d2eT <> " | " <> critST <> " | " <>
-            nlST <> " | " <> nlEstST <> " | " <> monoST <> " | " <> monoEstST <> " | " <> totalT <> " | " <> caseStatus <> " |"]
+            totalT <> " | " <> caseStatus <> " |"]
         ],
         {k, caseKeys}
       ];

--- a/Scripts/ExtractPaperResults.wls
+++ b/Scripts/ExtractPaperResults.wls
@@ -39,7 +39,7 @@ Do[
         ];
         Print[""]
     ],
-    {solver, {"CriticalCongestion", "NonLinearSolver", "Monotone"}}
+    {solver, {"CriticalCongestion"}}
 ]
 
 (* Validate critical solver produced feasible solution *)

--- a/Scripts/GeneratePaperTables.py
+++ b/Scripts/GeneratePaperTables.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Optional
 
 
 DEFAULT_TIERS = ["small", "core", "large", "vlarge", "stress", "paper"]
-DEFAULT_SOLVERS = ["CriticalCongestion", "NonLinearSolver", "Monotone"]
+DEFAULT_SOLVERS = ["CriticalCongestion"]
 STATUS_ORDER = ["OK", "TIMEOUT", "FAILED", "SKIPPED", "UNKNOWN"]
 
 TIER_LABELS = {
@@ -35,8 +35,6 @@ TIER_LABELS = {
 
 SOLVER_LABELS = {
     "CriticalCongestion": "Critical",
-    "NonLinearSolver": "NonLinear",
-    "Monotone": "Monotone",
     "DataToEquations": "DataToEquations",
 }
 

--- a/Scripts/ProfileInstrument.wls
+++ b/Scripts/ProfileInstrument.wls
@@ -257,19 +257,5 @@ ProfiledCriticalCongestion[d2e_] :=
     result
   ];
 
-ProfiledNonLinearSolver[eqs_] :=
-  Module[{result},
-    Block[{V = Function[{x, edge}, 0]},
-      result = NonLinearSolver[eqs]
-    ];
-    result
-  ];
-
-ProfiledMonotone[d2e_] :=
-  Module[{result},
-    result = MonotoneSolver[d2e];
-    result
-  ];
-
 Print["ProfileInstrument.wls loaded successfully."];
 Print["Usage: InitProfile[]; InstallProfileWrappers[]; <run solver>; ProfileReport[]"];


### PR DESCRIPTION
## Summary
- remove active references to deprecated NonLinear/Monotone solver surfaces from scripts, workbook, and docs
- simplify SolveMFGAutomaticDispatch to a single critical stage while preserving method-trace behavior
- make benchmark/report tooling critical-only (BenchmarkSuite, helpers, table/report scripts)

## Verification
- `wolframscript -file Scripts/CheckCriticalSurfaceTests.wls` (pass)
- `python3 -m py_compile Scripts/GeneratePaperTables.py` (pass)
- benchmark smoke: `wolframscript -file Scripts/BenchmarkSuite.wls small case=1 solver=critical` (completed with timeout status + exports)
- fast suite was started and showed existing unrelated failures in `007-critical_congestion_ok.mt` and `012-critical_congestion.mt`
