### PR TITLE
Graphics: Augmented Infrastructure Plot (Paper Scheme)

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -6,109 +6,151 @@ This document is automatically generated from the Wolfram Language package usage
 
 alpha[edge] is the congestion exponent for an edge. Default is 1.
 
-## AltFlowOp
-
-AltFlowOp[j][list] returns the alternative: j@@list ==0 || j@@Reverse@list ==0.
-
-## AltSwitch
-
-AltSwitch[j, u, switchingCosts][v, e1, e2] returns the complementarity condition:
-(j[v, e1, e2] == 0) || (u[e1, v] == u[e2, v] + switchingCosts[{v, e1, e2}])
-Note that u[r, i] represents the value-function at vertex i on the edge e_{r,i}; thus u[e1, v] and u[e2, v] are both evaluated at vertex v.
-
-## AMScenario
-
-AMScenario[vl, am, entries, exits] creates a scenario from an explicit vertices list vl and adjacency matrix am. Optional: sc, alpha, V, g.
-
-## BuildAuxiliaryTopology
-
-BuildAuxiliaryTopology[model] returns an association with the auxiliary graph and metadata derived from the raw model.
-
-## BuildAuxTriples
-
-BuildAuxTriples[auxGraph] returns the list of all possible {v_in, v_mid, v_out} transitions (triples) in the graph.
-
-## completeScenario
-
-completeScenario[s] fills in derived fields and supplies default Benchmark values ("Tier" -> "core", "Timeout" -> 300) when missing. Returns a new scenario object.
-
-## ConsistentSwitchingCosts
-
-ConsistentSwitchingCosts[switchingcosts][{a,b,c}->S]
-returns True if S, the cost of switching from the edge ab to cb, is smaller than any other combination,
-such as, ab to bd and then from db to bc.
-Returns the condition for this switching cost to satisfy the triangle inequality when S, and the other
-switching costs too, does not have a numerical value.
-
 ## Cost
 
 Cost[m, edge] is the congestion cost function.
 
-## CycleScenario
+## ensureParallelKernels
 
-CycleScenario[n, entries, exits] creates a scenario on a directed n-cycle (1->2->...->n->1), vertices 1..n. Optional: sc, alpha, V, g.
-
-## DeriveAuxPairs
-
-DeriveAuxPairs[topology] returns the list of all directed edge pairs {u, v} in the auxiliary graph (including entry/exit and reversed graph edges).
-
-## EnsureParallelKernels
-
-EnsureParallelKernels[] launches parallel subkernels if none are running.
-
-## FlowGathering
-
-FlowGathering[auxTriples_List][x_] returns the triples that end with x.
-
-## FlowSplitting
-
-FlowSplitting[AT][UndirectedEdge[a, b]] returns the splitting that start with {a,b}.
-
-## GetExampleScenario
-
-GetExampleScenario[n] returns a 6-arg factory Function[{entries,exits,sc,alpha,V,g}, scenario[...]] for built-in example n. Topology is baked in; all parameters are caller-supplied. GetExampleScenario[n, entries, exits] calls the factory using the canonical switching costs for that case (sc=Automatic resolves via $CaseDefaultSC, defaulting to {} if none defined) and standard Hamiltonian defaults (alpha=1, V=0, g=Function[z,-1/z]). Additional optional arguments override each default in order: sc, alpha, V, g. Pass sc={} explicitly to force no switching costs. entries={{vertex,flow},...}, exits={{vertex,cost},...}, sc={{i,k,j,cost},...}. Returns $Failed for unknown keys.
-
-## GetKirchhoffLinearSystem
-
-GetKirchhoffLinearSystem[sys] returns the entry current vector, Kirchhoff matrix, and the variables in the order corresponding to the Kirchhoff matrix.
-
-## GetKirchhoffMatrix
-
-GetKirchhoffMatrix[sys] returns the entry current vector, Kirchhoff matrix, (critical congestion) cost function placeholder, and the variables in the order corresponding to the Kirchhoff matrix. The third slot is retained for backward compatibility.
-
-## GraphScenario
-
-GraphScenario[graph, entries, exits] creates a scenario from any WL directed Graph object. Optional: sc, alpha, V, g.
-
-## GridScenario
-
-GridScenario[dims, entries, exits] creates a scenario on a directed GridGraph[dims]. {n} gives a chain with vertices 1..n; {r,c} gives an r×c grid with vertices 1..r*c (row-major). Optional: sc (switching costs, default {}), alpha, V, g (Hamiltonian defaults from $DefaultHamiltonian).
-
-## IneqSwitch
-
-IneqSwitch[u, switchingCosts][v, e1, e2] returns the optimality condition at the vertex v related to switching from e1 to e2. Namely,
-u[e1, v] <= u[e2, v] + switchingCosts[{v, e1, e2}]
-Note that u[r, i] represents the value-function at vertex i on the edge e_{r,i}; thus u[e1, v] and u[e2, v] are both evaluated at vertex v.
-
-## IsSwitchingCostConsistent
-
-IsSwitchingCostConsistent[List of switching costs] is True if all switching costs satisfy the triangle inequality. If some switching costs are symbolic, then it returns the consistency conditions.
+ensureParallelKernels[] launches parallel subkernels if none are running.
 
 ## j
 
 j[v, e] or j[v, e1, e2] represents a flow variable.
 
+## mfgPrint
+
+mfgPrint[args___] prints args only when $MFGraphsVerbose is True.
+
+## mfgPrintTemporary
+
+mfgPrintTemporary[args___] prints a temporary message only when $MFGraphsVerbose is True.
+
+## u
+
+u[v, e] represents a value-function variable. u[r, i] is the value at vertex v_i on edge e_{r,i}.
+
+## z
+
+z[v] represents a vertex potential variable.
+
+## buildAuxiliaryTopology
+
+buildAuxiliaryTopology[model] returns an association with the auxiliary graph and metadata derived from the raw model.
+
+## buildAuxTriples
+
+buildAuxTriples[auxGraph] returns the list of all possible {v_in, v_mid, v_out} transitions (triples) in the graph.
+
+## completeScenario
+
+completeScenario[s] fills in derived fields and supplies default Benchmark values ("Tier" -> "core", "Timeout" -> 300) when missing. If cached topology is absent, it warns and rebuilds topology from the Model before completing. Returns a new scenario object.
+
+## deriveAuxPairs
+
+deriveAuxPairs[topology] returns the list of all directed edge pairs {u, v} in the auxiliary graph (including entry/exit and reversed graph edges).
+
 ## makeScenario
 
