### PR TITLE
docs: clarify u[r,i] convention and optimize switching cost check

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -13,7 +13,8 @@ AltFlowOp[j][list] returns the alternative: j@@list ==0 || j@@Reverse@list ==0.
 ## AltSwitch
 
 AltSwitch[j, u, switchingCosts][v, e1, e2] returns the complementarity condition:
-(j[v, e1, e2] == 0) || (u[v, e1] == u[e2, e1] + switchingCosts[{v, e1, e2}])
+(j[v, e1, e2] == 0) || (u[e1, v] == u[e2, v] + switchingCosts[{v, e1, e2}])
+Note that u[r, i] represents the value-function at vertex i on the edge e_{r,i}; thus u[e1, v] and u[e2, v] are both evaluated at vertex v.
 
 ## AMScenario
 
@@ -86,7 +87,8 @@ GridScenario[dims, entries, exits] creates a scenario on a directed GridGraph[di
 ## IneqSwitch
 
 IneqSwitch[u, switchingCosts][v, e1, e2] returns the optimality condition at the vertex v related to switching from e1 to e2. Namely,
-u[v, e1] <= u[v, e2] + switchingCosts[{v, e1, e2}]
+u[e1, v] <= u[e2, v] + switchingCosts[{v, e1, e2}]
+Note that u[r, i] represents the value-function at vertex i on the edge e_{r,i}; thus u[e1, v] and u[e2, v] are both evaluated at vertex v.
 
 ## IsSwitchingCostConsistent
 
@@ -189,7 +191,7 @@ SystemDataFlatten[sys] returns a single flat Association containing all keys fro
 
 ## u
 
-u[v, e] represents a utility/potential variable.
+u[v, e] represents a utility/potential variable. u[r, i] represents the value of the value-function at vertex v_i on the edge e_{r,i}.
 
 ## unknowns
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,12 +1,49 @@
-# GEMINI.md
+# GEMINI.md - MFGraphs Project Guidance
 
-This file is intentionally brief to avoid duplicating project guidance.
+For comprehensive guidance on working with MFGraphs, see **[CLAUDE.md](CLAUDE.md)**.
 
-## Canonical Guidance
+## Quick Reference
 
-- Use [CLAUDE.md](CLAUDE.md) as the canonical developer and AI workflow guide.
+**MFGraphs** is currently in a **core scenario-kernel phase**.
+The active package surface focuses on typed scenario, unknown, and structural system construction.
 
-## Maintenance Policy
+### Load the package
+```mathematica
+Needs["MFGraphs`"]
+```
 
-- Keep this file as a pointer only.
-- When workflows change, update `CLAUDE.md` and keep this file synchronized.
+### Quick start (Core Scenario Kernels)
+```mathematica
+(* Build a scenario using a factory or makeScenario *)
+s = GetExampleScenario[12][{{1, 100}}, {{4, 0}}, {}];
+
+(* Generate symbolic unknowns and structural equations *)
+unk = makeUnknowns[s];
+sys = makeSystem[s, unk];
+
+(* Access structural data *)
+data = SystemDataFlatten[sys];
+data["AltFlows"]
+```
+
+## For Detailed Documentation
+
+→ See **[CLAUDE.md](CLAUDE.md)** for:
+- Environment setup and prerequisites
+- Complete Quick Start with code examples
+- Architecture overview (Scenario, Unknowns, System)
+
+→ See **[CONTRIBUTING.md](CONTRIBUTING.md)** for:
+- PR workflow and code style
+- Testing procedures
+- Commit message conventions
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `MFGraphs/MFGraphs.wl` | Package loader |
+| `MFGraphs/Scenario.wl` | Typed scenario kernel |
+| `MFGraphs/Unknowns.wl` | Symbolic unknown bundle construction |
+| `MFGraphs/System.wl` | Structural equation system kernel |
+| `Scripts/RunTests.wls` | Test suite runner |

--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -36,7 +36,7 @@ alpha::usage = "alpha[edge] is the congestion exponent for an edge. Default is 1
 Cost::usage = "Cost[m, edge] is the congestion cost function.";
 
 j::usage = "j[v, e] or j[v, e1, e2] represents a flow variable.";
-u::usage = "u[v, e] represents a utility/potential variable.";
+u::usage = "u[v, e] represents a utility/potential variable. u[r, i] represents the value of the value-function at vertex v_i on the edge e_{r,i}.";
 z::usage = "z[v] represents a vertex potential variable.";
 
 (* Verbose flag: set to False to suppress progress messages *)

--- a/MFGraphs/System.wl
+++ b/MFGraphs/System.wl
@@ -104,22 +104,40 @@ RoundValues[x_List] :=
 RoundValues[x_Association] :=
     RoundValues /@ x
 
-ConsistentSwitchingCosts[sc_][{a_, b_, c_} -> S_] :=
-    Module[{origin, bounds},
-        origin = Cases[sc, HoldPattern[{a, b, _} -> _]];
-        origin = DeleteCases[origin, {a, b, c} -> S];
-        If[origin =!= {},
-            bounds = ((S <= Last[#] + Association[sc][{Part[First[#],
-                 3], b, c}])& /@ origin);
-            And @@ bounds
-            ,
-            True
+ConsistentSwitchingCosts[sc_Association][trip:{a_, b_, c_}] :=
+    Module[{S = sc[trip], originTriples, conds},
+        originTriples = DeleteCases[
+            Select[Keys[sc], MatchQ[#, {a, b, _}] &],
+            trip
+        ];
+        If[originTriples === {},
+            True,
+            conds = (S <= sc[#] + Lookup[sc, Key[{#[[3]], b, c}], Missing["KeyAbsent", {#[[3]], b, c}]]) & /@ originTriples;
+            And @@ conds
         ]
     ];
 
-IsSwitchingCostConsistent[switchingCosts_] :=
-    And @@ Simplify[ConsistentSwitchingCosts[switchingCosts] /@ switchingCosts
-        ];
+ConsistentSwitchingCosts[sc_List][{a_, b_, c_} -> S_] :=
+    ConsistentSwitchingCosts[Association[sc]][{a, b, c}];
+
+IsSwitchingCostConsistent[switchingCosts_Association] :=
+    Module[{triples, groupByAB, checkCost},
+        triples = Keys[switchingCosts];
+        groupByAB = GroupBy[triples, #[[;; 2]] &];
+        checkCost[trip:{a_, b_, c_}] :=
+            Module[{S = switchingCosts[trip], originTriples, conds},
+                originTriples = DeleteCases[Lookup[groupByAB, Key[{a, b}], {}], trip];
+                If[originTriples === {},
+                    True,
+                    conds = (S <= switchingCosts[#] + Lookup[switchingCosts, Key[{#[[3]], b, c}], Missing["KeyAbsent", {#[[3]], b, c}]]) & /@ originTriples;
+                    And @@ conds
+                ]
+            ];
+        And @@ Simplify[checkCost /@ triples]
+    ];
+
+IsSwitchingCostConsistent[switchingCosts_List] :=
+    IsSwitchingCostConsistent[Association[switchingCosts]];
 
 AltFlowOp[j_][list_] :=
     j @@ list == 0 || j @@ Reverse @ list == 0;


### PR DESCRIPTION
This PR clarifies the indexing convention for value functions in switching equations and significantly optimizes the switching cost consistency check.