### PR TITLE
Refactor scenario topology lifecycle and consolidate symbolic unknowns

### DIFF
--- a/MFGraphs/DataToEquations.wl
+++ b/MFGraphs/DataToEquations.wl
@@ -412,7 +412,7 @@ DataToEquations[Data_Association] :=
          blockedIncomingPairs, activeAuxTriples,
          Nlhs, ModuleVars, ModuleVarsNames, Nrhs, costpluscurrents, EqGeneral,
          inAuxEntryPairs, outAuxEntryPairs, inAuxExitPairs, outAuxExitPairs, 
-        pairs, halfPairs, consistentCosts, scenarioObj},
+        pairs, halfPairs, consistentCosts, scenarioObj, topology},
         
         (* Use makeScenario to get completed and validated data *)
         scenarioObj = makeScenario[<|"Model" -> Data|>];
@@ -426,17 +426,22 @@ DataToEquations[Data_Association] :=
         exitVerticesCosts = ScenarioData[scenarioObj, "Model"]["Exit Vertices and Terminal Costs"];
         SwitchingCosts = ScenarioData[scenarioObj, "Model"]["Switching Costs"];
 
-        (* Graph construction *)
-        graph = AdjacencyGraph[verticesList, adjacencyMatrix, VertexLabels
-             -> "Name", DirectedEdges -> False];
-        entryVertices = First /@ entryVerticesFlows;
-        exitVertices = First /@ exitVerticesCosts;
+        (* Use shared topology logic from Scenario.wl - preferably from cache *)
+        topology = ScenarioData[scenarioObj, "Topology"];
+        If[!AssociationQ[topology],
+            topology = BuildAuxiliaryTopology[ScenarioData[scenarioObj, "Model"]]
+        ];
+        
+        If[topology === $Failed, 
+            Return[Failure["DataToEquations", <|"Message" -> "Topology construction failed"|>], Module]
+        ];
 