-makeScenario[assoc] constructs a typed scenario from a raw association. The input must contain a "Model" key whose value is a network topology association accepted by the core scenario/system kernels (required keys: "Vertices List", "Adjacency Matrix", "Entrance Vertices and Flows", "Exit Vertices and Terminal Costs", "Switching Costs"). If "Model" contains a Wolfram Graph under key "Graph", missing "Vertices List" and/or "Adjacency Matrix" are derived automatically. Optional keys: "Hamiltonian" (<|"Alpha" -> a, "V" -> v, "G" -> g, "EdgeAlpha" -> <|{u,v} -> a_uv, ...|>, "EdgeV" -> <|{u,v} -> v_uv, ...|>, "EdgeG" -> <|{u,v} -> g_uv, ...|>|>), "Identity" (name, version), "Benchmark" (tier, timeout), "Visualization", "Inheritance". Default Hamiltonian is Alpha=1 and V=0 on all edges, with G[z]=-1/z (overridable globally and per edge). Boundary and switching-cost values must be numeric. Returns a scenario[...] object on success or Failure[...] on error.
+makeScenario[assoc] constructs a typed scenario from a raw association. The input must contain a "Model" key whose value is a network topology association (required keys: "Vertices", "Adjacency", "Entries", "Exits", "Switching"). If "Model" contains a Wolfram Graph under key "Graph", missing "Vertices" and/or "Adjacency" are derived automatically. Optional keys: "Hamiltonian" (<|"Alpha" -> a, "V" -> v, "G" -> g, "EdgeAlpha" -> <|{u,v} -> a_uv, ...|>, "EdgeV" -> <|{u,v} -> v_uv, ...|>, "EdgeG" -> <|{u,v} -> g_uv, ...|>|>), "Identity" (name, version), "Benchmark" (tier, timeout), "Visualization", "Inheritance". Default Hamiltonian is Alpha=1 and V=0 on all edges, with G[z]=-1/z (overridable globally and per edge). Boundary values must be numeric; switching-cost values must be numeric or Infinity. Returns a scenario[...] object on success or Failure[...] on error.
+
+## scenario
+
+scenario[assoc] is the typed head for a MFGraphs scenario object. Use makeScenario to construct one; use scenarioData to access keys.
+
+## scenarioData
+
+scenarioData[s, key] returns the value associated with key in the scenario s, or Missing["KeyAbsent", key] if absent. scenarioData[s] returns the underlying Association.
+
+## scenarioQ
+
+scenarioQ[x] returns True if x is a typed scenario[assoc_Association] object, False otherwise.
+
+## validateScenario
+
+validateScenario[s] checks that the scenario s has all required Model keys and that the Model value is an Association. Returns s unchanged on success, or Failure["ScenarioValidation", <|"Message" -> msg, "MissingKeys" -> {...}|>] on failure.
+
+## amScenario
+
+amScenario[vl, am, entries, exits] creates a scenario from an explicit vertices list vl and adjacency matrix am. Vertex labels in vl must be positive integers; non-integer labels are not accepted. Optional: sc, alpha, V, g.
+
+## cycleScenario
+
+cycleScenario[n, entries, exits] creates a scenario on a directed n-cycle (1->2->...->n->1), vertices 1..n. Optional: sc, alpha, V, g.
+
+## getExampleScenario
+
+getExampleScenario[n] returns a 6-arg factory Function[{entries,exits,sc,alpha,V,g}, scenario[...]] for built-in example n. Topology is baked in; all parameters are caller-supplied. getExampleScenario[n, entries, exits] calls the factory using the canonical switching costs for that case (sc=Automatic resolves via $CaseDefaultSC, defaulting to {} if none defined) and standard Hamiltonian defaults (alpha=1, V=0, g=Function[z,-1/z]). Additional optional arguments override each default in order: sc, alpha, V, g. Pass sc={} explicitly to force no switching costs. entries={{vertex,flow},...}, exits={{vertex,cost},...}, sc={{i,k,j,cost},...}. Returns $Failed for unknown keys.
+
+## graphScenario
+
+graphScenario[graph, entries, exits] creates a scenario from any WL directed Graph object. Vertex labels must be positive integers; non-integer labels are not accepted (makeScenario returns Failure). Optional: sc, alpha, V, g.
+
+## gridScenario
+
+gridScenario[dims, entries, exits] creates a scenario on a directed GridGraph[dims]. {n} gives a chain with vertices 1..n; {r,c} gives an r×c grid with vertices 1..r*c (row-major). Optional: sc (switching costs, default {}), alpha, V, g (Hamiltonian defaults from $DefaultHamiltonian).
+
+## makeUnknowns
+
+makeUnknowns[s] returns unknowns[<|"Js" -> ..., "Jts" -> ..., "Us" -> ...|>] for scenario s. "Js" are flow unknowns j[v,e], "Jts" are transition-flow unknowns j[v,e1,e2], and "Us" are value-function unknowns u[v,e].
+
+## unknowns
+
+unknowns[assoc] is the typed head for MFGraphs unknown-variable bundles.
+
+## unknownsData
+
+unknownsData[u, key] returns key from unknowns object u; unknownsData[u] returns the underlying association.
+
+## unknownsQ
+
+unknownsQ[x] returns True iff x is an unknowns[assoc_Association] object.
+
+## altFlowOp
+
+altFlowOp[j][list] returns the alternative: j@@list ==0 || j@@Reverse@list ==0.
+
+## altSwitch
+
+altSwitch[j, u, switchingCosts][v, e1, e2] returns the complementarity condition:
+(j[v, e1, e2] == 0) || (u[v, e1] == u[e2, e1] + switchingCosts[{v, e1, e2}])
+
+## consistentSwitchingCosts
+
+consistentSwitchingCosts[switchingcosts][{a,b,c}->S]
+returns True if S, the cost of switching from the edge ab to cb, is smaller than any other combination,
+such as, ab to bd and then from db to bc.
+Returns the condition for this switching cost to satisfy the triangle inequality when S, and the other
+switching costs too, does not have a numerical value.
+
+## flowGathering
+
+flowGathering[auxTriples_List][x_] returns the triples that end with x.
+
+## flowSplitting
+
+flowSplitting[AT][UndirectedEdge[a, b]] returns the splitting that start with {a,b}.
+
+## getKirchhoffLinearSystem
+
+getKirchhoffLinearSystem[sys] returns the entry current vector, Kirchhoff matrix, and the variables in the order corresponding to the Kirchhoff matrix.
+
+## getKirchhoffMatrix
+
+getKirchhoffMatrix[sys] returns the entry current vector, Kirchhoff matrix, (critical congestion) cost function placeholder, and the variables in the order corresponding to the Kirchhoff matrix. The third slot is retained for backward compatibility.
+
+## ineqSwitch
+
+ineqSwitch[u, switchingCosts][v, e1, e2] returns the optimality condition at the vertex v related to switching from e1 to e2. Namely,
+u[v, e1] <= u[e2, e1] + switchingCosts[{v, e1, e2}]
+
+## isSwitchingCostConsistent
+
+isSwitchingCostConsistent[List of switching costs] is True if all switching costs satisfy the triangle inequality. If some switching costs are symbolic, then it returns the consistency conditions.
 
 ## makeSystem
 
 makeSystem[s_scenario, unk_unknowns] constructs an mfgSystem by building the structural equations (SignedFlows, Balance equations, HJ conditions, etc.) from the provided scenario and symbolic unknowns. makeSystem[s_scenario] automatically derives unknowns using makeUnknowns[s].
-
-## makeUnknowns
-
-makeUnknowns[s] returns unknowns[<|"js" -> ..., "jts" -> ..., "us" -> ...|>] for scenario s. "js" are flow unknowns j[v,e], "jts" are transition-flow unknowns j[v,e1,e2], and "us" are value-function unknowns u[v,e].
 
 ## mfgBoundaryData
 
@@ -142,81 +184,38 @@ mfgHamiltonianData[assoc] is a typed record for Hamiltonian residuals and genera
 
 mfgHamiltonianDataQ[x] returns True if x is a typed mfgHamiltonianData object.
 
-## MFGParallelMap
-
-MFGParallelMap[f, list] applies f to each element of list, using ParallelMap
-when Length[list] >= $MFGraphsParallelThreshold (and kernels are already running)
-or Length[list] >= $MFGraphsParallelLaunchThreshold (when kernels must be launched).
-This avoids paying ~3s kernel launch overhead for small workloads.
-
-## MFGPrint
-
-MFGPrint[args___] prints args only when $MFGraphsVerbose is True.
-
-## MFGPrintTemporary
-
-MFGPrintTemporary[args___] prints a temporary message only when $MFGraphsVerbose is True.
-
 ## mfgSystem
 
-mfgSystem[assoc] is the typed head for an MFG structural equation system. Use makeSystem to construct one; use SystemData to access keys.
+mfgSystem[assoc] is the typed head for an MFG structural equation system. Use makeSystem to construct one; use systemData to access keys.
 
 ## mfgSystemQ
 
 mfgSystemQ[x] returns True if x is a typed mfgSystem[assoc_Association] object, False otherwise.
 
-## RoundValues
+## roundValues
 
-RoundValues[x] rounds numerical values in x to a standard precision (10^-10).
+roundValues[x] rounds numerical values in x to a standard precision (10^-10).
 
-## scenario
+## systemData
 
-scenario[assoc] is the typed head for a MFGraphs scenario object. Use makeScenario to construct one; use ScenarioData to access keys.
+systemData[sys, key] returns the value associated with key in the system sys, or Missing["KeyAbsent", key] if absent. systemData[sys] returns the underlying Association.
 
-## ScenarioData
+## systemDataFlatten
 
-ScenarioData[s, key] returns the value associated with key in the scenario s, or Missing["KeyAbsent", key] if absent. ScenarioData[s] returns the underlying Association.
+systemDataFlatten[sys] returns a single flat Association containing all keys from all nested typed sub-records within the system. Useful for backward compatibility with legacy solvers.
 
