### PR TITLE
Add typed scenario constructors and parametric example library

### DIFF
--- a/MFGraphs/Examples/ExampleScenarios.wl
+++ b/MFGraphs/Examples/ExampleScenarios.wl
@@ -1,29 +1,30 @@
 (* Wolfram Language package *)
-(* Scenario factories and direct constructors for all built-in MFGraphs examples.
+(* Scenario constructors and named-example registry for MFGraphs.
 
-   Direct constructors (preferred for custom scenarios):
-     GridScenario[{n}, entries, exits]          chain of n vertices (1..n)
-     GridScenario[{r,c}, entries, exits]        r x c grid (vertices 1..r*c, row-major)
+   Direct constructors — topology clear from arguments:
+     GridScenario[{n}, entries, exits]          chain, vertices 1..n
+     GridScenario[{r,c}, entries, exits]        grid, vertices 1..r*c row-major
+     CycleScenario[n, entries, exits]           directed n-cycle 1->2->...->n->1
+     GraphScenario[graph, entries, exits]       any WL directed Graph object
+     AMScenario[vl, am, entries, exits]         explicit vertices list + adjacency matrix
 
-   Named example registry (benchmark cases):
-     GetExampleScenario[7, {{1,80}}, {{3,0},{4,10}}]   uses canonical SC for case 7
-     GetExampleScenario[8, {{1,80}}, {{3,0},{4,10}}]   uses canonical SC for case 8
+   Named examples (benchmark registry):
+     GetExampleScenario[7, {{1,80}}, {{3,0},{4,10}}]      canonical SC for case 7
      GetExampleScenario[8, {{1,80}}, {{3,0},{4,10}}, {}]  override: no SC
 
-   All constructors accept optional: sc, alpha, V, g (Hamiltonian).
-   Defaults: sc={} (or canonical per case), alpha=1, V=0, g=Function[z,-1/z].
-   Numeric benchmark defaults are in Scripts/BenchmarkHelpers.wls ($DefaultParams/$CaseParams). *)
+   All constructors accept optional trailing args: sc, alpha, V, g.
+   Defaults: sc={}, alpha=1, V=0, g=Function[z,-1/z] (from $DefaultHamiltonian).
+   Numeric benchmark defaults are in Scripts/BenchmarkHelpers.wls. *)
 
 Begin["`Private`"];
 
-(* --- Shared adjacency-matrix constants for custom topologies --- *)
+(* --- Shared topology constants --- *)
 
 $Y1In2OutAM    = {{0,1,0,0},{0,0,1,1},{0,0,0,0},{0,0,0,0}};
 $Y2In1OutAM    = {{0,1,0,0},{0,0,0,1},{0,1,0,0},{0,0,0,0}};
 $Attraction4AM = {{0,1,1,0},{0,0,1,1},{0,0,0,1},{0,0,0,0}};
 
-(* Canonical switching costs for cases that have a well-defined default SC.
-   Looked up by GetExampleScenario when sc argument is Automatic. *)
+(* Canonical switching costs looked up by GetExampleScenario when sc=Automatic. *)
 $CaseDefaultSC = <|
     8  -> {{1,2,3,2},{1,2,4,3},{3,2,1,2},{3,2,4,1},{4,2,1,3},{4,2,3,1}},
     10 -> {{1,2,4,2},{1,2,3,3},{3,2,1,2},{3,2,4,1},{4,2,1,3},{4,2,3,1}},
@@ -37,12 +38,12 @@ $CaseDefaultSC = <|
     17 -> {{1,2,3,2},{3,2,1,1}},
     18 -> {{1,2,3,2},{3,2,1,1}},
     19 -> {{1,2,3,1},{1,2,4,1},{3,2,1,1},{3,2,4,1},{4,2,1,1},{4,2,3,1}},
-    "Braess split"     -> {{1,2,4,1},{5,7,8,1}},
-    "Braess congest"   -> {{1,2,4,1},{4,6,7,1}},
-    "Big Braess split" -> {{1,3,6,1},{5,7,10,1}},
+    "Braess split"       -> {{1,2,4,1},{5,7,8,1}},
+    "Braess congest"     -> {{1,2,4,1},{4,6,7,1}},
+    "Big Braess split"   -> {{1,3,6,1},{5,7,10,1}},
     "Big Braess congest" -> {{1,3,5,1},{5,7,9,1}},