-        auxEntryVertices = Symbol["en" <> ToString[#]]& /@ entryVertices;
-        auxExitVertices = Symbol["ex" <> ToString[#]]& /@ exitVertices;
-        entryEdges = MapThread[UndirectedEdge, {auxEntryVertices, entryVertices}];
-        exitEdges = MapThread[UndirectedEdge, {exitVertices, auxExitVertices}];
-        auxiliaryGraph = EdgeAdd[graph, Join[entryEdges, exitEdges]];
+        graph = topology["Graph"];
+        auxiliaryGraph = topology["AuxiliaryGraph"];
+        auxEntryVertices = topology["AuxEntryVertices"];
+        auxExitVertices = topology["AuxExitVertices"];
+        entryEdges = topology["AuxEntryEdges"];
+        exitEdges = topology["AuxExitEdges"];
             
         auxEdgeList = EdgeList[auxiliaryGraph];
         edgeList = EdgeList[graph];
@@ -448,11 +453,6 @@ DataToEquations[Data_Association] :=
         inAuxExitPairs = Reverse /@ outAuxExitPairs;
         outAuxEntryPairs = Reverse /@ inAuxEntryPairs;
         pairs = Join[halfPairs, Reverse /@ halfPairs];
-        auxPairs = Join[inAuxEntryPairs, outAuxEntryPairs, inAuxExitPairs,
-             outAuxExitPairs, pairs];
-        (* Insert the vertex in pairs of adjacent vertices *)
-        auxTriples = Flatten[Insert[#, 2] /@ Permutations[AdjacencyList[
-            auxiliaryGraph, #], {2}]& /@ auxVerticesList, 1];
 
         (* Prepare boundary data *)
         EntryDataAssociation = RoundValues @ AssociationThread[inAuxEntryPairs,
@@ -464,6 +464,8 @@ DataToEquations[Data_Association] :=
         js = UnknownsData[unknownBundle, "js"] /. Missing[_, _] -> {};
         jts = UnknownsData[unknownBundle, "jts"] /. Missing[_, _] -> {};
         us = UnknownsData[unknownBundle, "us"] /. Missing[_, _] -> {};
+        auxPairs = UnknownsData[unknownBundle, "auxPairs"] /. Missing[_, _] -> {};
+        auxTriples = UnknownsData[unknownBundle, "auxTriples"] /. Missing[_, _] -> {};
 
         (* Signed flows *)
         SignedFlows = AssociationMap[j @@ # - j @@ Reverse @ #&, Join[

--- a/MFGraphs/Examples/ExamplesData.wl
+++ b/MFGraphs/Examples/ExamplesData.wl
@@ -9,10 +9,21 @@ GetExampleData::usage =
 from the test case test[n].
 Supports test cases with 5 fields (basic), 6 fields (+cost function 'a'), or 7 fields (+alpha).";
 
+ScenarioByKey::usage =
+"ScenarioByKey[key, input] builds a typed scenario[...] from a built-in topology key.
+The base topology (\"Vertices List\", \"Adjacency Matrix\", optional \"a\"/\"alpha\") is
+loaded from key, while boundary and switching data are fully supplied by input:
+<|\"Entry flows\" -> <|v -> flow, ...|>,
+  \"Exit costs\" -> <|v -> cost, ...|>,
+  \"Switching Costs\" -> <|{vIn, vMid, vOut} -> cost, ...|>|>.
+Use \"switching costs\" as a lowercase alias if needed.";
+
 DataG::usage = "DataG is a backward-compatibility alias for GetExampleData.";
 
 GetExampleData::badfields =
 "Unexpected number of fields (`1`) for test case `2`.";
+GetExampleData::deprecated =
+"GetExampleData is deprecated; use ScenarioByKey with input associations for entry, exit, and switching data.";
 
 (* TODO: stop using these parameters. we should, maybe update the examples to only specify the entry and exit vertices and let makeScenario take the corresponding values directly.*)
 
@@ -557,7 +568,7 @@ $ExampleDataFields6 = Join[$ExampleDataFields5, {"a"}];
 
 $ExampleDataFields7 = Join[$ExampleDataFields6, {"alpha"}];
 
-GetExampleData[n_] :=
+GetExampleDataRaw[n_] :=
     With[{data = test[n]},
         Switch[Length[data],
             5, AssociationThread[$ExampleDataFields5, data],
@@ -565,7 +576,195 @@ GetExampleData[n_] :=
             7, AssociationThread[$ExampleDataFields7, data],
             _, (Message[GetExampleData::badfields, Length[data], n]; $Failed)
         ]
-    ]
+    ];
+
+$GetExampleDataDeprecationEmitted = False;
+EmitGetExampleDataDeprecation[] :=
+    If[!TrueQ[$GetExampleDataDeprecationEmitted],
+        Message[GetExampleData::deprecated];
+        $GetExampleDataDeprecationEmitted = True
+    ];
+
+SwitchingInput[input_Association] :=
+    Which[
+        KeyExistsQ[input, "Switching Costs"], input["Switching Costs"],
+        KeyExistsQ[input, "switching costs"], input["switching costs"],
+        True, Missing["KeyAbsent", "Switching Costs"]
+    ];
+
+VertexRuleList[vertexOrder_List, assoc_Association] :=
+    ({#, assoc[#]} &) /@ Select[vertexOrder, KeyExistsQ[assoc, #] &];
+
+AdjacentVerticesQ[adjacency_, vertexIndex_Association, u_, v_] :=
+    Module[{iu, iv},
+        iu = Lookup[vertexIndex, u, Missing["KeyAbsent", u]];
+        iv = Lookup[vertexIndex, v, Missing["KeyAbsent", v]];
+        If[MissingQ[iu] || MissingQ[iv], Return[False, Module]];
+        Quiet @ Check[
+            TrueQ[adjacency[[iu, iv]] =!= 0] || TrueQ[adjacency[[iv, iu]] =!= 0],
+            False
+        ]
+    ];
+
+ValidateSwitchingAssociation[switching_Association, vertices_List, adjacency_] :=
+    Module[{vertexSet, vertexIndex, keys, badShape, badVertex, badAdjacency, badValue},
+        vertexSet = AssociationThread[vertices, ConstantArray[True, Length[vertices]]];
+        vertexIndex = AssociationThread[vertices, Range[Length[vertices]]];
+        keys = Keys[switching];
+
+        badShape = Select[keys, !MatchQ[#, {_, _, _}] &];
+        If[badShape =!= {},
+            Return[
+                Failure["ScenarioByKey", <|
+                    "Message" -> "Switching Costs keys must be triples {vIn, vMid, vOut}.",
+                    "InvalidKeys" -> badShape
+                |>],
+                Module
+            ]
+        ];
+
+        badVertex = Select[
+            keys,
+            With[{triple = #},
+                !AllTrue[triple, KeyExistsQ[vertexSet, #] &]
+            ] &
+        ];
+        If[badVertex =!= {},
+            Return[
+                Failure["ScenarioByKey", <|
+                    "Message" -> "Switching Costs contains vertices not present in the example topology.",
+                    "InvalidKeys" -> badVertex
+                |>],
+                Module
+            ]
+        ];
+
+        badAdjacency = Select[
+            keys,
+            With[{triple = #},
+                !AdjacentVerticesQ[adjacency, vertexIndex, triple[[1]], triple[[2]]] ||
+                !AdjacentVerticesQ[adjacency, vertexIndex, triple[[2]], triple[[3]]]
+            ] &
+        ];
+        If[badAdjacency =!= {},
+            Return[
+                Failure["ScenarioByKey", <|
+                    "Message" -> "Switching Costs keys must be adjacent triples in the example topology.",
+                    "InvalidKeys" -> badAdjacency
+                |>],
+                Module
+            ]
+        ];
+
+        badValue = Select[Normal[switching], !NumericQ[Last[#]] &];
+        If[badValue =!= {},
+            Return[
+                Failure["ScenarioByKey", <|
+                    "Message" -> "Switching Costs values must be numeric.",
+                    "InvalidRules" -> badValue
+                |>],
+                Module
+            ]
+        ];
+
+        switching
+    ];
+
+ScenarioByKey[key_, input_Association] :=
+    Module[{base, vertices, adjacency, entryFlows, exitCosts, switchingCosts,
+            missing, badEntryVertices, badExitVertices, badEntryValues, badExitValues,
+            entryRules, exitRules, switchingValidated, model, requiredKeys},
+        base = GetExampleDataRaw[key];
+        If[base === $Failed, Return[$Failed, Module]];
+
+        requiredKeys = {"Entry flows", "Exit costs"};
+        missing = Select[requiredKeys, !KeyExistsQ[input, #] &];
+        If[!KeyExistsQ[input, "Switching Costs"] && !KeyExistsQ[input, "switching costs"],
+            missing = Append[missing, "Switching Costs"]
+        ];
+        If[missing =!= {},
+            Return[
+                Failure["ScenarioByKey", <|
+                    "Message" -> "Missing required input keys: " <> StringRiffle[missing, ", "],
+                    "MissingKeys" -> missing
+                |>],
+                Module
+            ]
+        ];
+
+        entryFlows = input["Entry flows"];
+        exitCosts = input["Exit costs"];
+        switchingCosts = SwitchingInput[input];
+        If[!AssociationQ[entryFlows] || !AssociationQ[exitCosts] || !AssociationQ[switchingCosts],
+            Return[
+                Failure["ScenarioByKey", <|
+                    "Message" -> "Entry flows, Exit costs, and Switching Costs must be Associations."
+                |>],
+                Module
+            ]
+        ];
+
+        vertices = Lookup[base, "Vertices List", {}];
+        adjacency = Normal @ Lookup[base, "Adjacency Matrix", {}];
+
+        badEntryVertices = Select[Keys[entryFlows], !MemberQ[vertices, #] &];
+        badExitVertices = Select[Keys[exitCosts], !MemberQ[vertices, #] &];
+        If[badEntryVertices =!= {} || badExitVertices =!= {},
+            Return[
+                Failure["ScenarioByKey", <|
+                    "Message" -> "Entry/Exit vertices must belong to the example topology vertices list.",
+                    "InvalidEntryVertices" -> badEntryVertices,
+                    "InvalidExitVertices" -> badExitVertices
+                |>],
+                Module
+            ]
+        ];
+
+        badEntryValues = Select[Normal[entryFlows], !NumericQ[Last[#]] &];
+        badExitValues = Select[Normal[exitCosts], !NumericQ[Last[#]] &];
+        If[badEntryValues =!= {} || badExitValues =!= {},
+            Return[
+                Failure["ScenarioByKey", <|
+                    "Message" -> "Entry flow and Exit cost values must be numeric.",
+                    "InvalidEntryRules" -> badEntryValues,
+                    "InvalidExitRules" -> badExitValues
+                |>],
+                Module
+            ]
+        ];
+
+        switchingValidated = ValidateSwitchingAssociation[switchingCosts, vertices, adjacency];
+        If[FailureQ[switchingValidated], Return[switchingValidated, Module]];
+
+        entryRules = VertexRuleList[vertices, entryFlows];
+        exitRules = VertexRuleList[vertices, exitCosts];
+
+        model = <|
+            "Vertices List" -> vertices,
+            "Adjacency Matrix" -> adjacency,
+            "Entrance Vertices and Flows" -> entryRules,
+            "Exit Vertices and Terminal Costs" -> exitRules,
+            "Switching Costs" -> switchingValidated
+        |>;
+        If[KeyExistsQ[base, "a"], model = Join[model, <|"a" -> base["a"]|>]];
+        If[KeyExistsQ[base, "alpha"], model = Join[model, <|"alpha" -> base["alpha"]|>]];
+
+        makeScenario[<|"Model" -> model|>]
+    ];
+
+ScenarioByKey[key_] := ScenarioByKey[key, <||>];
+
+ScenarioByKey[_, _] :=
+    Failure["ScenarioByKey", <|
+        "Message" -> "ScenarioByKey requires an Association input."
+    |>];
+
+GetExampleData[n_] :=
+    Module[{data},
+        EmitGetExampleDataDeprecation[];
+        data = GetExampleDataRaw[n];
+        data
+    ];
 
 (* --- Backward compatibility alias --- *)
 DataG = GetExampleData;

--- a/MFGraphs/Getting started.wl
+++ b/MFGraphs/Getting started.wl
@@ -1,5 +1,17 @@
 (* ::Package:: *)
 
+Quit[]
+
+
+$Path
+
+
+ Directory[]
+
+
+AppendTo[$Path, FileNameJoin[Directory[],"/"]]
+
+
 (* Notebook-friendly MFGraphs workbook.
    This file is meant to be evaluated section-by-section inside a notebook.
    It does not assume that the notebook directory is already on $Path. *)
@@ -287,6 +299,287 @@ examplePreview = <|
 examplePreview["Jamarat"]
 
 
+ Remove["Global`makeUnknowns", "Global`scenario", "Global`unknowns", "Global`UnknownsData"];
+  Needs["MFGraphs`"];
+
+
+
+Quit[]
+
+
+(* Notebook-friendly MFGraphs workbook.
+   This file is meant to be evaluated section-by-section inside a notebook.
+   It does not assume that the notebook directory is already on $Path. *)
+
+ClearAll[
+    FindMFGraphsRoot,
+    PackageUsageSymbols,
+    ClearMFGraphsNotebookShadows,
+    EnsureMFGraphsLoaded,
+    DescribeOutput,
+    AssociationValue,
+    NetEdgeFlows,
+    NetworkVisualData,
+    FlowStyleDirective,
+    NetworkGraphPlot,
+    SolutionFlowPlot,
+    DensityNetworkGraphic,
+    MassDensityCurve,
+    ValueFunctionCurve,
+    ExitFlowPlot,
+    JamaratScenario
+];
+
+FindMFGraphsRoot[] :=
+    Module[{origins, candidates},
+        origins = DeleteDuplicates @ Select[
+            {
+                Quiet @ Check[NotebookDirectory[], Nothing],
+                If[StringQ[$InputFileName] && $InputFileName =!= "",
+                    DirectoryName[$InputFileName],
+                    Nothing
+                ],
+                Directory[]
+            },
+            StringQ
+        ];
+        candidates = DeleteDuplicates @ Flatten[{
+            origins,
+            FileNameJoin[{#, "MFGraphs"}] & /@ origins,
+            FileNameJoin[{#, "..", "MFGraphs"}] & /@ origins
+        }];
+        SelectFirst[
+            candidates,
+            FileExistsQ[FileNameJoin[{#, "MFGraphs.wl"}]] &,
+            $Failed
+        ]
+    ];
+
+PackageUsageSymbols[packageDir_String] :=
+    Module[{sourceFiles, usageNames},
+        sourceFiles = FileNames["*.wl", packageDir, Infinity];
+        usageNames = DeleteDuplicates @ Flatten[
+            StringCases[
+                Import[#, "Text"],
+                RegularExpression["(?m)^\\s*([A-Za-z$][A-Za-z0-9$]*)::usage\\s*="] :> "$1"
+            ] & /@ sourceFiles
+        ];
+        usageNames
+    ];
+
+ClearMFGraphsNotebookShadows[] :=
+    Module[{packageDir = FindMFGraphsRoot[], exported, shadowed},
+        exported = If[packageDir === $Failed, {}, PackageUsageSymbols[packageDir]];
+        shadowed = Select[exported, NameQ["Global`" <> #] &];
+        Scan[ToExpression["Global`" <> #, InputForm, Remove] &, shadowed];
+        shadowed
+    ];
+
+EnsureMFGraphsLoaded[] :=
+    Module[{packageDir = FindMFGraphsRoot[], searchRoot, cleared},
+        If[packageDir === $Failed,
+            Print["Could not locate MFGraphs.wl relative to the notebook or current directory."];
+            Abort[]
+        ];
+        searchRoot = DirectoryName[packageDir];
+        cleared = ClearMFGraphsNotebookShadows[];
+        If[FreeQ[$Path, searchRoot], PrependTo[$Path, searchRoot]];
+        Get[FileNameJoin[{packageDir, "MFGraphs.wl"}]];
+        If[cleared =!= {},
+            Print["Removed shadowing Global` symbols before loading MFGraphs: ", cleared];
+        ];
+        packageDir
+    ];
+
+mfGraphsRoot = EnsureMFGraphsLoaded[];
+MFGraphs`$MFGraphsVerbose = False;
+
+(* Public MFGraphs symbols are now on $ContextPath, so the examples below can
+   use GetExampleData, DataToEquations, I1, U1, ... without a context prefix.
+   V, alpha, and g are now public MFGraphs symbols as well, so you can
+   override them directly with Block[...] or with WithHamiltonianFunctions[...]. *)
+
+DescribeOutput[title_String, description_String, expr_] :=
+    Column[
+        {
+            Style[title, 15, Bold, RGBColor[0.15, 0.26, 0.45]],
+            Style[description, 11, GrayLevel[0.35]],
+            expr
+        },
+        Alignment -> Left,
+        Spacings -> {0.2, 0.7}
+    ];
+
+(* Reuse canonical visualization helpers from Graphics.wl to avoid workbook drift. *)
+AssociationValue[assoc_Association, key_, default_: Missing["NotAvailable"]] :=
+    MFGraphs`AssociationValue[assoc, key, default];
+
+(* Net flow on each displayed edge, after eliminating dependent current variables. *)
+NetEdgeFlows[d2e_Association, solution_Association, pairs_: Automatic] :=
+    MFGraphs`NetEdgeFlows[d2e, solution, pairs];
+
+NetworkVisualData[d2e_Association] :=
+    MFGraphs`NetworkVisualData[d2e];
+
+FlowStyleDirective[flow_?NumericQ, maxFlow_?NumericQ] :=
+    MFGraphs`FlowStyleDirective[flow, maxFlow];
+
+(* NetworkGraphPlot and SolutionFlowPlot now live in Graphics.wl. *)
+
+DensityNetworkGraphic[d2e_Association, solution_Association, title_: Automatic, samples_Integer: 24] :=
+    Module[{visual, coords, pairs, flows, sampleXs, densitiesByPair, allDensities,
+      maxDensity, colorScale, edgeSegments, edgeLabels, vertexDisks, vertexLabels,
+      plotTitle, legendRange, hasDensityModelQ, usesProxyDensityQ = False},
+        visual = NetworkVisualData[d2e];
+        coords = visual["coords"];
+        pairs = List @@@ Lookup[d2e, "edgeList", {}];
+        flows = NetEdgeFlows[d2e, solution, pairs];
+        sampleXs = N @ Subdivide[0., 1., samples];
+        hasDensityModelQ = DownValues[MFGraphs`Private`M] =!= {};
+        densitiesByPair = AssociationThread[
+            pairs,
+            Table[
+                Module[{flow, sampled},
+                    flow = N @ AssociationValue[flows, pair, 0.];
+                    sampled = If[
+                        hasDensityModelQ,
+                        Quiet @ Check[
+                            N @ (MFGraphs`Private`M[flow, #, UndirectedEdge @@ pair] & /@ sampleXs),
+                            {}
+                        ],
+                        {}
+                    ];
+                    If[VectorQ[sampled, NumericQ],
+                        sampled,
+                        usesProxyDensityQ = True;
+                        ConstantArray[N @ Max[0., Abs[flow]], Length[sampleXs]]
+                    ]
+                ],
+                {pair, pairs}
+            ]
+        ];
+        allDensities = Select[Flatten[Values[densitiesByPair]], NumericQ];
+        maxDensity = Max[Append[allDensities, 0.]];
+        legendRange = {0., Max[maxDensity, 1.]};
+        colorScale[value_] :=
+            ColorData["SolarColors"][Rescale[value, legendRange]];
+        edgeSegments = Flatten @ Map[
+            Function[pair,
+                Module[{edgePoints, densities},
+                    edgePoints = ((1 - #) coords[pair[[1]]] + # coords[pair[[2]]]) & /@ sampleXs;
+                    densities = AssociationValue[densitiesByPair, pair, ConstantArray[0., Length[sampleXs]]];
+                    Table[
+                        {
+                            colorScale[Mean[densities[[k ;; k + 1]]]],
+                            AbsoluteThickness[8],
+                            Line[edgePoints[[k ;; k + 1]]]
+                        },
+                        {k, 1, Length[edgePoints] - 1}
+                    ]
+                ]
+            ],
+            pairs
+        ];
+        edgeLabels = Map[
+            Function[pair,
+                Inset[
+                    Framed[
+                        Style[
+                            Row[{"flow = ", NumberForm[AssociationValue[flows, pair, 0.], {Infinity, 1}]}],
+                            11,
+                            Black
+                        ],
+                        Background -> White,
+                        FrameStyle -> GrayLevel[0.8],
+                        RoundingRadius -> 3,
+                        FrameMargins -> Tiny
+                    ],
+                    Mean[{coords[pair[[1]]], coords[pair[[2]]]}]
+                ]
+            ],
+            pairs
+        ];
+        vertexDisks = Map[
+            Function[vertex,
+                {
+                    Lookup[visual["vertexColors"], vertex, GrayLevel[0.75]],
+                    EdgeForm[Directive[White, AbsoluteThickness[1.5]]],
+                    Disk[
+                        coords[vertex],
+                        Lookup[visual["vertexRadii"], vertex, 0.04]
+                    ]
+                }
+            ],
+            VertexList[visual["graph"]]
+        ];
+        vertexLabels = Map[
+            Function[vertex,
+                Inset[
+                    Style[vertex, 11, Bold, Black],
+                    coords[vertex]
+                ]
+            ],
+            VertexList[visual["graph"]]
+        ];
+        plotTitle = Replace[title, Automatic -> "Edge density profile"];
+        If[usesProxyDensityQ,
+            plotTitle = plotTitle <> " (flow-magnitude proxy)"
+        ];
+        Legended[
+            Graphics[
+                {
+                    edgeSegments,
+                    edgeLabels,
+                    vertexDisks,
+                    vertexLabels
+                },
+                PlotRange -> All,
+                PlotRangePadding -> Scaled[0.15],
+                ImageSize -> Large,
+                PlotLabel -> Style[plotTitle, 14, Bold]
+            ],
+            Placed[
+                BarLegend[
+                    {ColorData["SolarColors"], legendRange},
+                    LegendLabel -> Style[
+                        If[usesProxyDensityQ, "Flow-magnitude proxy", "Local density"],
+                        11
+                    ]
+                ],
+                Right
+            ]
+        ]
+    ];
+
+(* ExitFlowPlot now lives in Graphics.wl. *)
+
+(* Jamarat helper: solve one release/cost scenario and summarize exit usage. *)
+JamaratScenario[params_List] :=
+    Module[{data, d2e, result, exitPairs, exitFlows},
+        data = GetExampleData["Jamaratv9"] /. params;
+        d2e = DataToEquations[data];
+        result = Quiet @ CriticalCongestionSolver[d2e];
+        exitPairs = List @@@ Lookup[d2e, "exitEdges", {}];
+        exitFlows = If[AssociationQ[result["Solution"]],
+            AssociationThread[
+                Lookup[d2e, "exitVertices", {}],
+                N[((Lookup[d2e, "SignedFlows", <||>] /@ exitPairs) /. result["Solution"])]
+            ],
+            Missing["NotAvailable"]
+        ];
+        <|
+            "Parameters" -> params,
+            "Model" -> d2e,
+            "Solution" -> result["Solution"],
+            "Feasibility" -> result["Feasibility"],
+            "ExitFlows" -> exitFlows,
+            "InteriorFlows" ->
+                If[AssociationQ[result["Solution"]],
+                    NetEdgeFlows[d2e, result["Solution"]],
+                    Missing["NotAvailable"]
+                ]
+        |>
+    ];
 (* --- 2. Typed Scenarios and Unknowns --- *)
 
 (* Scenarios provide a typed wrapper for model data and parameters. *)
@@ -294,10 +587,13 @@ typedScenario = makeScenario[<|
     "Identity" -> <|"Name" -> "Y-junction benchmark"|>,
     "Model" -> GetExampleData[7],
     "Data" -> {I1 -> 100, U1 -> 0, U2 -> 0}
-|>];
+|>]
+Head@%
+
 
 (* makeUnknowns derives the symbolic variables (js, jts, us) from the scenario. *)
-unknowns = makeUnknowns[typedScenario];
+unknowns = makeUnknowns[typedScenario]
+
 
 Column[{
     DescribeOutput[

--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -177,6 +177,7 @@ launching parallel subkernels. Only applies when $KernelCount === 0. Default is 
 Get["MFGraphs`Examples`ExamplesData`"];
 Get["MFGraphs`DNFReduce`"];
 Get["MFGraphs`Scenario`"];
+Get["MFGraphs`Unknowns`"];
 Get["MFGraphs`DataToEquations`"];
 Get["MFGraphs`Solvers`"];
 Get["MFGraphs`Graphics`"];
@@ -761,7 +762,6 @@ Scan[
     {
         "MFGraphs`Examples`ExamplesData`",
         "MFGraphs`DNFReduce`",
-        "MFGraphs`Unknowns`",
         "MFGraphs`DataToEquations`",
         "MFGraphs`Solvers`",
         "MFGraphs`Graphics`",

--- a/MFGraphs/Scenario.wl
+++ b/MFGraphs/Scenario.wl
@@ -60,8 +60,12 @@ Association.";
 (* Shared Topology Logic *)
 
 BuildAuxiliaryTopology::usage =
-"BuildAuxiliaryTopology[model] returns an association with the auxiliary graph, \
-triples, pairs, and auxiliary vertex lists derived from the raw model.";
+"BuildAuxiliaryTopology[model] returns an association with the auxiliary graph and \
+metadata derived from the raw model.";
+
+BuildAuxTriples::usage =
+"BuildAuxTriples[auxGraph] returns the list of all possible {v_in, v_mid, v_out} \
+transitions (triples) in the graph.";
 
 Begin["`Private`"];
 
@@ -106,12 +110,18 @@ NormalizeScenarioModel[other_] := other;
 
 (* --- Topology Helpers --- *)
 
-BuildAuxiliaryTopology[model_Association] :=
+MFGraphs`BuildAuxTriples[auxGraph_Graph] :=
+    Module[{vertices = VertexList[auxGraph]},
+        Flatten[
+            Insert[#, 2] /@ Permutations[AdjacencyList[auxGraph, #], {2}] & /@ vertices,
+            1
+        ]
+    ];
+
+MFGraphs`BuildAuxiliaryTopology[model_Association] :=
     Module[{vertices, adjacency, entryFlows, exitCosts, graph, 
             entryVertices, exitVertices, auxEntryVertices, auxExitVertices,
-            entryEdges, exitEdges, auxiliaryGraph, auxVerticesList, 
-            auxTriples, edgeList, halfPairs, inAuxEntryPairs, 
-            outAuxEntryPairs, inAuxExitPairs, outAuxExitPairs, pairs, auxPairs},
+            entryEdges, exitEdges, auxiliaryGraph},
         
         vertices = Lookup[model, "Vertices List"];
         adjacency = Lookup[model, "Adjacency Matrix"];
@@ -137,26 +147,10 @@ BuildAuxiliaryTopology[model_Association] :=
         entryEdges = MapThread[UndirectedEdge, {auxEntryVertices, entryVertices}];
         exitEdges = MapThread[UndirectedEdge, {exitVertices, auxExitVertices}];
         auxiliaryGraph = EdgeAdd[graph, Join[entryEdges, exitEdges]];
-        
-        auxVerticesList = VertexList[auxiliaryGraph];
-        auxTriples = Flatten[
-            Insert[#, 2] /@ Permutations[AdjacencyList[auxiliaryGraph, #], {2}] & /@ auxVerticesList,
-            1
-        ];
-
-        edgeList = EdgeList[graph];
-        halfPairs = List @@@ edgeList;
-        inAuxEntryPairs = List @@@ entryEdges;
-        outAuxExitPairs = List @@@ exitEdges;
-        inAuxExitPairs = Reverse /@ outAuxExitPairs;
-        outAuxEntryPairs = Reverse /@ inAuxEntryPairs;
-        pairs = Join[halfPairs, Reverse /@ halfPairs];
-        auxPairs = Join[inAuxEntryPairs, outAuxEntryPairs, inAuxExitPairs, outAuxExitPairs, pairs];
 
         <|
+            "Graph" -> graph,
             "AuxiliaryGraph" -> auxiliaryGraph,
-            "AuxTriples" -> auxTriples,
-            "AuxPairs" -> auxPairs,
             "AuxEntryVertices" -> auxEntryVertices,
             "AuxExitVertices" -> auxExitVertices,
             "AuxEntryEdges" -> entryEdges,
@@ -209,31 +203,34 @@ validateScenario[x_] :=
 
 (* --- Complete --- *)
 
-CompleteSwitchingCosts[model_Association] :=
-    Module[{topology, inputSC, scAssoc},
-        topology = BuildAuxiliaryTopology[model];
-        If[topology === $Failed, Return[model, Module]];
-        
+CompleteSwitchingCosts[model_Association, topology_Association] :=
+    Module[{inputSC, scAssoc, triples},
         inputSC = Lookup[model, "Switching Costs", {}];
         scAssoc = If[AssociationQ[inputSC],
             inputSC,
             AssociationThread[Most /@ inputSC, Last /@ inputSC]
         ];
         
+        (* Derive triples for completion *)
+        triples = MFGraphs`BuildAuxTriples[topology["AuxiliaryGraph"]];
+        
         (* Explicitly complement with 0 for all possible transitions in the auxiliary graph *)
-        Join[AssociationMap[0&, topology["AuxTriples"]], scAssoc]
+        Join[AssociationMap[0&, triples], scAssoc]
     ];
 
 completeScenario[s_scenario] :=
-    Module[{assoc, identity, benchmark, model, hash, newAssoc, completedSC},
+    Module[{assoc, identity, benchmark, model, hash, newAssoc, completedSC, topology},
         assoc     = ScenarioData[s];
         model     = Lookup[assoc, "Model", <||>];
         identity  = Lookup[assoc, "Identity", <||>];
         benchmark = Lookup[assoc, "Benchmark", <||>];
+        topology  = Lookup[assoc, "Topology", Missing["KeyAbsent", "Topology"]];
 
         (* Ensure "Switching Costs" is explicitly completed before hashing. *)
-        completedSC = CompleteSwitchingCosts[model];
-        model = Join[model, <|"Switching Costs" -> completedSC|>];
+        If[!MissingQ[topology],
+            completedSC = CompleteSwitchingCosts[model, topology];
+            model = Join[model, <|"Switching Costs" -> completedSC|>]
+        ];
 
         (* Compute content hash from the canonical string of the completed Model. *)
         hash = Hash[ToString[model, InputForm], "SHA256", "HexString"];
@@ -258,14 +255,23 @@ completeScenario[x_] := x;   (* pass-through for non-scenario values *)
 (* --- Constructor --- *)
 
 makeScenario[rawAssoc_Association] :=
-    Module[{normalizedAssoc, wrapped, validated, completed},
+    Module[{normalizedAssoc, wrapped, validated, completed, model, topology},
         normalizedAssoc = rawAssoc;
-        If[AssociationQ[Lookup[rawAssoc, "Model", Missing["KeyAbsent", "Model"]]],
+        model = Lookup[rawAssoc, "Model", Missing["KeyAbsent", "Model"]];
+        
+        If[AssociationQ[model],
             normalizedAssoc = Join[
                 rawAssoc,
-                <|"Model" -> NormalizeScenarioModel[rawAssoc["Model"]]|>
+                <|"Model" -> NormalizeScenarioModel[model]|>
+            ];
+            
+            (* Build topology during construction if model is valid enough *)
+            topology = MFGraphs`BuildAuxiliaryTopology[normalizedAssoc["Model"]];
+            If[AssociationQ[topology],
+                normalizedAssoc = Join[normalizedAssoc, <|"Topology" -> topology|>]
             ]
         ];
+        
         wrapped   = scenario[normalizedAssoc];
         validated = validateScenario[wrapped];
         If[FailureQ[validated],

--- a/MFGraphs/Tests/package-loading.mt
+++ b/MFGraphs/Tests/package-loading.mt
@@ -7,7 +7,8 @@ Test[
     NameQ["MFGraphs`SolveMFG"] &&
     NameQ["MFGraphs`GetExampleData"] && NameQ["MFGraphs`DNFReduce"] &&
     NameQ["MFGraphs`GetKirchhoffLinearSystem"] &&
-    NameQ["MFGraphs`makeScenario"] && NameQ["MFGraphs`scenarioQ"]
+    NameQ["MFGraphs`makeScenario"] && NameQ["MFGraphs`scenarioQ"] &&
+    NameQ["MFGraphs`ScenarioByKey"]
     ,
     True
     ,

--- a/MFGraphs/Tests/scenario-kernel.mt
+++ b/MFGraphs/Tests/scenario-kernel.mt
@@ -7,7 +7,8 @@ Test[
     NameQ["MFGraphs`makeScenario"] &&
     NameQ["MFGraphs`validateScenario"] &&
     NameQ["MFGraphs`completeScenario"] &&
-    NameQ["MFGraphs`ScenarioData"]
+    NameQ["MFGraphs`ScenarioData"] &&
+    NameQ["MFGraphs`ScenarioByKey"]
     ,
     True
     ,
@@ -255,4 +256,91 @@ Test[
     True
     ,
     TestID -> "Scenario kernel: graph normalization preserves explicit vertices order"
+]
+
+(* Test: ScenarioByKey constructs a typed scenario from input-defined boundaries *)
+Test[
+    Module[{s, model},
+        s = ScenarioByKey[12, <|
+            "Entry flows" -> <|1 -> 100|>,
+            "Exit costs" -> <|4 -> 0|>,
+            "Switching Costs" -> <||>
+        |>];
+        model = ScenarioData[s, "Model"];
+        scenarioQ[s] &&
+        model["Entrance Vertices and Flows"] === {{1, 100}} &&
+        model["Exit Vertices and Terminal Costs"] === {{4, 0}}
+    ]
+    ,
+    True
+    ,
+    TestID -> "ScenarioByKey: builds typed scenario with input-defined boundaries"
+]
+
+(* Test: ScenarioByKey ignores base example entry/exit sets *)
+Test[
+    Module[{s, model},
+        s = ScenarioByKey[7, <|
+            "Entry flows" -> <|2 -> 11|>,
+            "Exit costs" -> <|4 -> 9|>,
+            "Switching Costs" -> <||>
+        |>];
+        model = ScenarioData[s, "Model"];
+        model["Entrance Vertices and Flows"] === {{2, 11}} &&
+        model["Exit Vertices and Terminal Costs"] === {{4, 9}}
+    ]
+    ,
+    True
+    ,
+    TestID -> "ScenarioByKey: input boundaries override base example boundaries"
+]
+
+(* Test: ScenarioByKey completes unspecified switching triples with zero *)
+Test[
+    Module[{s, sc},
+        s = ScenarioByKey[14, <|
+            "Entry flows" -> <|1 -> 10|>,
+            "Exit costs" -> <|3 -> 0|>,
+            "Switching Costs" -> <|{1, 2, 3} -> 5|>
+        |>];
+        sc = ScenarioData[s, "Model"]["Switching Costs"];
+        AssociationQ[sc] &&
+        KeyExistsQ[sc, {1, 2, 3}] && sc[{1, 2, 3}] == 5 &&
+        KeyExistsQ[sc, {3, 2, 1}] && sc[{3, 2, 1}] == 0
+    ]
+    ,
+    True
+    ,
+    TestID -> "ScenarioByKey: missing switching triples default to zero"
+]
+
+(* Test: ScenarioByKey rejects non-adjacent switching triples *)
+Test[
+    Module[{result},
+        result = ScenarioByKey[3, <|
+            "Entry flows" -> <|1 -> 1|>,
+            "Exit costs" -> <|3 -> 0|>,
+            "Switching Costs" -> <|{1, 3, 2} -> 7|>
+        |>];
+        FailureQ[result] && result["Tag"] === "ScenarioByKey"
+    ]
+    ,
+    True
+    ,
+    TestID -> "ScenarioByKey: rejects non-adjacent switching triples"
+]
+
+(* Test: ScenarioByKey validates required keys *)
+Test[
+    Module[{result},
+        result = ScenarioByKey[12, <|
+            "Entry flows" -> <|1 -> 1|>,
+            "Exit costs" -> <|4 -> 0|>
+        |>];
+        FailureQ[result] && result["Tag"] === "ScenarioByKey"
+    ]
+    ,
+    True
+    ,
+    TestID -> "ScenarioByKey: missing required input keys yields Failure"
 ]

--- a/MFGraphs/Unknowns.wl
+++ b/MFGraphs/Unknowns.wl
@@ -11,12 +11,27 @@ makeUnknowns::usage = "makeUnknowns[s] returns unknowns[<|\"js\" -> ..., \"jts\"
 
 Begin["`Private`"];
 
+DeriveAuxPairs[topology_Association] :=
+    Module[{graph, halfPairs, inAuxEntryPairs, outAuxExitPairs, inAuxExitPairs, 
+            outAuxEntryPairs, pairs},
+        graph = topology["Graph"];
+        halfPairs = List @@@ EdgeList[graph];
+        inAuxEntryPairs = List @@@ topology["AuxEntryEdges"];
+        outAuxExitPairs = List @@@ topology["AuxExitEdges"];
+        inAuxExitPairs = Reverse /@ outAuxExitPairs;
+        outAuxEntryPairs = Reverse /@ inAuxEntryPairs;
+        pairs = Join[halfPairs, Reverse /@ halfPairs];
+        Join[inAuxEntryPairs, outAuxEntryPairs, inAuxExitPairs, outAuxExitPairs, pairs]
+    ];
+
 MakeUnknownsFromPairsTriples[auxPairs_List, auxTriples_List] :=
     unknowns[
         <|
             "js" -> (j[Sequence @@ #] & /@ auxPairs),
             "jts" -> (j[Sequence @@ #] & /@ auxTriples),
-            "us" -> (u[Sequence @@ #] & /@ auxPairs)
+            "us" -> (u[Sequence @@ #] & /@ auxPairs),
+            "auxPairs" -> auxPairs,
+            "auxTriples" -> auxTriples
         |>
     ];
 
@@ -27,32 +42,32 @@ UnknownsData[unknowns[assoc_Association]] := assoc;
 UnknownsData[unknowns[assoc_Association], key_] := Lookup[assoc, key, Missing["KeyAbsent", key]];
 
 makeUnknowns[s_] :=
-    Module[{model, topology},
-        model = If[scenarioQ[s],
-            ScenarioData[s, "Model"],
-            If[AssociationQ[s], Lookup[s, "Model", s], $Failed]
+    Module[{model, topology, auxPairs, auxTriples},
+        topology = If[MFGraphs`scenarioQ[s], 
+            ScenarioData[s, "Topology"], 
+            $Failed
         ];
         
-        If[!AssociationQ[model],
-            Return[
-                Failure["makeUnknowns",
-                    <|"Message" -> "Input must be a scenario or a model association."|>
-                ],
-                Module
-            ]
+        If[!AssociationQ[topology],
+            model = If[MFGraphs`scenarioQ[s],
+                ScenarioData[s, "Model"],
+                If[AssociationQ[s], Lookup[s, "Model", s], $Failed]
+            ];
+            If[!AssociationQ[model],
+                Return[Failure["makeUnknowns", <|"Message" -> "Input must be a scenario or a model association."|>], Module]
+            ];
+            topology = MFGraphs`BuildAuxiliaryTopology[model];
         ];
-        
-        topology = BuildAuxiliaryTopology[model];
+
         If[topology === $Failed,
-            Return[
-                Failure["makeUnknowns",
-                    <|"Message" -> "Could not build auxiliary topology from model."|>
-                ],
-                Module
-            ]
+            Return[Failure["makeUnknowns", <|"Message" -> "Could not build auxiliary topology."|>], Module]
         ];
+
+        (* Combinatorial creation of pairs and triples moved here *)
+        auxPairs = DeriveAuxPairs[topology];
+        auxTriples = MFGraphs`BuildAuxTriples[topology["AuxiliaryGraph"]];
         
-        MakeUnknownsFromPairsTriples[topology["AuxPairs"], topology["AuxTriples"]]
+        MakeUnknownsFromPairsTriples[auxPairs, auxTriples]
     ];
 
 End[];


### PR DESCRIPTION
Refactored scenario lifecycle and symbolic unknown management for architectural consistency.

Summary of changes:
- **Scenario Source of Truth**: MFGraphs/Scenario.wl now owns shared topology derivation (BuildAuxiliaryTopology) and caches it in a "Topology" block.
- **Explicit Switching Costs**: Switching costs are now explicitly completed with zeros for all valid transitions during completeScenario.
- **Unknowns Consolidation**: MFGraphs/Unknowns.wl now leverages shared topology logic and stores auxPairs/auxTriples in the unknown bundle.
- **Pipeline Integration**: MFGraphs/DataToEquations.wl now uses fully-validated and completed data from makeScenario and cached topology.