### PR TITLE
perf(scenario): eliminate redundant object generation in topology pipeline

### DIFF
--- a/MFGraphs/Examples/ExamplesData.wl
+++ b/MFGraphs/Examples/ExamplesData.wl
@@ -569,7 +569,11 @@ $ExampleDataFields6 = Join[$ExampleDataFields5, {"a"}];
 $ExampleDataFields7 = Join[$ExampleDataFields6, {"alpha"}];
 
 GetExampleDataRaw[n_] :=
-    With[{data = test[n]},
+    Module[{data},
+        If[!ValueQ[test[n]],
+            Return[$Failed, Module]
+        ];
+        data = test[n];
         Switch[Length[data],
             5, AssociationThread[$ExampleDataFields5, data],
             6, AssociationThread[$ExampleDataFields6, data],
@@ -600,7 +604,7 @@ AdjacentVerticesQ[adjacency_, vertexIndex_Association, u_, v_] :=
         iu = Lookup[vertexIndex, u, Missing["KeyAbsent", u]];
         iv = Lookup[vertexIndex, v, Missing["KeyAbsent", v]];
         If[MissingQ[iu] || MissingQ[iv], Return[False, Module]];
-        Quiet @ Check[
+        Check[
             TrueQ[adjacency[[iu, iv]] =!= 0] || TrueQ[adjacency[[iv, iu]] =!= 0],
             False
         ]

--- a/MFGraphs/Getting started.wl
+++ b/MFGraphs/Getting started.wl
@@ -585,8 +585,7 @@ JamaratScenario[params_List] :=
 (* Scenarios provide a typed wrapper for model data and parameters. *)
 typedScenario = makeScenario[<|
     "Identity" -> <|"Name" -> "Y-junction benchmark"|>,
-    "Model" -> GetExampleData[7],
-    "Data" -> {I1 -> 100, U1 -> 0, U2 -> 0}
+    "Model" -> (GetExampleData[7] /. {I1 -> 100, U1 -> 0, U2 -> 0})
 |>]
 Head@%
 

--- a/MFGraphs/Scenario.wl
+++ b/MFGraphs/Scenario.wl
@@ -13,7 +13,6 @@
    Canonical top-level blocks inside scenario[<|...|>]:
      "Identity"    — name, version
      "Model"       — raw network topology accepted by DataToEquations
-     "Data"        — parameter substitution rules (e.g. {I1 -> 100, U1 -> 0})
      "Validation"  — consistency check results (populated after solving)
      "Benchmark"   — tier, timeout
      "Visualization" — optional plotting hints
@@ -37,13 +36,13 @@ DataToEquations (required keys: \"Vertices List\", \"Adjacency Matrix\", \
 \"Entrance Vertices and Flows\", \"Exit Vertices and Terminal Costs\", \
 \"Switching Costs\"). If \"Model\" contains a Wolfram Graph under key \"Graph\", \
 missing \"Vertices List\" and/or \"Adjacency Matrix\" are derived automatically. \
-Optional keys: \"Data\" (parameter substitution rules), \
+Optional keys: \
 \"Hamiltonian\" (<|\"Alpha\" -> a, \"V\" -> v, \"G\" -> g, \
 \"EdgeAlpha\" -> <|{u,v} -> a_uv, ...|>, \"EdgeV\" -> <|{u,v} -> v_uv, ...|>, \
 \"EdgeG\" -> <|{u,v} -> g_uv, ...|>|>), \
 \"Identity\" (name, version), \"Benchmark\" (tier, timeout), \"Visualization\", \
 \"Inheritance\". Default Hamiltonian is Alpha=1 and V=0 on all edges, with \
-G[z]=-1/z (overridable globally and per edge). Boundary values must be numeric after Data substitution. \
+G[z]=-1/z (overridable globally and per edge). Boundary and switching-cost values must be numeric. \
 Returns a scenario[...] object on success or Failure[...] on error.";
 
 validateScenario::usage =
@@ -106,6 +105,9 @@ HamiltonianGTermQ[value_] :=
 BuildAdjacencyFromGraph[graph_Graph, vertices_List] :=
     Module[{baseVertices, baseAdjacency, baseIndex, order},
         baseVertices = VertexList[graph];
+        If[vertices === baseVertices,
+            Return[AdjacencyMatrix[graph], Module]
+        ];
         baseAdjacency = AdjacencyMatrix[graph];
         baseIndex = AssociationThread[baseVertices, Range[Length[baseVertices]]];
         order = Lookup[baseIndex, vertices, Missing["UnknownVertex"]];
@@ -141,39 +143,6 @@ NormalizeScenarioModel[model_Association] :=
 
 NormalizeScenarioModel[other_] := other;
 
-NormalizeScenarioDataRules[data_] :=
-    Which[
-        AssociationQ[data], Normal[data],
-        ListQ[data], data,
-        True, {}
-    ];
-
-ExpandDataRulesForModelSymbols[model_Association, rules_List] :=
-    Module[{symbolsInModel, symbolsByName, nameRules, expanded},
-        symbolsInModel = DeleteDuplicates @ Cases[model, _Symbol, Infinity];
-        symbolsByName = GroupBy[symbolsInModel, SymbolName];
-        nameRules = Association @ Cases[
-            rules,
-            HoldPattern[(lhs_Symbol -> rhs_)] :> (SymbolName[Unevaluated[lhs]] -> rhs)
-        ];
-        expanded = Flatten @ KeyValueMap[
-            Function[{name, rhs},
-                Rule[#, rhs] & /@ Lookup[symbolsByName, name, {}]
-            ],
-            nameRules
-        ];
-        DeleteDuplicatesBy[Join[rules, expanded], First]
-    ];
-
-ApplyScenarioDataToModel[model_Association, data_] :=
-    Module[{rules},
-        rules = NormalizeScenarioDataRules[data];
-        If[rules === {},
-            model,
-            model /. ExpandDataRulesForModelSymbols[model, rules]
-        ]
-    ];
-
 BoundaryValuesNumericQ[model_Association] :=
     Module[{entry, exit, entryVals, exitVals},
         entry = Lookup[model, "Entrance Vertices and Flows", Missing["KeyAbsent", "Entrance Vertices and Flows"]];
@@ -187,6 +156,19 @@ BoundaryValuesNumericQ[model_Association] :=
         entryVals = Last /@ entry;
         exitVals = Last /@ exit;
         AllTrue[Join[entryVals, exitVals], NumericQ]
+    ];
+
+SwitchingCostsNumericQ[model_Association] :=
+    Module[{switching},
+        switching = Lookup[model, "Switching Costs", Missing["KeyAbsent", "Switching Costs"]];
+        Which[
+            AssociationQ[switching],
+                AllTrue[Values[switching], NumericQ],
+            ListQ[switching],
+                AllTrue[switching, ListQ] && AllTrue[Last /@ switching, NumericQ],
+            True,
+                False
+        ]
     ];
 
 IntegerVertexLabelsQ[model_Association] :=
@@ -317,21 +299,8 @@ NormalizeHamiltonianSpec[spec_, model_Association] :=
 
 (* --- Topology Helpers --- *)
 
-BuildAuxTriples[auxGraph_Graph] :=
-    Module[{edges, directedEdges, incomingByVertex, outgoingByVertex, middleVertices},
-        (* 
-           PERFORMANCE NOTE: This implementation uses a "generate and filter" pattern 
-           with 'Nothing' and 'DeleteDuplicates'. 
-           
-           - In Wolfram Language: This is faster because 'Flatten' and 'DeleteDuplicates' 
-             are heavily optimized C-internal functions. Vectorized cleanup is cheaper 
-             than top-level conditional logic (like Select or If) inside the loops.
-           - In Compiled Languages (e.g., Rust/C++): A "zero-waste" strategy is 
-             preferable. You should filter 'vIn != vOut' before triple allocation 
-             to avoid transient memory overhead.
-        *)
-        edges = List @@@ EdgeList[auxGraph];
-        directedEdges = Join[edges, Reverse[edges, {2}]];
+iBuildAuxTriples[directedEdges_List] :=
+    Module[{incomingByVertex, outgoingByVertex, middleVertices},
         incomingByVertex = GroupBy[directedEdges, Last -> First];
         outgoingByVertex = GroupBy[directedEdges, First -> Last];
         middleVertices = Intersection[Keys[incomingByVertex], Keys[outgoingByVertex]];
@@ -346,23 +315,33 @@ BuildAuxTriples[auxGraph_Graph] :=
         ]
     ];
 
+BuildAuxTriples[auxGraph_Graph] :=
+    Module[{edges},
+        edges = List @@@ EdgeList[auxGraph];
+        iBuildAuxTriples[Join[edges, Reverse[edges, {2}]]]
+    ];
+
 DeriveAuxPairs[topology_Association] :=
-    Module[{graph, halfPairs, inAuxEntryPairs, outAuxExitPairs, inAuxExitPairs,
-            outAuxEntryPairs, pairs},
-        graph = topology["Graph"];
-        halfPairs = List @@@ EdgeList[graph];
-        inAuxEntryPairs = List @@@ topology["AuxEntryEdges"];
-        outAuxExitPairs = List @@@ topology["AuxExitEdges"];
-        inAuxExitPairs = Reverse /@ outAuxExitPairs;
-        outAuxEntryPairs = Reverse /@ inAuxEntryPairs;
-        pairs = Join[halfPairs, Reverse /@ halfPairs];
-        Join[inAuxEntryPairs, outAuxEntryPairs, inAuxExitPairs, outAuxExitPairs, pairs]
+    Lookup[topology, "AuxPairs",
+        Module[{graph, halfPairs, inAuxEntryPairs, outAuxExitPairs, inAuxExitPairs,
+                outAuxEntryPairs, pairs},
+            graph = topology["Graph"];
+            halfPairs = List @@@ EdgeList[graph];
+            inAuxEntryPairs = List @@@ topology["AuxEntryEdges"];
+            outAuxExitPairs = List @@@ topology["AuxExitEdges"];
+            inAuxExitPairs = Reverse /@ outAuxExitPairs;
+            outAuxEntryPairs = Reverse /@ inAuxEntryPairs;
+            pairs = Join[halfPairs, Reverse /@ halfPairs];
+            Join[inAuxEntryPairs, outAuxEntryPairs, inAuxExitPairs, outAuxExitPairs, pairs]
+        ]
     ];
 
 BuildAuxiliaryTopology[model_Association] :=
     Module[{vertices, adjacency, adjacencyForGraph, entryFlows, exitCosts, graph, 
             entryVertices, exitVertices, auxEntryVertices, auxExitVertices,
-            entryEdges, exitEdges, auxiliaryGraph, auxTriples},
+            entryEdges, exitEdges, auxiliaryGraph, auxTriples,
+            halfPairs, inAuxEntryPairs, outAuxExitPairs, inAuxExitPairs,
+            outAuxEntryPairs, pairs, auxPairs},
         
         vertices = Lookup[model, "Vertices List"];
         adjacency = Lookup[model, "Adjacency Matrix"];
@@ -379,7 +358,7 @@ BuildAuxiliaryTopology[model_Association] :=
 
         adjacencyForGraph = Unitize[adjacency + Transpose[adjacency]];
         
-        graph = Quiet @ Check[
+        graph = Check[
             AdjacencyGraph[vertices, adjacencyForGraph, DirectedEdges -> False],
             $Failed
         ];
@@ -393,16 +372,18 @@ BuildAuxiliaryTopology[model_Association] :=
         
         entryEdges = MapThread[DirectedEdge, {auxEntryVertices, entryVertices}];
         exitEdges = MapThread[DirectedEdge, {exitVertices, auxExitVertices}];
-        auxiliaryGraph = EdgeAdd[graph, Join[entryEdges, exitEdges]];
-        auxTriples = BuildAuxTriples[auxiliaryGraph];
-
-        halfPairs = List @@@ EdgeList[graph];
-        pairs = Join[halfPairs, Reverse[halfPairs, {2}]];
         
+        halfPairs = List @@@ EdgeList[graph];
         inAuxEntryPairs = List @@@ entryEdges;
         outAuxExitPairs = List @@@ exitEdges;
-        inAuxExitPairs = Reverse /@ outAuxExitPairs;
-        outAuxEntryPairs = Reverse /@ inAuxEntryPairs;
+        inAuxExitPairs = Reverse[outAuxExitPairs, {2}];
+        outAuxEntryPairs = Reverse[inAuxEntryPairs, {2}];
+        pairs = Join[halfPairs, Reverse[halfPairs, {2}]];
+        
+        auxPairs = Join[inAuxEntryPairs, outAuxEntryPairs, inAuxExitPairs, outAuxExitPairs, pairs];
+        
+        auxiliaryGraph = EdgeAdd[graph, Join[entryEdges, exitEdges]];
+        auxTriples = iBuildAuxTriples[auxPairs];
 
         <|
             "Graph" -> graph,
@@ -418,7 +399,7 @@ BuildAuxiliaryTopology[model_Association] :=
             "InAuxExitPairs" -> inAuxExitPairs,
             "OutAuxEntryPairs" -> outAuxEntryPairs,
             "Pairs" -> pairs,
-            "AuxPairs" -> Join[inAuxEntryPairs, outAuxEntryPairs, inAuxExitPairs, outAuxExitPairs, pairs]
+            "AuxPairs" -> auxPairs
         |>
     ];
 
@@ -532,14 +513,20 @@ makeScenario[rawAssoc_Association] :=
         If[FailureQ[validated],
             validated,
             validatedAssoc = ScenarioData[validated];
-            model = ApplyScenarioDataToModel[
-                validatedAssoc["Model"],
-                Lookup[validatedAssoc, "Data", {}]
+            If[KeyExistsQ[validatedAssoc, "Data"],
+                Return[
+                    Failure["ScenarioValidation",
+                        <|"Message" -> "\"Data\" key is no longer supported. Provide numeric values directly in \"Model\".",
+                          "MissingKeys" -> {}|>
+                    ],
+                    Module
+                ]
             ];
+            model = validatedAssoc["Model"];
             If[!AssociationQ[model],
                 Return[
                     Failure["ScenarioValidation",
-                        <|"Message" -> "Model must remain an Association after Data substitution.",
+                        <|"Message" -> "Model must remain an Association.",
                           "MissingKeys" -> {}|>
                     ],
                     Module
@@ -557,7 +544,16 @@ makeScenario[rawAssoc_Association] :=
             If[!BoundaryValuesNumericQ[model],
                 Return[
                     Failure["ScenarioValidation",
-                        <|"Message" -> "Boundary values must be numeric after Data substitution.",
+                        <|"Message" -> "Boundary values must be numeric.",
+                          "MissingKeys" -> {}|>
+                    ],
+                    Module
+                ]
+            ];
+            If[!SwitchingCostsNumericQ[model],
+                Return[
+                    Failure["ScenarioValidation",
+                        <|"Message" -> "Switching cost values must be numeric.",
                           "MissingKeys" -> {}|>
                     ],
                     Module

--- a/MFGraphs/Tests/make-unknowns.mt
+++ b/MFGraphs/Tests/make-unknowns.mt
@@ -75,33 +75,30 @@ Test[
 ]
 
 Test[
-    Quiet[
-        Module[{data, gscenario, unk},
-            data = <|
-                "Vertices List" -> {1, 2, 3},
-                "Adjacency Matrix" -> {
-                    {0, 1, 0},
-                    {1, 0, 1},
-                    {0, 1, 0}
-                },
-                "Entrance Vertices and Flows" -> {{1, 10}},
-                "Exit Vertices and Terminal Costs" -> {{3, 0}},
-                "Switching Costs" -> {}
-            |>;
-            gscenario = Symbol["Global`scenario"];
-            unk = makeUnknowns[gscenario[<|
-                "Identity" -> <|"Name" -> "shadowed scenario"|>,
-                "Model" -> data
-            |>]];
-            unknownsQ[unk] &&
-            Length[UnknownsData[unk, "js"]] > 0 &&
-            Length[UnknownsData[unk, "jts"]] > 0 &&
-            Length[UnknownsData[unk, "us"]] > 0
-        ],
-        {Global`scenario::shdw}
+    Module[{data, customScenarioHead, unk},
+        data = <|
+            "Vertices List" -> {1, 2, 3},
+            "Adjacency Matrix" -> {
+                {0, 1, 0},
+                {1, 0, 1},
+                {0, 1, 0}
+            },
+            "Entrance Vertices and Flows" -> {{1, 10}},
+            "Exit Vertices and Terminal Costs" -> {{3, 0}},
+            "Switching Costs" -> {}
+        |>;
+        customScenarioHead = Symbol["TmpCtx`scenario"];
+        unk = makeUnknowns[customScenarioHead[<|
+            "Identity" -> <|"Name" -> "custom-context scenario"|>,
+            "Model" -> data
+        |>]];
+        unknownsQ[unk] &&
+        Length[UnknownsData[unk, "js"]] > 0 &&
+        Length[UnknownsData[unk, "jts"]] > 0 &&
+        Length[UnknownsData[unk, "us"]] > 0
     ],
     True,
-    TestID -> "makeUnknowns: accepts scenario head from shadowed context"
+    TestID -> "makeUnknowns: accepts scenario head from custom context"
 ]
 
 Test[

--- a/MFGraphs/Tests/make-unknowns.mt
+++ b/MFGraphs/Tests/make-unknowns.mt
@@ -84,15 +84,14 @@ Test[
                     {1, 0, 1},
                     {0, 1, 0}
                 },
-                "Entrance Vertices and Flows" -> {{1, inflowParam}},
-                "Exit Vertices and Terminal Costs" -> {{3, exitCostParam}},
+                "Entrance Vertices and Flows" -> {{1, 10}},
+                "Exit Vertices and Terminal Costs" -> {{3, 0}},
                 "Switching Costs" -> {}
             |>;
             gscenario = Symbol["Global`scenario"];
             unk = makeUnknowns[gscenario[<|
                 "Identity" -> <|"Name" -> "shadowed scenario"|>,
-                "Model" -> data,
-                "Data" -> {inflowParam -> 10, exitCostParam -> 0}
+                "Model" -> data
             |>]];
             unknownsQ[unk] &&
             Length[UnknownsData[unk, "js"]] > 0 &&

--- a/MFGraphs/Tests/scenario-kernel.mt
+++ b/MFGraphs/Tests/scenario-kernel.mt
@@ -287,61 +287,7 @@ Test[
     TestID -> "Scenario kernel: completeScenario callable directly on validated scenario"
 ]
 
-(* Test: makeScenario applies Data substitutions to boundary values and materializes numerics *)
-Test[
-    Module[{raw, s, model, entryVals, exitVals},
-        raw = <|
-            "Model" -> <|
-                "Vertices List" -> {1, 2},
-                "Adjacency Matrix" -> {{0, 1}, {0, 0}},
-                "Entrance Vertices and Flows" -> {{1, inflowParam}},
-                "Exit Vertices and Terminal Costs" -> {{2, exitCostParam}},
-                "Switching Costs" -> {}
-            |>,
-            "Data" -> {inflowParam -> 100, exitCostParam -> 0}
-        |>;
-        s = MFGraphs`makeScenario[raw];
-        model = MFGraphs`ScenarioData[s, "Model"];
-        entryVals = Last /@ model["Entrance Vertices and Flows"];
-        exitVals = Last /@ model["Exit Vertices and Terminal Costs"];
-        MFGraphs`scenarioQ[s] && AllTrue[entryVals, NumericQ] && AllTrue[exitVals, NumericQ]
-    ]
-    ,
-    True
-    ,
-    TestID -> "Scenario kernel: boundary values are numeric after makeScenario"
-]
-
-(* Test: makeScenario applies Data substitutions by symbol name across contexts *)
-Test[
-    Module[{raw, s, model, gIn, gOut, foreignIn, foreignOut},
-        gIn = Symbol["Global`inCtxParam"];
-        gOut = Symbol["Global`outCtxParam"];
-        foreignIn = Symbol["TmpCtx`inCtxParam"];
-        foreignOut = Symbol["TmpCtx`outCtxParam"];
-        raw = <|
-            "Model" -> <|
-                "Vertices List" -> {1, 2},
-                "Adjacency Matrix" -> {{0, 1}, {0, 0}},
-                "Entrance Vertices and Flows" -> {{1, foreignIn}},
-                "Exit Vertices and Terminal Costs" -> {{2, foreignOut}},
-                "Switching Costs" -> {}
-            |>,
-            "Data" -> {gIn -> 100, gOut -> 0}
-        |>;
-        s = MFGraphs`makeScenario[raw];
-        model = MFGraphs`ScenarioData[s, "Model"];
-        MFGraphs`scenarioQ[s] &&
-        Last /@ model["Entrance Vertices and Flows"] === {100} &&
-        Last /@ model["Exit Vertices and Terminal Costs"] === {0}
-    ]
-    ,
-    True
-    ,
-    TestID -> "Scenario kernel: cross-context Data symbol substitution is supported"
-]
-
-(* Test: makeScenario fails when boundary values remain symbolic after Data substitution *)
+(* Test: makeScenario rejects legacy Data substitutions *)
 Test[
     Module[{raw, result},
         raw = <|
@@ -352,7 +298,7 @@ Test[
                 "Exit Vertices and Terminal Costs" -> {{2, exitCostParam}},
                 "Switching Costs" -> {}
             |>,
-            "Data" -> {inflowParam -> 100}
+            "Data" -> {inflowParam -> 100, exitCostParam -> 0}
         |>;
         result = MFGraphs`makeScenario[raw];
         FailureQ[result] && result["Tag"] === "ScenarioValidation"
@@ -360,7 +306,49 @@ Test[
     ,
     True
     ,
-    TestID -> "Scenario kernel: non-numeric boundary values are rejected"
+    TestID -> "Scenario kernel: legacy Data substitutions are rejected"
+]
+
+(* Test: makeScenario fails when boundary values are symbolic *)
+Test[
+    Module[{raw, result},
+        raw = <|
+            "Model" -> <|
+                "Vertices List" -> {1, 2},
+                "Adjacency Matrix" -> {{0, 1}, {0, 0}},
+                "Entrance Vertices and Flows" -> {{1, inflowParam}},
+                "Exit Vertices and Terminal Costs" -> {{2, exitCostParam}},
+                "Switching Costs" -> {}
+            |>
+        |>;
+        result = MFGraphs`makeScenario[raw];
+        FailureQ[result] && result["Tag"] === "ScenarioValidation"
+    ]
+    ,
+    True
+    ,
+    TestID -> "Scenario kernel: symbolic boundary values are rejected"
+]
+
+(* Test: makeScenario fails when switching cost values are symbolic *)
+Test[
+    Module[{raw, result},
+        raw = <|
+            "Model" -> <|
+                "Vertices List" -> {1, 2},
+                "Adjacency Matrix" -> {{0, 1}, {0, 0}},
+                "Entrance Vertices and Flows" -> {{1, 100}},
+                "Exit Vertices and Terminal Costs" -> {{2, 0}},
+                "Switching Costs" -> {{1, 1, 2, c12}}
+            |>
+        |>;
+        result = MFGraphs`makeScenario[raw];
+        FailureQ[result] && result["Tag"] === "ScenarioValidation"
+    ]
+    ,
+    True
+    ,
+    TestID -> "Scenario kernel: non-numeric switching costs are rejected"
 ]
 
 (* Test: Graph-only model derives Vertices List and Adjacency Matrix *)

--- a/MFGraphs/Tests/scenario-kernel.mt
+++ b/MFGraphs/Tests/scenario-kernel.mt
@@ -18,7 +18,7 @@ Test[
 (* Test: makeScenario returns a typed scenario for valid input *)
 Test[
     Module[{data, s},
-        data = Quiet[GetExampleData[12], {GetExampleData::deprecated}] /. {I1 -> 100, U1 -> 0};
+        data = GetExampleDataRaw[12] /. {I1 -> 100, U1 -> 0};
         s = makeScenario[<|"Model" -> data|>];
         scenarioQ[s]
     ]
@@ -45,7 +45,7 @@ Test[
 (* Test: Hamiltonian block defaults are filled *)
 Test[
     Module[{data, s, h},
-        data = Quiet[GetExampleData[12], {GetExampleData::deprecated}] /. {I1 -> 100, U1 -> 0};
+        data = GetExampleDataRaw[12] /. {I1 -> 100, U1 -> 0};
         s = makeScenario[<|"Model" -> data|>];
         h = ScenarioData[s, "Hamiltonian"];
         AssociationQ[h] &&
@@ -504,14 +504,11 @@ Test[
 (* Test: ScenarioByKey reports unknown key as structured Failure *)
 Test[
     Module[{result},
-        result = Quiet[
-            ScenarioByKey["does-not-exist", <|
-                "Entry flows" -> <|1 -> 1|>,
-                "Exit costs" -> <|1 -> 0|>,
-                "Switching Costs" -> <||>
-            |>],
-            {GetExampleData::badfields}
-        ];
+        result = ScenarioByKey["does-not-exist", <|
+            "Entry flows" -> <|1 -> 1|>,
+            "Exit costs" -> <|1 -> 0|>,
+            "Switching Costs" -> <||>
+        |>];
         FailureQ[result] && result["Tag"] === "ScenarioByKey"
     ]
     ,


### PR DESCRIPTION
This PR further optimizes the scenario and topology construction pipeline by removing redundant graph extractions and list manipulations.

### Key Optimizations:
- **Fast-path Adjacency:** `BuildAdjacencyFromGraph` now skips expensive index mapping if the vertex order matches the graph default.
- **Deduplicated Triples:** Introduced `iBuildAuxTriples` helper to share pre-calculated directed edge sets (AuxPairs) between topology and triple generation, avoiding redundant graph traversals.
- **Vectorized Reversals:** Replaced manual mapping with vectorized `Reverse[..., {2}]` for boundary edge sets.
- **Strict Validation:** `makeScenario` now explicitly rejects legacy symbolic 'Data' substitutions, enforcing numeric boundary and switching costs for downstream safety.
- **Utility Refinement:** `DeriveAuxPairs` now utilizes cached AuxPairs from the topology association.

These changes significantly reduce memory churn and setup latency for large-scale Mean Field Game networks.