-## scenarioQ
+## isValidSystemSolution
 
-scenarioQ[x] returns True if x is a typed scenario[assoc_Association] object, False otherwise.
+isValidSystemSolution[sys, sol] checks whether sol (the output of reduceSystem[sys]) satisfies the constraint blocks of sys. Returns True or False. With option "ReturnReport" -> True, returns a detailed association with per-block results. Tolerance for numeric checks is set via "Tolerance" (default 10^-6). For underdetermined solutions the partial rules are checked; blocks that remain symbolic after substitution are reported as Indeterminate, not False.
 
-## SystemData
+## reduceSystem
 
-SystemData[sys, key] returns the value associated with key in the system sys, or Missing["KeyAbsent", key] if absent. SystemData[sys] returns the underlying Association.
+reduceSystem[sys] reduces the structural equations, flow balance, non-negativity constraints, and complementarity conditions of the mfgSystem sys using Reduce over the Reals. Includes AltOptCond (switching-cost optimality complementarity) and IneqSwitchingByVertex (switching-cost optimality inequalities). Fails for non-critical congestion systems where Alpha != 1 on any edge. Returns a list of rules when the system is fully determined, or <|"Rules" -> rules, "Equations" -> residual|> when underdetermined.
 
-## SystemDataFlatten
+## mfgSolutionPlot
 
-SystemDataFlatten[sys] returns a single flat Association containing all keys from all nested typed sub-records within the system. Useful for backward compatibility with legacy solvers.
+mfgSolutionPlot[s, sys, sol] plots a combined solution graph with real and auxiliary edges. Edge labels include both j and u values, and real-edge directions follow solved net flow orientation. An optional fourth argument sets the title.
 
-## u
+## scenarioTopologyPlot
 
-u[v, e] represents a utility/potential variable. u[r, i] represents the value of the value-function at vertex v_i on the edge e_{r,i}.
-
-## unknowns
-
-unknowns[assoc] is the typed head for MFGraphs unknown-variable bundles.
-
-## UnknownsData
-
-UnknownsData[u, key] returns key from unknowns object u; UnknownsData[u] returns the underlying association.
-
-## unknownsQ
-
-unknownsQ[x] returns True iff x is an unknowns[assoc_Association] object.
-
-## validateScenario
-
-validateScenario[s] checks that the scenario s has all required Model keys and that the Model value is an Association. Returns s unchanged on success, or Failure["ScenarioValidation", <|"Message" -> msg, "MissingKeys" -> {...}|>] on failure.
-
-## z
-
-z[v] represents a vertex potential variable.
-
-## $MFGraphsParallelReady
-
-False is the symbol for the Boolean value false. 
-
-## $MFGraphsVerbose
-
-False is the symbol for the Boolean value false. 
+scenarioTopologyPlot[s, sys] plots the scenario topology using vertex coloring for entry, exit, and internal vertices. An optional third argument sets the title.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ The graph is always undirected. A non-symmetric AM is symmetrized (`Unitize[AM +
 
 ### Switching costs
 
-Switching costs may be supplied as a List of 4-tuples or an Association with 3-tuple keys. `completeScenario` normalizes all representations and fills every missing triple with cost `0`. A triangle-inequality check runs at validation time; violations emit a message but do **not** abort scenario construction.
+Switching costs may be supplied as a List of 4-tuples or an Association with 3-tuple keys. Values may be numeric or `Infinity` for blocked transitions. `completeScenario` normalizes all representations and fills every missing triple with cost `0`; if called without cached topology, it warns and rebuilds topology from the model before completing.
 
 ### Examples registry
 
@@ -110,11 +110,18 @@ Switching costs may be supplied as a List of 4-tuples or an Association with 3-t
 - **System Records**: `mfgBoundaryData`, `mfgFlowData`, `mfgComplementarityData`, `mfgHamiltonianData`
 - **Linear Helpers**: `getKirchhoffLinearSystem`, `getKirchhoffMatrix`
 
-### Solver (`solversTools``)
-- `reduceSystem` — naive `Reduce`-based solver (no switching costs)
+### Solver (`solversTools`)
+- `reduceSystem` — naive `Reduce`-based solver for critical congestion (`Alpha == 1`) systems
 - `isValidSystemSolution` — solution validator
 
+### Graphics (`graphics`)
+- `scenarioTopologyPlot` — entry/exit/internal vertex coloring
+- `mfgSolutionPlot` — network-centric plot (j and u labels)
+- `mfgTransitionPlot` — transition graph (nodes = edges, edges = j[a,b,c])
+- `mfgAugmentedPlot` — paper infrastructure graph (nodes = (e,v) pairs)
+
 ### Runtime flags
+
 - `$MFGraphsVerbose` — set `True` to enable progress/timing prints (default `False`)
 - `$MFGraphsParallelThreshold` — minimum list length for `ParallelMap`/`ParallelTable` (default `6`; set `Infinity` to disable)
 
@@ -130,7 +137,7 @@ The following are currently not loaded from `MFGraphs.wl`:
 - solver-phase backend helpers (archived in `MFGraphs/archive/SolverBackendHelpers.wl`)
 
 **V, G, EdgeV, EdgeG Hamiltonian parameters** are validated and stored in the scenario
-schema but are **not applied** in `BuildHamiltonianData` — only `Alpha`/`EdgeAlpha` are
+schema but are **not applied** in `buildHamiltonianData` — only `Alpha`/`EdgeAlpha` are
 used in system construction. Implementing V and G requires extending the HJ-equation
 builder. Treat these fields as schema-only for now.
 

--- a/MFGraphs/Getting started.wl
+++ b/MFGraphs/Getting started.wl
@@ -1,25 +1,31 @@
 (* ::Package:: *)
 
 (* Notebook-friendly MFGraphs workbook covering the typed scenario kernels
-   and the reduceSystem solver. *)
+   and the solversTools solver. *)
 
 (* Evaluate cells one at a time or section by section \[LongDash] do not evaluate the entire file at once. *)
 
-(* This file lives alongside MFGraphs.wl in the same directory. *)
-mfgDir = If[$InputFileName === "", NotebookDirectory[], DirectoryName[$InputFileName]];
-
 (* Force clean reload \[LongDash] safe to re-evaluate without restarting the kernel. *)
 Quiet[
-    Unprotect /@ Names["MFGraphs`*"];
-    Remove /@ Names["MFGraphs`*"];
-    Unprotect[$Packages];
-    $Packages = DeleteCases[$Packages, "MFGraphs`"];
-    Protect[$Packages]
+    (* Clear notebook variables to avoid shadowing/collisions *)
+    ClearAll["Global`*"];
+    Remove["MFGraphs`*", "primitives`*", "scenarioTools`*", "examples`*", "unknownsTools`*", "systemTools`*", "solversTools`*", "graphics`*"];
+    $Packages = DeleteCases[$Packages, Alternatives @@ {"MFGraphs`", "primitives`", "scenarioTools`", "examples`", "unknownsTools`", "systemTools`", "solversTools`", "graphics`"}];
 ];
+
+(* This file lives alongside MFGraphs.wl in the same directory. *)
+mfgDir = If[$InputFileName === "", 
+    NotebookDirectory[], 
+    DirectoryName[$InputFileName]
+];
+
+(* Robustness: ensure mfgDir is a string for ParentDirectory *)
+If[!StringQ[mfgDir] || mfgDir === "", 
+    mfgDir = ExpandFileName["."];
+];
+
 PrependTo[$Path, ParentDirectory[mfgDir]];
-Get[FileNameJoin[{mfgDir, "MFGraphs.wl"}]];
-
-
+Needs["MFGraphs`"];
 
 ClearAll[DescribeOutput];
 
@@ -34,17 +40,18 @@ DescribeOutput[title_String, description_String, expr_] :=
         Spacings -> {0.2, 0.7}
     ];
 