-    "Paper example"    -> {{1,2,3,2},{3,2,1,1},{2,3,4,3},{4,3,2,1}},
-    (* SC that violates the triangle inequality — infeasible by design *)
+    "Paper example"      -> {{1,2,3,2},{3,2,1,1},{2,3,4,3},{4,3,2,1}},
+    (* SC violates triangle inequality — infeasible by design *)
     "Inconsistent Y shortcut" ->
         {{1,2,3,5},{1,2,4,1},{3,2,1,1},{3,2,4,1},{4,2,1,1},{4,2,3,1}},
     "Inconsistent attraction shortcut" ->
@@ -50,6 +51,8 @@ $CaseDefaultSC = <|
          {1,3,4,1},{4,3,1,1},{1,3,2,1},{2,3,1,1},{3,4,2,1},{2,4,3,1},
          {2,3,4,1},{4,3,2,1},{3,1,2,1},{2,1,3,1}}
 |>;
+
+(* --- Direct constructors — each calls makeScenario once, no intermediate helpers --- *)
 
 GridScenario[dims_List, entries_, exits_,
         sc_    : {},
@@ -66,39 +69,69 @@ GridScenario[dims_List, entries_, exits_,
         "Hamiltonian" -> <|"Alpha" -> alpha, "V" -> V, "G" -> g|>
     |>];
 
+CycleScenario[n_Integer, entries_, exits_,
+        sc_    : {},
+        alpha_ : $DefaultHamiltonian["Alpha"],
+        V_     : $DefaultHamiltonian["V"],
+        g_     : $DefaultHamiltonian["G"]] :=
+    makeScenario[<|
+        "Model" -> <|
+            "Graph"                           -> CycleGraph[n, DirectedEdges -> True],
+            "Entrance Vertices and Flows"     -> entries,
+            "Exit Vertices and Terminal Costs" -> exits,
+            "Switching Costs"                 -> sc
+        |>,
+        "Hamiltonian" -> <|"Alpha" -> alpha, "V" -> V, "G" -> g|>
+    |>];
+
+GraphScenario[graph_, entries_, exits_,
+        sc_    : {},
+        alpha_ : $DefaultHamiltonian["Alpha"],
+        V_     : $DefaultHamiltonian["V"],
+        g_     : $DefaultHamiltonian["G"]] :=
+    makeScenario[<|
+        "Model" -> <|
+            "Graph"                           -> graph,
+            "Entrance Vertices and Flows"     -> entries,
+            "Exit Vertices and Terminal Costs" -> exits,
+            "Switching Costs"                 -> sc
+        |>,
+        "Hamiltonian" -> <|"Alpha" -> alpha, "V" -> V, "G" -> g|>
+    |>];
+
+AMScenario[vl_, am_, entries_, exits_,
+        sc_    : {},
+        alpha_ : $DefaultHamiltonian["Alpha"],
+        V_     : $DefaultHamiltonian["V"],
+        g_     : $DefaultHamiltonian["G"]] :=
+    makeScenario[<|
+        "Model" -> <|
+            "Vertices List"                   -> vl,
+            "Adjacency Matrix"                -> am,
+            "Entrance Vertices and Flows"     -> entries,
+            "Exit Vertices and Terminal Costs" -> exits,
+            "Switching Costs"                 -> sc
+        |>,
+        "Hamiltonian" -> <|"Alpha" -> alpha, "V" -> V, "G" -> g|>
+    |>];
+
+(* --- Private factory helpers — thin wrappers used by $ExampleScenarios --- *)
+
 $MakeGridFactory[dims_List] :=
     With[{d = dims},
-        Function[{entries, exits, sc, alpha, V, g},
-            GridScenario[d, entries, exits, sc, alpha, V, g]]];
+        Function[{entries, exits, sc, alpha, V, g}, GridScenario[d,  entries, exits, sc, alpha, V, g]]];
 
-$MakeCycleFactory[n_Integer] := $MakeGraphFactory[CycleGraph[n, DirectedEdges -> True]];
+$MakeCycleFactory[n_Integer] :=
+    With[{k = n},
+        Function[{entries, exits, sc, alpha, V, g}, CycleScenario[k, entries, exits, sc, alpha, V, g]]];
 
 $MakeGraphFactory[graph_] :=