-MFGraphs`$MFGraphsVerbose = False;
+(* Use the global flag from primitives context *)
+$MFGraphsVerbose = False;
 
 (* --- 1. Build scenarios with ExampleScenarios constructors --- *)
 
-gridScenario = gridScenario[
+sGrid = gridScenario[
     {3},
     {{1, 120.0}},
     {{3, 0.0}}
 ];
 
-cycleScenario = cycleScenario[
+sCycle = cycleScenario[
     3,
     {{1, 50.0}},
     {{2, 0.0}, {3, 10.0}},
@@ -54,7 +61,7 @@ cycleScenario = cycleScenario[
     }
 ];
 
-amScenario = amScenario[
+sAm = amScenario[
     {1, 2, 3, 4},
     {
         {0, 1, 1, 0},
@@ -70,30 +77,30 @@ Column[{
     DescribeOutput[
         "gridScenario output",
         "A typed scenario object with completed defaults and derived topology.",
-        gridScenario
+        sGrid
     ],
     DescribeOutput[
         "cycleScenario output",
         "Cycle topology with explicit switching costs.",
-        cycleScenario
+        sCycle
     ],
     DescribeOutput[
         "amScenario output",
         "Adjacency-matrix constructor for explicit benchmark topologies.",
-        amScenario
+        sAm
     ]
 }]
 
 
 (* --- 2. Use named factory examples from ExampleScenarios.wl --- *)
 
-exampleY = getExampleScenario[
+exY = getExampleScenario[
     7,
     {{1, 100.0}},
     {{3, 0.0}, {4, 10.0}}
 ];
 
-exampleGrid = getExampleScenario[
+exGrid = getExampleScenario[
     "Grid0303",
     {{1, 30.0}},
     {{9, 0.0}}
@@ -103,12 +110,12 @@ Column[{
     DescribeOutput[
         "Named example (7)",
         "Factory-backed scenario with canonical topology and defaults.",
-        exampleY
+        exY
     ],
     DescribeOutput[
         "Named example (Grid0303)",
         "Grid example from the scenario registry.",
-        exampleGrid
+        exGrid
     ]
 }]
 
@@ -116,12 +123,12 @@ Column[{
 (* --- 3. Inspect scenario structure from Scenario.wl --- *)
 
 scenarioChecks = <|
-    "scenarioQ[exampleY]" -> scenarioQ[exampleY],
-    "Identity" -> scenarioData[exampleY, "Identity"],
-    "Benchmark" -> scenarioData[exampleY, "Benchmark"],
-    "Hamiltonian" -> scenarioData[exampleY, "Hamiltonian"],
-    "Model keys" -> Keys @ scenarioData[exampleY, "Model"],
-    "Topology keys" -> Keys @ scenarioData[exampleY, "Topology"]
+    "scenarioQ[exY]" -> scenarioQ[exY],
+    "Identity" -> scenarioData[exY, "Identity"],
+    "Benchmark" -> scenarioData[exY, "Benchmark"],
+    "Hamiltonian" -> scenarioData[exY, "Hamiltonian"],
+    "Model keys" -> Keys @ scenarioData[exY, "Model"],
+    "Topology keys" -> Keys @ scenarioData[exY, "Topology"]
 |>;
 
 DescribeOutput[
@@ -133,7 +140,7 @@ DescribeOutput[
 
 (* --- 4. Build unknown bundles from Unknowns.wl --- *)
 
-exampleUnknowns = makeUnknowns[exampleY];
+exampleUnknowns = makeUnknowns[exY];
 
 unknownSummary = <|
     "unknownsQ" -> unknownsQ[exampleUnknowns],
@@ -154,7 +161,7 @@ DescribeOutput[
 
 (* --- 5. Build structural systems from System.wl --- *)
 
-exampleSystem = makeSystem[exampleY, exampleUnknowns];
+exampleSystem = makeSystem[exY, exampleUnknowns];
 
 systemSummary = <|
     "mfgSystemQ" -> mfgSystemQ[exampleSystem],

--- a/MFGraphs/Getting started.wl
+++ b/MFGraphs/Getting started.wl
@@ -273,6 +273,11 @@ sol1Ex = reduceSystem[sys1Ex];
 
 Column[{
     DescribeOutput[
+        "Solution validation",
+        "isValidSystemSolution confirms that the solved rules satisfy all system constraints.",
+        isValidSystemSolution[sys1Ex, sol1Ex]
+    ],
+    DescribeOutput[
         "Combined solution plot \[LongDash] chain 1\[Rule]2\[Rule]3, single exit",
         "Directed edges show j-flow direction/magnitude; labels show both j and u. Auxiliary edges are included.",
         mfgSolutionPlot[chain1Ex, sys1Ex, sol1Ex,

--- a/MFGraphs/Getting started.wl
+++ b/MFGraphs/Getting started.wl
@@ -166,7 +166,7 @@ systemSummary = <|
     "# js" -> Length @ systemData[exampleSystem, "Js"],
     "# jts" -> Length @ systemData[exampleSystem, "Jts"],
     "# us" -> Length @ systemData[exampleSystem, "Us"],
-    "Switching-cost consistency" -> IsSwitchingCostConsistent[
+    "Switching-cost consistency" -> isSwitchingCostConsistent[
         Normal @ systemData[exampleSystem, "SwitchingCosts"]
     ]
 |>;
@@ -291,5 +291,23 @@ Column[{
         "Edge {1,2} is directed 1\[Rule]2 (j[1,2]>0). Labels show j and u on real + auxiliary edges.",
         mfgSolutionPlot[chain2ExNoSC, sysNoSC, solNoSC,
             "Chain 1\[Rule]2\[Rule]3: combined solution (exits at 2 and 3)"]
+    ]
+}]
+
+
+(* --- 10. Advanced Solution Visualization (Paper Scheme) --- *)
+
+Column[{
+    DescribeOutput[
+        "Transition graph plot",
+        "Nodes represent network edges (pairs); edges represent transition flows (j[a,b,c]).",
+        mfgTransitionPlot[chain1Ex, sys1Ex, sol1Ex,
+            "Chain 1\[Rule]2\[Rule]3: transition graph"]
+    ],
+    DescribeOutput[
+        "Augmented infrastructure graph (Paper scheme)",
+        "Nodes are (e, v) pairs. Value functions (u) are vertex labels; all flows (j) are edge labels.",
+        mfgAugmentedPlot[chain1Ex, sys1Ex, sol1Ex,
+            "Chain 1\[Rule]2\[Rule]3: augmented infrastructure"]
     ]
 }]

--- a/MFGraphs/Tests/reduce-system.mt
+++ b/MFGraphs/Tests/reduce-system.mt
@@ -97,3 +97,14 @@ Test[
     True,
     TestID -> "reduceSystem: non-integer decimal boundaries solve after exactification"
 ]
+
+Test[
+    Module[{s, sys, result},
+        s = gridScenario[{2}, {{1, 10}}, {{2, 0}}, {}, 2];
+        sys = makeSystem[s];
+        result = Quiet[reduceSystem[sys], reduceSystem::noncritical];
+        FailureQ[result] && result["Tag"] === "reduceSystem"
+    ],
+    True,
+    TestID -> "reduceSystem: non-critical congestion systems fail"
+]

--- a/MFGraphs/Tests/scenario-kernel.mt
+++ b/MFGraphs/Tests/scenario-kernel.mt
@@ -361,7 +361,29 @@ Test[
     ,
     True
     ,
+    {completeScenario::notopology}
+    ,
     TestID -> "Scenario kernel: completeScenario callable directly on validated scenario"
+]
+
+(* Test: completeScenario direct call warns and completes switching costs when topology is absent *)
+Test[
+    Module[{raw, validated, completed, sc},
+        raw = scenario[<|"Model" -> <|
+            "Vertices" -> {1, 2},
+            "Adjacency" -> {{0, 1}, {1, 0}},
+            "Entries" -> {{1, 10}},
+            "Exits" -> {{2, 0}},
+            "Switching" -> {{1, 1, 2, 3}}
+        |>|>];
+        validated = validateScenario[raw];
+        completed = completeScenario[validated];
+        sc = scenarioData[completed, "Model"]["Switching"];
+        scenarioQ[completed] && AssociationQ[sc]
+    ],
+    True,
+    {completeScenario::notopology},
+    TestID -> "Scenario kernel: completeScenario rebuilds missing topology with warning"
 ]
 
 (* Test: makeScenario rejects legacy Data substitutions *)
@@ -407,6 +429,44 @@ Test[
     TestID -> "Scenario kernel: symbolic boundary values are rejected"
 ]
 
+(* Test: makeScenario fails when an entry vertex is outside Vertices *)
+Test[
+    Module[{raw, result},
+        raw = <|
+            "Model" -> <|
+                "Vertices" -> {1, 2},
+                "Adjacency" -> {{0, 1}, {1, 0}},
+                "Entries" -> {{99, 10}},
+                "Exits" -> {{2, 0}},
+                "Switching" -> {}
+            |>
+        |>;
+        result = makeScenario[raw];
+        FailureQ[result] && result["Tag"] === "ScenarioValidation"
+    ],
+    True,
+    TestID -> "Scenario kernel: unknown entry vertex is rejected"
+]
+
+(* Test: makeScenario fails when an exit vertex is outside Vertices *)
+Test[
+    Module[{raw, result},
+        raw = <|
+            "Model" -> <|
+                "Vertices" -> {1, 2},
+                "Adjacency" -> {{0, 1}, {1, 0}},
+                "Entries" -> {{1, 10}},
+                "Exits" -> {{99, 0}},
+                "Switching" -> {}
+            |>
+        |>;
+        result = makeScenario[raw];
+        FailureQ[result] && result["Tag"] === "ScenarioValidation"
+    ],
+    True,
+    TestID -> "Scenario kernel: unknown exit vertex is rejected"
+]
+
 (* Test: makeScenario fails when switching cost values are symbolic *)
 Test[
     Module[{raw, result},
@@ -426,6 +486,25 @@ Test[
     True
     ,
     TestID -> "Scenario kernel: non-numeric switching costs are rejected"
+]
+
+(* Test: Infinity switching costs are accepted for blocked transitions *)
+Test[
+    Module[{s, sc},
+        s = makeScenario[<|
+            "Model" -> <|
+                "Vertices" -> {1, 2, 3},
+                "Adjacency" -> {{0, 1, 0}, {1, 0, 1}, {0, 1, 0}},
+                "Entries" -> {{1, 10}},
+                "Exits" -> {{3, 0}},
+                "Switching" -> {{1, 2, 3, Infinity}}
+            |>
+        |>];
+        sc = scenarioData[s, "Model"]["Switching"];
+        scenarioQ[s] && sc[{1, 2, 3}] === Infinity
+    ],
+    True,
+    TestID -> "Scenario kernel: Infinity switching costs are accepted"
 ]
 
 (* Test: Graph-only model derives Vertices List and Adjacency Matrix *)

--- a/MFGraphs/graphics.wl
+++ b/MFGraphs/graphics.wl
@@ -9,6 +9,12 @@ scenarioTopologyPlot::usage =
 mfgSolutionPlot::usage =
 "mfgSolutionPlot[s, sys, sol] plots a combined solution graph with real and auxiliary edges. Edge labels include both j and u values, and real-edge directions follow solved net flow orientation. An optional fourth argument sets the title.";
 
+mfgTransitionPlot::usage =
+"mfgTransitionPlot[s, sys, sol] plots the transition graph of the solution. Nodes represent network edges (or entry/exit), and directed edges represent transition flows (j[a, b, c]). Nodes are labeled with their internal values (u).";
+
+mfgAugmentedPlot::usage =
+"mfgAugmentedPlot[s, sys, sol] plots the augmented infrastructure graph (Paper scheme). Nodes represent edge-vertex pairs (e, v), and edges represent both flows within edges and transitions at vertices. Value functions (u) are vertex labels, and transition flows (j) are edge labels.";
+
 Begin["`Private`"];
 
 extractRules[sol_List] := Select[sol, MatchQ[#, _Rule | _RuleDelayed] &];
@@ -121,18 +127,185 @@ mfgSolutionPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title_: Automatic] :=
         ];
 
         plotTitle = Replace[title, Automatic -> "Solution graph: flows and values"];
+        auxEntryV = systemData[sys, "AuxEntryVertices"];
+        auxExitV  = systemData[sys, "AuxExitVertices"];
+
         Graph[Join[realV, auxV], dispEdges,
             VertexLabels -> Placed["Name", Center],
             VertexStyle  -> Normal @ Join[
                 AssociationThread[entryV,    RGBColor[0.22, 0.6, 0.3]],
                 AssociationThread[exitV,     RGBColor[0.82, 0.27, 0.2]],
                 AssociationThread[internalV, GrayLevel[0.72]],
-                AssociationThread[Select[auxV, StringStartsQ[TextString[#], "auxEntry"] &], RGBColor[0.38, 0.74, 0.9]],
-                AssociationThread[Select[auxV, StringStartsQ[TextString[#], "auxExit"] &],  RGBColor[0.95, 0.7, 0.4]]
+                AssociationThread[Intersection[auxV, auxEntryV], RGBColor[0.38, 0.74, 0.9]],
+                AssociationThread[Intersection[auxV, auxExitV],  RGBColor[0.95, 0.7, 0.4]]
             ],
             VertexSize   -> Normal @ Join[
                 AssociationThread[realV, 0.38],
                 AssociationThread[auxV, 0.28]
+            ],
+            EdgeStyle    -> Normal[edgeStyles],
+            EdgeLabels   -> Normal[edgeLabels],
+            GraphLayout  -> "LayeredDigraphEmbedding",
+            PlotLabel    -> Style[plotTitle, 14, Bold],
+            ImageSize    -> Large
+        ]
+    ];
+
+mfgTransitionPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title_: Automatic] :=
+    Module[{triples, rules, transitionEdges, nodeLabels, edgeStyles, edgeLabels,
+            numericJ, maxJ, plotTitle, auxPairs},
+        triples  = systemData[sys, "AuxTriples"];
+        auxPairs = systemData[sys, "AuxPairs"];
+        rules    = extractRules[sol];
+
+        transitionEdges = DirectedEdge[#[[1 ;; 2]], #[[2 ;; 3]]] & /@ triples;
+
+        numericJ = Cases[(j @@ # /. rules) & /@ triples, _?NumericQ, Infinity];
+        maxJ = Max[Append[Abs @ numericJ, 1]];
+
+        edgeStyles = Association @ Map[
+            With[{trip = {#[[1, 1]], #[[1, 2]], #[[2, 2]]}, jv = (j @@ {#[[1, 1]], #[[1, 2]], #[[2, 2]]}) /. rules},
+                # -> Directive[
+                    Which[
+                        NumericQ[jv] && jv > 0, RGBColor[0.12, 0.45, 0.78],
+                        NumericQ[jv] && jv < 0, RGBColor[0.82, 0.39, 0.2],
+                        True, GrayLevel[0.45]
+                    ],
+                    AbsoluteThickness[
+                        If[NumericQ[jv], Rescale[Abs[jv], {0, maxJ}, {1.5, 7}], 2.0]
+                    ],
+                    Opacity[0.9]
+                ]
+            ] &,
+            transitionEdges
+        ];
+
+        edgeLabels = Association @ Map[
+            With[{trip = {#[[1, 1]], #[[1, 2]], #[[2, 2]]}, jv = (j @@ {#[[1, 1]], #[[1, 2]], #[[2, 2]]}) /. rules},
+                # -> Placed[
+                    Style[
+                        If[NumericQ[jv], NumberForm[N[jv], {5, 1}], "?"],
+                        9, Black, Background -> White
+                    ],
+                    Center
+                ]
+            ] &,
+            transitionEdges
+        ];
+
+        nodeLabels = Association @ Map[
+            With[{uv = edgeUValue[#[[1]], #[[2]], rules]},
+                # -> Placed[
+                    Style[
+                        Row[{
+                            ToString[#],
+                            " (u=", If[NumericQ[uv], NumberForm[N[uv], {5, 1}], "?"], ")"
+                        }],
+                        10, Black, Background -> RGBColor[0.95, 0.95, 0.95]
+                    ],
+                    Center
+                ]
+            ] &,
+            auxPairs
+        ];
+
+        plotTitle = Replace[title, Automatic -> "Transition graph: flows and values"];
+        Graph[auxPairs, transitionEdges,
+            VertexShapeFunction -> "RoundRectangle",
+            VertexLabels -> Normal[nodeLabels],
+            VertexSize   -> {"Scaled", 0.15},
+            EdgeStyle    -> Normal[edgeStyles],
+            EdgeLabels   -> Normal[edgeLabels],
+            GraphLayout  -> "LayeredDigraphEmbedding",
+            PlotLabel    -> Style[plotTitle, 14, Bold],
+            ImageSize    -> Large
+        ]
+    ];
+
+mfgAugmentedPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title_: Automatic] :=
+    Module[{auxPairs, triples, rules, flowEdges, transitionEdges, allAugEdges,
+            edgeStyles, edgeLabels, nodeLabels, plotTitle, numericJ, maxJ,
+            getJ, getU, auxEntryV, auxExitV},
+
+        auxPairs = systemData[sys, "AuxPairs"];
+        triples  = systemData[sys, "AuxTriples"];
+        rules    = extractRules[sol];
+        auxEntryV = systemData[sys, "AuxEntryVertices"];
+        auxExitV  = systemData[sys, "AuxExitVertices"];
+
+        (* 1. Flow edges: {u, v} -> {v, u} (magnitude j[v, u]) *)
+        flowEdges = Map[DirectedEdge[#, Reverse[#]] &, auxPairs];
+
+        (* 2. Transition edges: {i, r} -> {i, w} (magnitude j[i, r, w]) *)
+        transitionEdges = DirectedEdge[{#[[2]], #[[1]]}, {#[[2]], #[[3]]}] & /@ triples;
+
+        allAugEdges = Join[flowEdges, transitionEdges];
+
+        getJ[DirectedEdge[p1_, p2_]] :=
+            If[p1 === Reverse[p2],
+                j @@ p2, (* Flow within edge: magnitude j[target, source] *)
+                j[p1[[1]], p1[[2]], p2[[2]]] (* Transition at vertex: magnitude j[v, e1, e2] *)
+            ];
+
+        getU[p_] := (u @@ p) /. rules;
+
+        numericJ = Cases[getJ /@ allAugEdges /. rules, _?NumericQ, Infinity];
+        maxJ = Max[Append[Abs @ numericJ, 1]];
+
+        edgeStyles = Association @ Map[
+            With[{jv = getJ[#] /. rules},
+                # -> Directive[
+                    Which[
+                        NumericQ[jv] && jv > 0, RGBColor[0.12, 0.45, 0.78],
+                        NumericQ[jv] && jv < 0, RGBColor[0.82, 0.39, 0.2],
+                        True, GrayLevel[0.45]
+                    ],
+                    AbsoluteThickness[
+                        If[NumericQ[jv], Rescale[Abs[jv], {0, maxJ}, {1.5, 7}], 2.0]
+                    ],
+                    Opacity[0.8]
+                ]
+            ] &,
+            allAugEdges
+        ];
+
+        edgeLabels = Association @ Map[
+            With[{jv = getJ[#] /. rules},
+                # -> Placed[
+                    Style[
+                        If[NumericQ[jv] && Abs[jv] > 10^-5, NumberForm[N[jv], {5, 1}], ""],
+                        8, Black, Background -> White
+                    ],
+                    Center
+                ]
+            ] &,
+            allAugEdges
+        ];
+
+        nodeLabels = Association @ Map[
+            With[{uv = getU[#]},
+                # -> Placed[
+                    Style[
+                        Row[{
+                            ToString[#],
+                            "\n",
+                            If[NumericQ[uv], NumberForm[N[uv], {5, 2}], "?"]
+                        }],
+                        9, Black
+                    ],
+                    Center
+                ]
+            ] &,
+            auxPairs
+        ];
+
+        plotTitle = Replace[title, Automatic -> "Augmented infrastructure graph (Paper scheme)"];
+        Graph[auxPairs, allAugEdges,
+            VertexLabels -> Normal[nodeLabels],
+            VertexSize   -> 0.4,
+            VertexStyle  -> Normal @ Join[
+                AssociationThread[Select[auxPairs, MemberQ[auxEntryV, #[[1]]] &], RGBColor[0.38, 0.74, 0.9]],
+                AssociationThread[Select[auxPairs, MemberQ[auxExitV,  #[[1]]] &], RGBColor[0.95, 0.7, 0.4]]
             ],
             EdgeStyle    -> Normal[edgeStyles],
             EdgeLabels   -> Normal[edgeLabels],

--- a/MFGraphs/scenarioTools.wl
+++ b/MFGraphs/scenarioTools.wl
@@ -46,8 +46,9 @@ Optional keys: \
 \"EdgeG\" -> <|{u,v} -> g_uv, ...|>|>), \
 \"Identity\" (name, version), \"Benchmark\" (tier, timeout), \"Visualization\", \
 \"Inheritance\". Default Hamiltonian is Alpha=1 and V=0 on all edges, with \
-G[z]=-1/z (overridable globally and per edge). Boundary and switching-cost values \
-must be numeric. Returns a scenario[...] object on success or Failure[...] on error.";
+G[z]=-1/z (overridable globally and per edge). Boundary values must be numeric; \
+switching-cost values must be numeric or Infinity. Returns a scenario[...] object \
+on success or Failure[...] on error.";
 
 validateScenario::usage =
 "validateScenario[s] checks that the scenario s has all required Model keys and that \
@@ -57,7 +58,9 @@ on failure.";
 
 completeScenario::usage =
 "completeScenario[s] fills in derived fields and supplies default Benchmark values \
-(\"Tier\" -> \"core\", \"Timeout\" -> 300) when missing. Returns a new scenario object.";
+(\"Tier\" -> \"core\", \"Timeout\" -> 300) when missing. If cached topology is \
+absent, it warns and rebuilds topology from the Model before completing. Returns \
+a new scenario object.";
 
 scenarioData::usage =
 "scenarioData[s, key] returns the value associated with key in the scenario s, or \
@@ -162,17 +165,35 @@ boundaryValuesNumericQ[model_Association] :=
         AllTrue[Last /@ Join[entry, exit], NumericQ]
     ];
 
+(* Boundary vertex membership is checked after integerVertexLabelsQ, so a separate
+   IntegerQ test here would be redundant: every valid member of "Vertices" is
+   already known to be an integer label. *)
+boundaryVerticesPresentQ[model_Association] :=
+    Module[{vertices, entryVertices, exitVertices},
+        vertices = Lookup[model, "Vertices", Missing[]];
+        If[!ListQ[vertices], Return[False, Module]];
+        entryVertices = First /@ Lookup[model, "Entries", {}];
+        exitVertices  = First /@ Lookup[model, "Exits", {}];
+        AllTrue[Join[entryVertices, exitVertices], MemberQ[vertices, #] &]
+    ];
+
+(* Infinity is the explicit sentinel for blocked transitions. In WL this is the
+   canonical positive infinity value; other directed infinities are intentionally
+   not accepted as switching costs. *)
+switchingCostValueQ[value_] :=
+    NumericQ[value] || value === Infinity;
+
 switchingCostsNumericQ[model_Association] :=
     Module[{switching},
         switching = Lookup[model, "Switching", Missing[]];
         Which[
             AssociationQ[switching],
                 AllTrue[Keys[switching], ListQ[#] && Length[#] === 3 && AllTrue[#, IntegerQ] &] &&
-                AllTrue[Values[switching], NumericQ],
+                AllTrue[Values[switching], switchingCostValueQ],
             ListQ[switching],
                 switching === {} ||
                 (AllTrue[switching, ListQ[#] && Length[#] === 4 && AllTrue[Take[#, 3], IntegerQ] &] &&
-                 AllTrue[Last /@ switching, NumericQ]),
+                 AllTrue[Last /@ switching, switchingCostValueQ]),
             True,
                 False
         ]
@@ -397,6 +418,8 @@ completeSwitchingCosts[model_Association, topology_Association] :=
 
 completeScenario::notscenario =
     "completeScenario expected a scenario object; got `1`. Returning input unchanged.";
+completeScenario::notopology =
+    "completeScenario was called without cached topology; rebuilding topology from the Model before completing derived fields.";
 
 completeScenario[s_scenario] :=
     Module[{assoc, identity, benchmark, model, hamiltonian, topology, completedSC},
@@ -407,7 +430,13 @@ completeScenario[s_scenario] :=
         benchmark   = Lookup[assoc, "Benchmark",   <||>];
         topology    = Lookup[assoc, "Topology",    Missing["KeyAbsent", "Topology"]];
 
-        If[!MissingQ[topology],
+        If[MissingQ[topology] && AssociationQ[model],
+            Message[completeScenario::notopology];
+            model = Join[model, <|"Switching" -> normalizeSwitchingCosts[Lookup[model, "Switching", <||>]]|>];
+            topology = buildAuxiliaryTopology[model]
+        ];
+
+        If[AssociationQ[topology],
             completedSC = completeSwitchingCosts[model, topology];
             model = Join[model, <|"Switching" -> completedSC|>]
         ];
@@ -455,6 +484,8 @@ makeScenario[rawAssoc_Association] :=
             Return[scenarioFailure["\"Vertices\" must contain only integers."], Module]];
         If[!boundaryValuesNumericQ[model],
             Return[scenarioFailure["Boundary values must be numeric."], Module]];
+        If[!boundaryVerticesPresentQ[model],
+            Return[scenarioFailure["Entry and exit vertices must belong to \"Vertices\"."], Module]];
         If[!switchingCostsNumericQ[model],
             Return[scenarioFailure["Switching cost values must be numeric."], Module]];
 

--- a/MFGraphs/solversTools.wl
+++ b/MFGraphs/solversTools.wl
@@ -17,6 +17,7 @@ non-negativity constraints, and complementarity conditions of the \
 mfgSystem sys using Reduce over the Reals. Includes AltOptCond \
 (switching-cost optimality complementarity) and \
 IneqSwitchingByVertex (switching-cost optimality inequalities). \
+Fails for non-critical congestion systems where Alpha != 1 on any edge. \
 Returns a list of rules when the system is fully determined, or \
 <|\"Rules\" -> rules, \"Equations\" -> residual|> when underdetermined.";
 
@@ -29,12 +30,25 @@ with per-block results. Tolerance for numeric checks is set via \
 rules are checked; blocks that remain symbolic after substitution are \
 reported as Indeterminate, not False.";
 
+reduceSystem::noncritical =
+"reduceSystem supports only critical congestion systems with Alpha == 1 on every edge.";
+
 Begin["`Private`"];
 
 reduceSystem[sys_?mfgSystemQ] :=
     Module[{eqEntryIn, eqSplit, eqGather, eqHJ,
             ineqJs, ineqJts, ineqSwitchingByVertex, altFlows, altTrans, altOptCond,
             ruleExitVals, baseConstraints, constraints, allVars, rulesAcc},
+
+        If[!criticalCongestionSystemQ[sys],
+            Message[reduceSystem::noncritical];
+            Return[
+                Failure["reduceSystem", <|
+                    "Message" -> "reduceSystem supports only critical congestion systems with Alpha == 1 on every edge."
+                |>],
+                Module
+            ]
+        ];
 
         eqEntryIn    = systemData[sys, "EqEntryIn"];
         eqSplit      = systemData[sys, "EqBalanceSplittingFlows"];
@@ -74,6 +88,27 @@ reduceSystem[sys_?mfgSystemQ] :=
 
 trackedVarQ[var_] :=
     MatchQ[var, j[__] | u[__]];
+
+(* reduceSystem only handles the critical-congestion structural system. The
+   system object carries the scenario Hamiltonian so this check can reject any
+   non-1 default Alpha or per-edge EdgeAlpha before Reduce sees nonlinear
+   placeholder equations. *)
+criticalCongestionSystemQ[sys_?mfgSystemQ] :=
+    Module[{halfPairs, hamiltonian, alphaDefault, edgeAlpha, alphaAtEdge},
+        halfPairs   = systemData[sys, "HalfPairs"];
+        hamiltonian = systemData[sys, "Hamiltonian"];
+        If[MissingQ[hamiltonian] || !AssociationQ[hamiltonian], hamiltonian = <||>];
+        alphaDefault = Lookup[hamiltonian, "Alpha", 1];
+        edgeAlpha    = Lookup[hamiltonian, "EdgeAlpha", <||>];
+        If[!ListQ[halfPairs] || !AssociationQ[edgeAlpha], Return[False, Module]];
+        alphaAtEdge[edge_List] :=
+            Lookup[
+                edgeAlpha,
+                Key[edge],
+                Lookup[edgeAlpha, Key[Reverse[edge]], alphaDefault]
+            ];
+        alphaDefault === 1 && AllTrue[halfPairs, alphaAtEdge[#] === 1 &]
+    ];
 
 mergeRules[oldRules_List, newRules_List] :=
     Reverse @ DeleteDuplicatesBy[Reverse @ Join[oldRules, newRules], First];

--- a/MFGraphs/systemTools.wl
+++ b/MFGraphs/systemTools.wl
@@ -541,6 +541,8 @@ makeSystem[s_?scenarioQ, unk_?unknownsQ] :=
                 "Js"          -> unknownsData[unk, "Js"],
                 "Us"          -> unknownsData[unk, "Us"],
                 "Jts"         -> unknownsData[unk, "Jts"],
+                (* Keep modeling metadata available to solver-layer eligibility checks. *)
+                "Hamiltonian" -> scenarioData[s, "Hamiltonian"],
                 "Edges"       -> edges,
                 "AuxEdges"    -> auxEdges,
                 "AuxVertices" -> auxVertices,

--- a/README.md
+++ b/README.md
@@ -7,16 +7,19 @@ The repository is currently in a **core scenario-kernel phase**. The active pack
 - example scenario factories
 - unknown-variable bundle construction
 - structural system construction
-
-Solver modules are intentionally not loaded by the current package bootstrap.
+- critical-congestion symbolic solving
+- visualization helpers
 
 ## Current status
 
 Loaded by `Needs["MFGraphs`"]`:
-- `MFGraphs/Scenario.wl`
-- `MFGraphs/Examples/ExampleScenarios.wl`
-- `MFGraphs/Unknowns.wl`
-- `MFGraphs/System.wl`
+- `MFGraphs/primitives.wl`
+- `MFGraphs/scenarioTools.wl`
+- `MFGraphs/examples.wl`
+- `MFGraphs/unknownsTools.wl`
+- `MFGraphs/systemTools.wl`
+- `MFGraphs/solversTools.wl`
+- `MFGraphs/graphics.wl`
 
 Archived/inactive modules:
 - `MFGraphs/Examples/archive/ExamplesData.wl`
@@ -24,7 +27,7 @@ Archived/inactive modules:
 
 ## Solver Status
 
-The symbolic solver (`MFGraphs/solver.wl`) is currently designed for **critical congestion only** (`alpha = 1`). It does not yet support non-linear Hamiltonian cost currents or general `alpha != 1` cases.
+The symbolic solver (`MFGraphs/solversTools.wl`) is designed for **critical congestion only** (`Alpha = 1` on every edge). Non-critical systems (`Alpha != 1` or edge-specific non-1 `EdgeAlpha`) fail explicitly.
 
 ## Installation
 
@@ -43,11 +46,11 @@ Needs["MFGraphs`"];
 
 s = makeScenario[<|
   "Model" -> <|
-    "Vertices List" -> {1, 2, 3},
-    "Adjacency Matrix" -> {{0, 1, 0}, {0, 0, 1}, {0, 0, 0}},
-    "Entrance Vertices and Flows" -> {{1, 10}},
-    "Exit Vertices and Terminal Costs" -> {{3, 0}},
-    "Switching Costs" -> {}
+    "Vertices" -> {1, 2, 3},
+    "Adjacency" -> {{0, 1, 0}, {0, 0, 1}, {0, 0, 0}},
+    "Entries" -> {{1, 10}},
+    "Exits" -> {{3, 0}},
+    "Switching" -> {}
   |>
 |>];
 