-    With[{g = graph},
-        Function[{entries, exits, sc, alpha, V, gFunc},
-            makeScenario[<|
-                "Model" -> <|
-                    "Graph"                           -> g,
-                    "Entrance Vertices and Flows"     -> entries,
-                    "Exit Vertices and Terminal Costs" -> exits,
-                    "Switching Costs"                 -> sc
-                |>,
-                "Hamiltonian" -> <|"Alpha" -> alpha, "V" -> V, "G" -> gFunc|>
-            |>]]];
+    With[{gr = graph},
+        Function[{entries, exits, sc, alpha, V, g}, GraphScenario[gr, entries, exits, sc, alpha, V, g]]];
 
 $MakeAMFactory[vl_, am_] :=
     With[{vertices = vl, matrix = am},
-        Function[{entries, exits, sc, alpha, V, gFunc},
-            makeScenario[<|
-                "Model" -> <|
-                    "Vertices List"                   -> vertices,
-                    "Adjacency Matrix"                -> matrix,
-                    "Entrance Vertices and Flows"     -> entries,
-                    "Exit Vertices and Terminal Costs" -> exits,
-                    "Switching Costs"                 -> sc
-                |>,
-                "Hamiltonian" -> <|"Alpha" -> alpha, "V" -> V, "G" -> gFunc|>
-            |>]]];
+        Function[{entries, exits, sc, alpha, V, g}, AMScenario[vertices, matrix, entries, exits, sc, alpha, V, g]]];
 
 (* --- Scenario registry --- *)
 
@@ -140,7 +173,6 @@ $ExampleScenarios = Association[
 
     (* ------------------------------------------------------------------ *)
     (* Triangle 3-vertex directed cycle: 1->2->3->1                       *)
-    (* CycleGraph[3, DirectedEdges->True]                                  *)
     (* ------------------------------------------------------------------ *)
 
     14                        -> $MakeCycleFactory[3],
@@ -212,10 +244,12 @@ $ExampleScenarios = Association[
             {0,1,1,0,0,0,0},{0,0,0,1,0,0,0},{0,0,0,1,0,0,0},
             {0,0,0,0,1,1,0},{0,0,0,0,0,0,1},{0,0,0,0,0,0,1},{0,0,0,0,0,0,0}}],
 