@@ -62,7 +65,7 @@ mfgSystemQ[sys]
 Example factory workflow:
 
 ```mathematica
-f = GetExampleScenario[12];
+f = getExampleScenario[12];
 s = f[{{1, 100}}, {{4, 0}}, {}, 1, 0, Function[z, -1/z]];
 ```
 
@@ -71,15 +74,16 @@ s = f[{{1, 100}}, {{4, 0}}, {}, 1, 0, Function[z, -1/z]];
 Scenario kernel:
 - `scenario`, `scenarioQ`
 - `makeScenario`, `validateScenario`, `completeScenario`
-- `ScenarioData`
+- `scenarioData`
 
 Example scenario factories:
-- `GetExampleScenario`
-- `GridScenario`, `CycleScenario`, `GraphScenario`, `AMScenario`
+- `getExampleScenario`
+- `gridScenario`, `cycleScenario`, `graphScenario`, `amScenario`
 
 Unknowns/system kernels:
-- `unknowns`, `unknownsQ`, `UnknownsData`, `makeUnknowns`
-- `mfgSystem`, `mfgSystemQ`, `SystemData`, `makeSystem`
+- `unknowns`, `unknownsQ`, `unknownsData`, `makeUnknowns`
+- `mfgSystem`, `mfgSystemQ`, `systemData`, `makeSystem`
+- `reduceSystem`, `isValidSystemSolution`
 
 Core symbolic primitives:
 - `j`, `u`, `z`, `alpha`, `Cost`
@@ -112,11 +116,14 @@ Current active runner suites (`Scripts/RunTests.wls`):
 ```text
 MFGraphs/
   MFGraphs.wl
-  Scenario.wl
-  Unknowns.wl
-  System.wl
+  primitives.wl
+  scenarioTools.wl
+  examples.wl
+  unknownsTools.wl
+  systemTools.wl
+  solversTools.wl
+  graphics.wl
   Examples/
-    ExampleScenarios.wl
     archive/
       ExamplesData.wl
   archive/

--- a/Scripts/AuditPublicAPI.py
+++ b/Scripts/AuditPublicAPI.py
@@ -37,7 +37,7 @@ CATEGORY_OVERRIDES = {
     'makeScenario': ('core', 'keep'),
     'validateScenario': ('core', 'keep'),
     'completeScenario': ('core', 'keep'),
-    'ScenarioData': ('advanced', 'keep'),
+    'scenarioData': ('advanced', 'keep'),
     'scenario': ('advanced', 'review'),
     'scenarioQ': ('advanced', 'keep'),
     'Data2Equations': ('compatibility', 'keep-with-deprecation'),
@@ -181,7 +181,7 @@ def write_inventory(rows: list[dict], priv: dict[str, list[str]]) -> Path:
         '',
         '## Phase 1 observations',
         '',
-        'The exported surface is broader than the currently documented user narrative. It mixes core workflow functions, advanced solver helpers, runtime globals, symbolic heads, compatibility aliases, and several example-parameter symbols. It also contains suspicious exports such as `alpha$` and `j$`, which appear to be packaging artefacts rather than intentional API symbols.',
+        'The exported surface is broader than the currently documented user narrative. It mixes core workflow functions, advanced solver helpers, runtime globals, symbolic heads, compatibility aliases, and several example-parameter symbols. Generated user docs filter internal packaging artefacts, but this audit still flags them so package export hygiene can be reviewed explicitly.',
     ]
     out.write_text('\n'.join(lines) + '\n', encoding='utf-8')
     return out
@@ -216,7 +216,7 @@ def write_gap_report(rows: list[dict]) -> Path:
         '',
         '| Gap | Why it matters | Recommended Phase 2 action |',
         '|---|---|---|',
-        '| Accidental exports such as `alpha$` and `j$` | These weaken confidence in the API boundary and pollute generated docs | Fix package export hygiene before broadening the public surface |',
+        '| Accidental/internal exports | These weaken confidence in the API boundary and require filtering in generated docs | Fix package export hygiene before broadening the public surface |',
         '| Broad advanced-helper surface with sparse direct tests | Publicization without verification would reduce trust instead of increasing it | Add a symbol-to-test coverage matrix and targeted low-level unit tests |',
         '| Runtime globals exposed without explicit stability policy | Users cannot tell whether these are supported controls or incidental internals | Decide which globals remain public and document the rest as internal controls |',
         '| Example-parameter symbols exported beside functional API symbols | These clutter the generated reference and blur the distinction between examples and supported functions | Decide whether parameters stay exported, move to examples-only docs, or get grouped specially |',

--- a/Scripts/GenerateDocs.wls
+++ b/Scripts/GenerateDocs.wls
@@ -4,14 +4,27 @@
 (* :!CodeAnalysis::BeginBlock:: *)
 (* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
 
-$RepoRoot = "/Users/ribeirrd/Documents/GitHub/MFGraphs";
+$RepoRoot = DirectoryName[DirectoryName[$InputFileName]];
 PrependTo[$Path, $RepoRoot];
 Needs["MFGraphs`"];
 
 Print["Generating API Reference..."];
 