+    (* "New Braess" carries an extra "a" congestion field — not expressible
+       via the standard constructors, so defined inline. *)
     "New Braess" -> With[{newBraessAM = {
                 {0,1,0,1,0,0},{0,0,1,0,0,0},{0,0,0,0,0,1},
                 {0,0,0,0,1,0},{0,0,0,0,0,1},{0,0,0,0,0,0}}},
-        Function[{entries, exits, sc, alpha, V, gFunc},
+        Function[{entries, exits, sc, alpha, V, g},
             makeScenario[<|
                 "Model" -> <|
                     "Vertices List"                   -> Range[6],
@@ -228,7 +262,7 @@ $ExampleScenarios = Association[
                                 edge === DirectedEdge[3,6] || edge === DirectedEdge[1,4], j/100,
                                 True, 0]]
                 |>,
-                "Hamiltonian" -> <|"Alpha" -> alpha, "V" -> V, "G" -> gFunc|>
+                "Hamiltonian" -> <|"Alpha" -> alpha, "V" -> V, "G" -> g|>
             |>]]],
 
     "Big Braess split" -> $MakeAMFactory[Range[10], {
@@ -258,11 +292,8 @@ $ExampleScenarios = Association[
     (* Inconsistent switching (feature validation — infeasible by design)  *)
     (* ------------------------------------------------------------------ *)
 
-    "Inconsistent Y shortcut" ->
-        $MakeAMFactory[{1,2,3,4}, $Y1In2OutAM],
-
-    "Inconsistent attraction shortcut" ->
-        $MakeAMFactory[{1,2,3,4}, $Attraction4AM],
+    "Inconsistent Y shortcut"          -> $MakeAMFactory[{1,2,3,4}, $Y1In2OutAM],
+    "Inconsistent attraction shortcut" -> $MakeAMFactory[{1,2,3,4}, $Attraction4AM],
 
     (* ------------------------------------------------------------------ *)
     (* Grid cases: directed GridGraph[{r,c}]                              *)
@@ -281,8 +312,7 @@ $ExampleScenarios = Association[
 
 GetExampleScenario[n_] := Lookup[$ExampleScenarios, n, $Failed];
 
-(* sc=Automatic resolves to the canonical SC for the case (from $CaseDefaultSC),
-   or {} if the case has no canonical SC. Hamiltonian defaults from $DefaultHamiltonian. *)
+(* sc=Automatic resolves to the canonical SC via $CaseDefaultSC, or {} if undefined. *)
 GetExampleScenario[n_, entries_, exits_,
         sc_    : Automatic,
         alpha_ : $DefaultHamiltonian["Alpha"],

--- a/MFGraphs/Examples/ExampleScenarios.wl
+++ b/MFGraphs/Examples/ExampleScenarios.wl
@@ -116,12 +116,12 @@ AMScenario[vl_, am_, entries_, exits_,
 (* --- Private factory helpers — thin wrappers used by $ExampleScenarios --- *)
 
 MakeGridFactory[dims_List] :=
-    With[{d = dims},
-        Function[{entries, exits, sc, alpha, V, g}, GridScenario[d,  entries, exits, sc, alpha, V, g]]];
+    With[{dims = dims},
+        Function[{entries, exits, sc, alpha, V, g}, GridScenario[dims, entries, exits, sc, alpha, V, g]]];
 
 MakeCycleFactory[n_Integer] :=
-    With[{k = n},
-        Function[{entries, exits, sc, alpha, V, g}, CycleScenario[k, entries, exits, sc, alpha, V, g]]];
+    With[{n = n},
+        Function[{entries, exits, sc, alpha, V, g}, CycleScenario[n, entries, exits, sc, alpha, V, g]]];
 
 MakeAMFactory[vl_, am_] :=
     With[{vertices = vl, matrix = am},

--- a/MFGraphs/Examples/ExampleScenarios.wl
+++ b/MFGraphs/Examples/ExampleScenarios.wl
@@ -115,15 +115,15 @@ AMScenario[vl_, am_, entries_, exits_,
 
 (* --- Private factory helpers — thin wrappers used by $ExampleScenarios --- *)
 
-$MakeGridFactory[dims_List] :=
+MakeGridFactory[dims_List] :=
     With[{d = dims},
         Function[{entries, exits, sc, alpha, V, g}, GridScenario[d,  entries, exits, sc, alpha, V, g]]];
 
-$MakeCycleFactory[n_Integer] :=
+MakeCycleFactory[n_Integer] :=
     With[{k = n},
         Function[{entries, exits, sc, alpha, V, g}, CycleScenario[k, entries, exits, sc, alpha, V, g]]];
 
-$MakeAMFactory[vl_, am_] :=
+MakeAMFactory[vl_, am_] :=
     With[{vertices = vl, matrix = am},
         Function[{entries, exits, sc, alpha, V, g}, AMScenario[vertices, matrix, entries, exits, sc, alpha, V, g]]];
 
@@ -135,70 +135,70 @@ $ExampleScenarios = Association[
     (* Linear chains (cases 1–6): directed GridGraph[{n}]                 *)
     (* ------------------------------------------------------------------ *)
 
-    1 -> $MakeGridFactory[{1}],
-    2 -> $MakeGridFactory[{2}],
-    3 -> $MakeGridFactory[{3}],
-    4 -> $MakeGridFactory[{4}],
-    5 -> $MakeGridFactory[{5}],
-    6 -> $MakeGridFactory[{10}],
+    1 -> MakeGridFactory[{1}],
+    2 -> MakeGridFactory[{2}],
+    3 -> MakeGridFactory[{3}],
+    4 -> MakeGridFactory[{4}],
+    5 -> MakeGridFactory[{5}],
+    6 -> MakeGridFactory[{10}],
 
     (* ------------------------------------------------------------------ *)
     (* Y 1-in 2-out, 4 vertices (cases 7, 8, 19)                          *)
     (* ------------------------------------------------------------------ *)
 
-    7  -> $MakeAMFactory[{1,2,3,4}, $Y1In2OutAM],
-    8  -> $MakeAMFactory[{1,2,3,4}, $Y1In2OutAM],
-    19 -> $MakeAMFactory[{1,2,3,4}, $Y1In2OutAM],
+    7  -> MakeAMFactory[{1,2,3,4}, $Y1In2OutAM],
+    8  -> MakeAMFactory[{1,2,3,4}, $Y1In2OutAM],
+    19 -> MakeAMFactory[{1,2,3,4}, $Y1In2OutAM],
 
     (* ------------------------------------------------------------------ *)
     (* Y 2-in 1-out, 4 vertices (cases 9, 10)                             *)
     (* ------------------------------------------------------------------ *)
 
-    9  -> $MakeAMFactory[{1,2,3,4}, $Y2In1OutAM],
-    10 -> $MakeAMFactory[{1,2,3,4}, $Y2In1OutAM],
+    9  -> MakeAMFactory[{1,2,3,4}, $Y2In1OutAM],
+    10 -> MakeAMFactory[{1,2,3,4}, $Y2In1OutAM],
 
     (* ------------------------------------------------------------------ *)
     (* Attraction 4-vertex diamond (cases 11, 12, 13)                     *)
     (* ------------------------------------------------------------------ *)
 
-    11 -> $MakeAMFactory[{1,2,3,4}, $Attraction4AM],
-    12 -> $MakeAMFactory[{1,2,3,4}, $Attraction4AM],
-    13 -> $MakeAMFactory[{1,2,3,4}, {{0,1,1,0},{0,0,0,1},{0,0,0,1},{0,0,0,0}}],
+    11 -> MakeAMFactory[{1,2,3,4}, $Attraction4AM],
+    12 -> MakeAMFactory[{1,2,3,4}, $Attraction4AM],
+    13 -> MakeAMFactory[{1,2,3,4}, {{0,1,1,0},{0,0,0,1},{0,0,0,1},{0,0,0,0}}],
 
     (* ------------------------------------------------------------------ *)
     (* Triangle 3-vertex directed cycle: 1->2->3->1                       *)
     (* ------------------------------------------------------------------ *)
 
-    14                        -> $MakeCycleFactory[3],
-    104                       -> $MakeCycleFactory[3],
-    "triangle with two exits" -> $MakeCycleFactory[3],
+    14                        -> MakeCycleFactory[3],
+    104                       -> MakeCycleFactory[3],
+    "triangle with two exits" -> MakeCycleFactory[3],
 
     (* ------------------------------------------------------------------ *)
     (* 3-vertex directed chain with two exits (cases 105, alias)          *)
     (* ------------------------------------------------------------------ *)
 
-    "chain with two exits" -> $MakeGridFactory[{3}],
-    105                    -> $MakeGridFactory[{3}],
+    "chain with two exits" -> MakeGridFactory[{3}],
+    105                    -> MakeGridFactory[{3}],
 
     (* ------------------------------------------------------------------ *)
     (* 3-vertex misc (cases 15–18)                                        *)
     (* ------------------------------------------------------------------ *)
 
-    15 -> $MakeAMFactory[{1,2,3}, {{0,0,0},{1,0,0},{1,0,0}}],
-    16 -> $MakeAMFactory[{1,2,3}, {{0,1,0},{0,0,1},{0,0,0}}],
-    17 -> $MakeAMFactory[{1,2,3}, {{0,1,0},{0,0,1},{0,0,0}}],
-    18 -> $MakeAMFactory[{1,2,3}, {{0,1,0},{0,0,1},{0,0,0}}],
+    15 -> MakeAMFactory[{1,2,3}, {{0,0,0},{1,0,0},{1,0,0}}],
+    16 -> MakeAMFactory[{1,2,3}, {{0,1,0},{0,0,1},{0,0,0}}],
+    17 -> MakeAMFactory[{1,2,3}, {{0,1,0},{0,0,1},{0,0,0}}],
+    18 -> MakeAMFactory[{1,2,3}, {{0,1,0},{0,0,1},{0,0,0}}],
 
     (* ------------------------------------------------------------------ *)
     (* Multi-entrance/exit (cases 20–23, "Jamaratv9")                     *)
     (* ------------------------------------------------------------------ *)
 
-    20 -> $MakeAMFactory[Range[9], {
+    20 -> MakeAMFactory[Range[9], {
             {0,0,1,0,0,0,0,0,0},{0,0,1,0,0,0,0,0,0},{0,0,0,1,0,0,0,0,0},
             {0,0,0,0,1,0,0,0,0},{0,0,0,0,0,1,0,0,0},{0,0,0,0,0,0,1,1,1},
             {0,0,0,0,0,0,0,0,0},{0,0,0,0,0,0,0,0,0},{0,0,0,0,0,0,0,0,0}}],
 
-    21 -> $MakeAMFactory[Range[12], {
+    21 -> MakeAMFactory[Range[12], {
             {0,0,1,0,0,0,0,0,0,0,0,0},{0,0,0,1,0,0,0,0,0,0,0,0},
             {0,0,0,1,1,0,0,0,0,0,0,0},{0,0,0,0,0,1,0,0,0,0,0,0},
             {0,0,0,0,0,1,1,0,0,0,0,0},{0,0,0,0,0,0,0,1,0,0,0,0},
@@ -206,16 +206,16 @@ $ExampleScenarios = Association[
             {0,0,0,0,0,0,0,0,0,0,0,1},{0,0,0,0,0,0,0,0,0,0,0,0},
             {0,0,0,0,0,0,0,0,0,0,0,0},{0,0,0,0,0,0,0,0,0,0,0,0}}],
 
-    22 -> $MakeAMFactory[Range[7], {
+    22 -> MakeAMFactory[Range[7], {
             {0,1,1,0,0,0,0},{0,0,0,1,0,0,0},{0,0,0,1,1,0,0},
             {0,0,0,0,0,1,0},{0,0,0,0,0,1,1},{0,0,0,0,0,0,1},{0,0,0,0,0,0,0}}],
 
-    "Jamaratv9" -> $MakeAMFactory[Range[9], {
+    "Jamaratv9" -> MakeAMFactory[Range[9], {
             {0,1,1,0,0,0,0,0,0},{0,0,0,1,0,0,0,0,0},{0,0,0,1,1,0,0,0,0},
             {0,0,0,0,0,1,0,0,0},{0,0,0,0,0,1,1,0,0},{0,0,0,0,0,0,0,1,0},
             {0,0,0,0,0,0,0,0,1},{0,0,0,0,0,0,0,0,1},{0,0,0,0,0,0,0,0,0}}],
 
-    23 -> $MakeAMFactory[Range[6], {
+    23 -> MakeAMFactory[Range[6], {
             {0,1,1,0,0,0},{0,0,1,0,0,0},{0,0,0,1,1,0},
             {0,0,0,0,1,1},{0,0,0,0,0,1},{0,0,0,0,0,0}}],
 
@@ -223,18 +223,18 @@ $ExampleScenarios = Association[
     (* 2-vertex undirected edge (case 27)                                  *)
     (* ------------------------------------------------------------------ *)
 
-    27 -> $MakeAMFactory[{1,2}, {{0,1},{1,0}}],
+    27 -> MakeAMFactory[{1,2}, {{0,1},{1,0}}],
 
     (* ------------------------------------------------------------------ *)
     (* Braess variants                                                     *)
     (* ------------------------------------------------------------------ *)
 
-    "Braess split" -> $MakeAMFactory[Range[8], {
+    "Braess split" -> MakeAMFactory[Range[8], {
             {0,1,1,0,0,0,0,0},{0,0,0,1,0,0,0,0},{0,0,0,0,1,0,0,0},
             {0,0,0,0,0,1,0,0},{0,0,0,0,0,0,1,0},{0,0,0,0,0,0,0,1},
             {0,0,0,0,0,0,0,1},{0,0,0,0,0,0,0,0}}],
 
-    "Braess congest" -> $MakeAMFactory[Range[7], {
+    "Braess congest" -> MakeAMFactory[Range[7], {
             {0,1,1,0,0,0,0},{0,0,0,1,0,0,0},{0,0,0,1,0,0,0},
             {0,0,0,0,1,1,0},{0,0,0,0,0,0,1},{0,0,0,0,0,0,1},{0,0,0,0,0,0,0}}],
 
@@ -259,13 +259,13 @@ $ExampleScenarios = Association[
                 "Hamiltonian" -> <|"Alpha" -> alpha, "V" -> V, "G" -> g|>
             |>]]],
 
-    "Big Braess split" -> $MakeAMFactory[Range[10], {
+    "Big Braess split" -> MakeAMFactory[Range[10], {
             {0,1,1,0,0,0,0,0,0,0},{0,0,0,1,0,0,0,0,0,0},{0,0,0,0,0,1,0,0,0,0},
             {0,0,0,0,1,0,0,0,0,0},{0,0,0,0,0,0,1,0,0,0},{0,0,0,0,0,0,0,1,0,0},
             {0,0,0,0,0,0,0,0,0,1},{0,0,0,0,0,0,0,0,1,0},{0,0,0,0,0,0,0,0,0,1},
             {0,0,0,0,0,0,0,0,0,0}}],
 
-    "Big Braess congest" -> $MakeAMFactory[Range[9], {
+    "Big Braess congest" -> MakeAMFactory[Range[9], {
             {0,1,1,0,0,0,0,0,0},{0,0,0,1,0,0,0,0,0},{0,0,0,0,1,0,0,0,0},
             {0,0,0,0,1,0,0,0,0},{0,0,0,0,0,1,1,0,0},{0,0,0,0,0,0,0,1,0},
             {0,0,0,0,0,0,0,0,1},{0,0,0,0,0,0,0,0,1},{0,0,0,0,0,0,0,0,0}}],
@@ -274,32 +274,32 @@ $ExampleScenarios = Association[
     (* Paper / benchmark cases                                             *)
     (* ------------------------------------------------------------------ *)
 
-    "HRF Scenario 1" -> $MakeAMFactory[Range[10], {
+    "HRF Scenario 1" -> MakeAMFactory[Range[10], {
             {0,1,0,0,0,0,0,0,0,0},{0,0,1,1,0,0,0,0,0,0},{0,0,0,1,1,0,1,0,0,0},
             {0,0,0,0,1,1,1,0,0,0},{0,0,0,0,0,1,1,0,0,0},{0,0,0,0,0,0,1,0,0,0},
             {0,0,0,0,0,0,0,1,0,1},{0,0,0,0,0,0,0,0,0,0},{0,0,1,0,0,0,0,0,0,0},
             {0,0,0,0,0,0,0,0,0,0}}],
 
-    "Paper example" -> $MakeGridFactory[{4}],
+    "Paper example" -> MakeGridFactory[{4}],
 
     (* ------------------------------------------------------------------ *)
     (* Inconsistent switching (feature validation — infeasible by design)  *)
     (* ------------------------------------------------------------------ *)
 
-    "Inconsistent Y shortcut"          -> $MakeAMFactory[{1,2,3,4}, $Y1In2OutAM],
-    "Inconsistent attraction shortcut" -> $MakeAMFactory[{1,2,3,4}, $Attraction4AM],
+    "Inconsistent Y shortcut"          -> MakeAMFactory[{1,2,3,4}, $Y1In2OutAM],
+    "Inconsistent attraction shortcut" -> MakeAMFactory[{1,2,3,4}, $Attraction4AM],
 
     (* ------------------------------------------------------------------ *)
     (* Grid cases: directed GridGraph[{r,c}]                              *)
     (* ------------------------------------------------------------------ *)
 
-    "Grid0303" -> $MakeGridFactory[{3,3}],
-    "Grid0404" -> $MakeGridFactory[{4,4}],
-    "Grid0505" -> $MakeGridFactory[{5,5}],
-    "Grid0707" -> $MakeGridFactory[{7,7}],
-    "Grid0710" -> $MakeGridFactory[{7,10}],
-    "Grid1010" -> $MakeGridFactory[{10,10}],
-    "Grid1020" -> $MakeGridFactory[{10,20}]
+    "Grid0303" -> MakeGridFactory[{3,3}],
+    "Grid0404" -> MakeGridFactory[{4,4}],
+    "Grid0505" -> MakeGridFactory[{5,5}],
+    "Grid0707" -> MakeGridFactory[{7,7}],
+    "Grid0710" -> MakeGridFactory[{7,10}],
+    "Grid1010" -> MakeGridFactory[{10,10}],
+    "Grid1020" -> MakeGridFactory[{10,20}]
 ];
 
 (* --- Accessors --- *)

--- a/MFGraphs/Examples/ExampleScenarios.wl
+++ b/MFGraphs/Examples/ExampleScenarios.wl
@@ -115,17 +115,9 @@ AMScenario[vl_, am_, entries_, exits_,
 
 (* --- Private factory helpers — thin wrappers used by $ExampleScenarios --- *)
 
-MakeGridFactory[dims_List] :=
-    With[{dims = dims},
-        Function[{entries, exits, sc, alpha, V, g}, GridScenario[dims, entries, exits, sc, alpha, V, g]]];
-
-MakeCycleFactory[n_Integer] :=
-    With[{n = n},
-        Function[{entries, exits, sc, alpha, V, g}, CycleScenario[n, entries, exits, sc, alpha, V, g]]];
-
-MakeAMFactory[vl_, am_] :=
-    With[{vertices = vl, matrix = am},
-        Function[{entries, exits, sc, alpha, V, g}, AMScenario[vertices, matrix, entries, exits, sc, alpha, V, g]]];
+MakeGridFactory[dims_List]  := Function[{entries, exits, sc, alpha, V, g}, GridScenario[dims,  entries, exits, sc, alpha, V, g]];
+MakeCycleFactory[n_Integer] := Function[{entries, exits, sc, alpha, V, g}, CycleScenario[n,    entries, exits, sc, alpha, V, g]];
+MakeAMFactory[vl_, am_]     := Function[{entries, exits, sc, alpha, V, g}, AMScenario[vl, am, entries, exits, sc, alpha, V, g]];
 
 (* --- Scenario registry --- *)
 

--- a/MFGraphs/Examples/ExampleScenarios.wl
+++ b/MFGraphs/Examples/ExampleScenarios.wl
@@ -52,8 +52,6 @@ $CaseDefaultSC = <|
          {2,3,4,1},{4,3,2,1},{3,1,2,1},{2,1,3,1}}
 |>;
 
-(* --- Direct constructors — each calls makeScenario once, no intermediate helpers --- *)
-
 GridScenario[dims_List, entries_, exits_,
         sc_    : {},
         alpha_ : $DefaultHamiltonian["Alpha"],
@@ -124,10 +122,6 @@ $MakeGridFactory[dims_List] :=
 $MakeCycleFactory[n_Integer] :=
     With[{k = n},
         Function[{entries, exits, sc, alpha, V, g}, CycleScenario[k, entries, exits, sc, alpha, V, g]]];
-
-$MakeGraphFactory[graph_] :=
-    With[{gr = graph},
-        Function[{entries, exits, sc, alpha, V, g}, GraphScenario[gr, entries, exits, sc, alpha, V, g]]];
 
 $MakeAMFactory[vl_, am_] :=
     With[{vertices = vl, matrix = am},

--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -175,10 +175,20 @@ launching parallel subkernels. Only applies when $KernelCount === 0. Default is 
 
 GridScenario::usage =
 "GridScenario[dims, entries, exits] creates a scenario on a directed GridGraph[dims]. \
-dims is a list of dimensions: {n} for a chain of n vertices (1..n), {r,c} for an r\[Times]c grid \
-(vertices 1..r*c, row-major). Optional arguments: sc (switching costs, default {}), \
-alpha, V, g (Hamiltonian parameters, defaults from $DefaultHamiltonian). \
-Example: GridScenario[{3,3}, {{1,100}}, {{9,0}}] — entry at vertex 1, exit at vertex 9.";
+{n} gives a chain with vertices 1..n; {r,c} gives an r\[Times]c grid with vertices 1..r*c (row-major). \
+Optional: sc (switching costs, default {}), alpha, V, g (Hamiltonian defaults from $DefaultHamiltonian).";
+
+CycleScenario::usage =
+"CycleScenario[n, entries, exits] creates a scenario on a directed n-cycle (1->2->...->n->1), \
+vertices 1..n. Optional: sc, alpha, V, g.";
+
+GraphScenario::usage =
+"GraphScenario[graph, entries, exits] creates a scenario from any WL directed Graph object. \
+Optional: sc, alpha, V, g.";
+
+AMScenario::usage =
+"AMScenario[vl, am, entries, exits] creates a scenario from an explicit vertices list vl \
+and adjacency matrix am. Optional: sc, alpha, V, g.";
 
 GetExampleScenario::usage =
 "GetExampleScenario[n] returns a 6-arg factory Function[{entries,exits,sc,alpha,V,g}, scenario[...]] \


### PR DESCRIPTION
## Summary

- **5 public constructors** for building scenarios directly from topology: `GridScenario[dims,...]`, `CycleScenario[n,...]`, `GraphScenario[graph,...]`, `AMScenario[vl,am,...]` — each calls `makeScenario` once with no intermediate composition. Dimensions/vertex counts are visible in the call, so users know which vertices to use as entries/exits.
- **`GetExampleScenario`** extended to a 6-arg form with defaults for `sc`, `alpha`, `V`, `g`; canonical switching costs preserved per case via `$CaseDefaultSC` (Automatic sentinel).
- **`ExampleScenarios.wl`** fully rewritten: all 45 named examples use three thin private factory helpers (`MakeGridFactory`, `MakeCycleFactory`, `MakeAMFactory`) that are single-line `Function` wrappers — no `With`, no intermediate helpers.
- **`DataToEquations[s_scenario]`** overload added; `GetExampleScenario::usage` and four new `::usage` strings added to public declarations.

## Test plan

- [ ] `wolframscript -file MFGraphs/Tests/scenario-kernel.mt`
- [ ] `wolframscript -file Scripts/RunTests.wls fast`
- [ ] Smoke-check: `GridScenario[{3,3}, {{1,100}}, {{9,0}}]` returns a valid `scenario[...]`
- [ ] Smoke-check: `GetExampleScenario[8, {{1,80}}, {{3,0},{4,10}}]` uses canonical SC

🤖 Generated with [Claude Code](https://claude.ai/claude-code)