-symbols = Names["MFGraphs`*"];
-publicSymbols = Select[symbols, (!StringContainsQ[#, "Private`"]) &];
+$PublicContexts = {
+  "primitives`",
+  "scenarioTools`",
+  "examples`",
+  "unknownsTools`",
+  "systemTools`",
+  "solversTools`",
+  "graphics`"
+};
+
+symbols = DeleteDuplicates @ Flatten[Names[# <> "*"] & /@ $PublicContexts];
+publicSymbols = Select[
+  symbols,
+  !StringContainsQ[#, "Private`"] && !StringEndsQ[#, "$"] &
+];
 
 mdContent = {
   "# MFGraphs API Reference",
@@ -21,9 +34,9 @@ mdContent = {
 };
 
 Do[
-  symName = StringReplace[s, "MFGraphs`" -> ""];
+  symName = Last @ StringSplit[s, "`"];
   usage = Information[Symbol[s], "Usage"];
-  If[StringQ[usage],
+  If[StringQ[usage] && !StringStartsQ[usage, "False is the symbol for"],
     AppendTo[mdContent, "## " <> symName];
     AppendTo[mdContent, ""];
     AppendTo[mdContent, usage];

--- a/Scripts/LEGACY_SOLVER_SCRIPTS.md
+++ b/Scripts/LEGACY_SOLVER_SCRIPTS.md
@@ -4,7 +4,7 @@ The scripts listed here still depend on solver-era symbols such as
 `DataToEquations`, `CriticalCongestionSolver`, and/or `GetExampleData`.
 
 They are **not part of the active core-only workflow** while `MFGraphs.wl`
-loads only Scenario/ExampleScenarios/Unknowns/System.
+loads the active core stack through scenarioTools/examples/unknownsTools/systemTools.
 
 ## Typical affected scripts
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -152,11 +152,11 @@
 **Verify network data format:**
 ```mathematica
 Data = <|
-  "Vertices List" -> {1, 2, 3, 4},
-  "Adjacency Matrix" -> {{0,1,0,0}, {0,0,1,0}, {0,0,0,1}, {0,0,0,0}},
-  "Entrance Vertices and Flows" -> {{1, 200}},
-  "Exit Vertices and Terminal Costs" -> {{4, 0}},
-  "Switching Costs" -> {{1,2,3, 5}, {3,2,1, 5}}
+  "Vertices" -> {1, 2, 3, 4},
+  "Adjacency" -> {{0,1,0,0}, {0,0,1,0}, {0,0,0,1}, {0,0,0,0}},
+  "Entries" -> {{1, 200}},
+  "Exits" -> {{4, 0}},
+  "Switching" -> {{1,2,3, 5}, {3,2,1, 5}}
 |>
 ```
 


### PR DESCRIPTION
This PR implements the augmented infrastructure graph visualization scheme described in the paper.

### Key Changes:
- **mfgAugmentedPlot**: New visualization where nodes are (v, e) pairs, allowing value functions (u) to be seen as vertex values and transition flows (j) as flows on edges.
- **mfgTransitionPlot**: Dedicated transition graph where nodes represent network edges.
- **Getting started.wl**: Updated with examples of the new advanced visualizations and fixed casing for consistency.
- **Scenario Kernel**: Added robustness checks for boundary vertices and support for Infinity in switching costs.
- **Solver**: Added guards to ensure only critical congestion systems are processed.
- **Tests**: Added new tests for the scenario kernel and solver guards.

All 64 tests in the fast suite passed.