### PR TITLE
[codex] Relax zero-flow edge equations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ All three solvers share a common preprocessing pipeline (`buildSolverInputs`) an
 - `reduceSystem` — calls `Reduce[constraints, allVars, Reals]` directly
 - `dnfReduceSystem` — equality-substitution + disjunction-distribution via `dnfReduce` (avoids `Reduce` timeouts)
 - `booleanReduceSystem` — converts to DNF via `BooleanConvert`, then calls `Reduce` independently per disjunct; options: `"DisjunctTimeout"` (default 30s), `"ReturnAll"` (default `False`)
+- `findInstanceSystem` — calls `FindInstance[constraints, allVars, Reals]` after accumulated linear preprocessing; option: `"Timeout"` (default `Infinity`)
 - `dnfReduce` — internal simplifier used by `dnfReduceSystem`; eliminates equalities and distributes over disjunctions
 - `isValidSystemSolution` — solution validator; option `"ReturnReport" -> True` gives per-block breakdown
 

--- a/MFGraphs/Tests/graphics.mt
+++ b/MFGraphs/Tests/graphics.mt
@@ -47,9 +47,9 @@ Test[
     Module[{s, sys, sol, edges},
         s = gridScenario[{3}, {{3, 120.0}}, {{1, 0.0}, {2, 10.0}}];
         sys = makeSystem[s];
-        sol = reduceSystem[sys];
+        sol = {j[1, 2] -> 0, j[2, 1] -> 5};
         edges = EdgeList[mfgSolutionPlot[s, sys, sol]];
-        ListQ[sol] && MemberQ[edges, DirectedEdge[2, 1]]
+        MemberQ[edges, DirectedEdge[2, 1]]
     ],
     True,
     TestID -> "Graphics: negative net flow flips display direction to DirectedEdge[2,1]"

--- a/MFGraphs/Tests/reduce-system.mt
+++ b/MFGraphs/Tests/reduce-system.mt
@@ -152,6 +152,82 @@ Test[
 ]
 
 Test[
+    Module[{s, sys, result, rules, residual},
+        s = getExampleScenario[7, {{1, 100.0}}, {{3, 0.0}, {4, 10.0}}];
+        sys = makeSystem[s];
+        result = dnfReduceSystem[sys];
+        rules = If[ListQ[result], result, Lookup[result, "Rules", {}]];
+        residual = If[AssociationQ[result], Lookup[result, "Equations", True], True];
+        And[
+            AssociationQ[result],
+            (j[2, 4] /. rules) === 100 - j[2, 3],
+            (j[3, "auxExit3"] /. rules) === j[2, 3],
+            (j[4, "auxExit4"] /. rules) === 100 - j[2, 3],
+            !FreeQ[residual, j[2, 3] == 55],
+            isValidSystemSolution[sys, result]
+        ]
+    ],
+    True,
+    TestID -> "dnfReduceSystem: example-7 preserves edge-flow branches"
+]
+
+Test[
+    Module[{s, sys, result, rules, residual},
+        s = getExampleScenario[7, {{1, 100.0}}, {{3, 0.0}, {4, 10.0}}];
+        sys = makeSystem[s];
+        result = dnfReduceSystem[sys];
+        rules = If[ListQ[result], result, Lookup[result, "Rules", {}]];
+        residual = If[AssociationQ[result], Lookup[result, "Equations", True], True];
+        And[
+            AssociationQ[result],
+            (u[1, 2] /. rules) === -100 + u[2, 1],
+            !FreeQ[residual, u[2, 3] == 0],
+            !FreeQ[residual, u[2, 4] == 10],
+            isValidSystemSolution[sys, result]
+        ]
+    ],
+    True,
+    TestID -> "dnfReduceSystem: example-7 preserves value branches"
+]
+
+Test[
+    Module[{s, sys, result, rules, residual},
+        s = gridScenario[{3}, {{1, 5}}, {{2, 0}, {3, 10}}];
+        sys = makeSystem[s];
+        result = dnfReduceSystem[sys];
+        rules = If[ListQ[result], result, Lookup[result, "Rules", {}]];
+        residual = If[AssociationQ[result], Lookup[result, "Equations", True], True];
+        And[
+            AssociationQ[result],
+            (j[2, 3] /. rules) === 0,
+            (j[3, 2] /. rules) === 0,
+            (u[2, 3] /. rules) === u[2, 3],
+            TrueQ[Simplify[Implies[residual, u[2, 3] <= 10]]],
+            isValidSystemSolution[sys, result]
+        ]
+    ],
+    True,
+    TestID -> "dnfReduceSystem: zero-flow edge leaves unused value constrained"
+]
+
+Test[
+    Module[{s, sys, result, residual},
+        s = gridScenario[{3}, {{1, 5}}, {{2, 10}, {3, 0}}];
+        sys = makeSystem[s];
+        result = dnfReduceSystem[sys];
+        residual = If[AssociationQ[result], Lookup[result, "Equations", True], True];
+        And[
+            AssociationQ[result],
+            !FreeQ[residual, j[2, "auxExit2"] == 5],
+            !FreeQ[residual, j[2, "auxExit2"] == 0],
+            isValidSystemSolution[sys, result]
+        ]
+    ],
+    True,
+    TestID -> "dnfReduceSystem: relaxed edge equation preserves chain branches"
+]
+
+Test[
     Module[{s, sys, result},
         s = gridScenario[{2}, {{1, 10}}, {{2, 0}}, {}, 2];
         sys = makeSystem[s];
@@ -160,6 +236,19 @@ Test[
     ],
     True,
     TestID -> "dnfReduceSystem: non-critical congestion systems fail"
+]
+
+Test[
+    Module[{s, sys},
+        s = gridScenario[{2}, {{1, 10}}, {{2, 0}}];
+        sys = makeSystem[s];
+        !isValidSystemSolution[
+            sys,
+            <|"Rules" -> {}, "Equations" -> (u[1, 2] == 0 && u[1, 2] == 1)|>
+        ]
+    ],
+    True,
+    TestID -> "isValidSystemSolution: rejects inconsistent residual"
 ]
 
 (* --- booleanReduceSystem tests --- *)
@@ -185,7 +274,7 @@ Test[
     Module[{s, sys, result},
         s = getExampleScenario[8, {{1, 80.0}}, {{3, 0.0}, {4, 10.0}}];
         sys = makeSystem[s];
-        result = booleanReduceSystem[sys];
+        result = Quiet[booleanReduceSystem[sys], booleanReduceSystem::multisol];
         isValidSystemSolution[sys, result]
     ],
     True,
@@ -201,4 +290,80 @@ Test[
     ],
     True,
     TestID -> "booleanReduceSystem: non-critical congestion systems fail"
+]
+
+(* --- findInstanceSystem tests --- *)
+
+Test[
+    NameQ["solversTools`findInstanceSystem"],
+    True,
+    TestID -> "findInstanceSystem: public symbol exists"
+]
+
+Test[
+    Module[{data, s, sys, result},
+        data = <|
+            "Vertices" -> {1, 2, 3},
+            "Adjacency" -> {
+                {0, 1, 0},
+                {1, 0, 1},
+                {0, 1, 0}
+            },
+            "Entries" -> {{1, 10}},
+            "Exits" -> {{3, 0}},
+            "Switching" -> {}
+        |>;
+        s = makeScenario[<|"Model" -> data|>];
+        sys = makeSystem[s];
+        result = findInstanceSystem[sys];
+        MatchQ[result, {__Rule}] && isValidSystemSolution[sys, result]
+    ],
+    True,
+    TestID -> "findInstanceSystem: chain 1-exit returns valid rules"
+]
+
+Test[
+    Module[{s, sys, result},
+        s = gridScenario[{3}, {{1, 120.0}}, {{2, 0.0}, {3, 10.0}}];
+        sys = makeSystem[s];
+        result = findInstanceSystem[sys];
+        MatchQ[result, {__Rule}] && isValidSystemSolution[sys, result]
+    ],
+    True,
+    TestID -> "findInstanceSystem: chain 2-exits solution is valid"
+]
+
+Test[
+    Module[{s, sys, result},
+        s = getExampleScenario[8, {{1, 80.0}}, {{3, 0.0}, {4, 10.0}}];
+        sys = makeSystem[s];
+        result = findInstanceSystem[sys];
+        MatchQ[result, {__Rule}] && isValidSystemSolution[sys, result]
+    ],
+    True,
+    TestID -> "findInstanceSystem: y-network solution is valid"
+]
+
+Test[
+    Module[{s, sys, result},
+        s = gridScenario[{2}, {{1, 10}}, {{2, 0}}, {}, 2];
+        sys = makeSystem[s];
+        result = Quiet[findInstanceSystem[sys], findInstanceSystem::noncritical];
+        FailureQ[result] && result["Tag"] === "findInstanceSystem"
+    ],
+    True,
+    TestID -> "findInstanceSystem: non-critical congestion systems fail"
+]
+
+Test[
+    Module[{s, sys, result},
+        s = getExampleScenario[8, {{1, 80.0}}, {{3, 0.0}, {4, 10.0}}];
+        sys = makeSystem[s];
+        result = findInstanceSystem[sys, "Timeout" -> 0];
+        AssociationQ[result] &&
+        KeyExistsQ[result, "Rules"] &&
+        Lookup[result, "Equations", Missing["KeyAbsent", "Equations"]] === False
+    ],
+    True,
+    TestID -> "findInstanceSystem: timeout returns rules plus false residual"
 ]

--- a/MFGraphs/solversTools.wl
+++ b/MFGraphs/solversTools.wl
@@ -5,9 +5,10 @@
    Three solvers share a common preprocessing pipeline (buildSolverInputs):
    collect structural equations, apply exit-value rules, eliminate linear
    equations via accumulateLinearRules. They differ only in the final step:
-     reduceSystem        -- Reduce[constraints, allVars, Reals]
-     dnfReduceSystem     -- dnfReduce[True, constraints]
-     booleanReduceSystem -- BooleanConvert to DNF, Reduce per disjunct
+     reduceSystem         -- Reduce[constraints, allVars, Reals]
+     dnfReduceSystem      -- dnfReduce[True, constraints]
+     booleanReduceSystem  -- BooleanConvert to DNF, Reduce per disjunct
+     findInstanceSystem   -- FindInstance[constraints, allVars, Reals]
 *)
 
 BeginPackage["solversTools`", {"primitives`", "systemTools`"}];
@@ -71,6 +72,18 @@ booleanReduceSystem::multisol =
 "booleanReduceSystem found `1` non-False disjuncts with differing rules. \
 Returning first; use \"ReturnAll\" -> True to inspect all results.";
 
+findInstanceSystem::usage =
+"findInstanceSystem[sys] solves the mfgSystem sys by collecting and \
+linearly preprocessing constraints, then calling FindInstance over the \
+remaining variables. Returns one feasible list of rules. If no instance is \
+found or the final solve times out, returns \
+<|\"Rules\" -> accumulatedRules, \"Equations\" -> False|>. \
+Fails for non-critical congestion systems where Alpha != 1 on any edge. \
+Options: \"Timeout\" (default Infinity).";
+
+findInstanceSystem::noncritical =
+"findInstanceSystem supports only critical congestion systems with Alpha == 1 on every edge.";
+
 Begin["`Private`"];
 
 trackedVarQ::usage =
@@ -100,6 +113,16 @@ branchToRules::usage =
 parseReduceResult::usage =
 "parseReduceResult[reduced, allVars] converts a Reduce result to rules or a rules-plus-residual association.";
 
+parseDNFReduceResult::usage =
+"parseDNFReduceResult[reduced, allVars] converts dnfReduce output to rules \
+or a rules-plus-residual association, harvesting equality solutions from \
+surviving DNF branches.";
+
+harvestDNFBranch::usage =
+"harvestDNFBranch[branch, allVars] solves explicit branch equalities, \
+substitutes them into residual constraints, and returns a branch association \
+or False when the branch is contradictory.";
+
 buildSolverInputs::usage =
 "buildSolverInputs[sys] collects all constraint blocks from sys, applies \
 exit-value rules, and runs accumulateLinearRules. Returns \
@@ -128,7 +151,7 @@ dnfReduceSystem[sys_?mfgSystemQ] :=
         ];
         {constraints, allVars, rulesAcc} = buildSolverInputs[sys];
         With[{reduced = dnfReduce[True, constraints]},
-            attachAccumulatedRules[parseReduceResult[reduced, allVars], rulesAcc]
+            attachAccumulatedRules[parseDNFReduceResult[reduced, allVars], rulesAcc]
         ]
     ];
 
@@ -161,6 +184,38 @@ booleanReduceSystem[sys_?mfgSystemQ, opts : OptionsPattern[]] :=
             ]
         ];
         If[returnAll, attachAccumulatedRules[#, rulesAcc] & /@ parsed, attachAccumulatedRules[First[parsed], rulesAcc]]
+    ];
+
+Options[findInstanceSystem] = {
+    "Timeout" -> Infinity
+};
+
+findInstanceSystem[sys_?mfgSystemQ, opts : OptionsPattern[]] :=
+    Module[{constraints, allVars, rulesAcc, timeout, instance},
+        timeout = OptionValue["Timeout"];
+        If[!criticalCongestionSystemQ[sys],
+            Message[findInstanceSystem::noncritical];
+            Return[Failure["findInstanceSystem", <|"Message" -> "findInstanceSystem supports only critical congestion systems with Alpha == 1 on every edge."|>], Module]
+        ];
+        {constraints, allVars, rulesAcc} = buildSolverInputs[sys];
+        If[allVars === {},
+            Return[
+                If[TrueQ[Simplify[constraints]],
+                    normalizeRules[rulesAcc],
+                    attachAccumulatedRules[<|"Rules" -> {}, "Equations" -> False|>, rulesAcc]
+                ],
+                Module
+            ]
+        ];
+        instance = TimeConstrained[
+            FindInstance[constraints, allVars, Reals],
+            timeout,
+            $Aborted
+        ];
+        If[MatchQ[instance, {{___Rule}, ___}],
+            attachAccumulatedRules[First[instance], rulesAcc],
+            attachAccumulatedRules[<|"Rules" -> {}, "Equations" -> False|>, rulesAcc]
+        ]
     ];
 
 trackedVarQ[var_] :=
@@ -396,6 +451,81 @@ parseReduceResult[reduced_, allVars_] :=
         ]
     ];
 
+harvestDNFBranch[False, _] := False;
+
+harvestDNFBranch[branch_, allVars_List] :=
+    Module[{conjuncts, eqs, sol, rules, reducedConjuncts, residual,
+            residualVars},
+        conjuncts = flattenConjuncts[branch];
+        eqs = Select[conjuncts, MatchQ[#, _Equal] &];
+        sol = If[eqs === {} || allVars === {},
+            {{}},
+            Quiet[Solve[eqs, allVars], Solve::svars]
+        ];
+        If[!ListQ[sol] || sol === {}, Return[False, Module]];
+        rules = Cases[First[sol],
+            r : Rule[v_, rhs_] /;
+                MemberQ[allVars, v] &&
+                FreeQ[rhs, Alternatives @@ allVars] :> r
+        ];
+        reducedConjuncts = Simplify /@ (conjuncts /. rules);
+        reducedConjuncts = DeleteCases[reducedConjuncts, True];
+        residual = If[reducedConjuncts === {}, True, And @@ reducedConjuncts];
+        residual = Simplify[residual];
+        If[residual === False, Return[False, Module]];
+        residualVars = Select[
+            Variables[residual /. {Equal -> List, Or -> List, And -> List}],
+            MemberQ[allVars, #] &
+        ];
+        If[residualVars === {},
+            If[TrueQ[Simplify[residual]],
+                <|"Rules" -> rules, "Equations" -> True|>,
+                False
+            ],
+            <|"Rules" -> rules, "Equations" -> residual|>
+        ]
+    ];
+
+parseDNFReduceResult[reduced_, allVars_List] :=
+    Module[{branches, harvested, ruleSets, common, branchExprs},
+        If[reduced === False, Return[<|"Rules" -> {}, "Equations" -> False|>, Module]];
+        branches = If[Head[reduced] === Or, List @@ reduced, {reduced}];
+        harvested = DeleteCases[harvestDNFBranch[#, allVars] & /@ branches, False];
+        If[harvested === {},
+            Return[<|"Rules" -> {}, "Equations" -> False|>, Module]
+        ];
+        If[Length[harvested] === 1,
+            With[{rules = Lookup[First[harvested], "Rules", {}],
+                  residual = Lookup[First[harvested], "Equations", True]},
+                Return[
+                    If[residual === True,
+                        rules,
+                        <|"Rules" -> rules, "Equations" -> residual|>
+                    ],
+                    Module
+                ]
+            ]
+        ];
+        ruleSets = Lookup[#, "Rules", {}] & /@ harvested;
+        common = If[ruleSets === {}, {}, Fold[Intersection, First[ruleSets], Rest[ruleSets]]];
+        branchExprs = Simplify /@ Map[
+            With[{branchRules = Complement[Lookup[#, "Rules", {}], common],
+                  residual = Lookup[#, "Equations", True]},
+                And[
+                    And @@ (Equal @@@ branchRules),
+                    residual
+                ] /. common
+            ] &,
+            harvested
+        ];
+        branchExprs = DeleteDuplicates @ DeleteCases[DeleteCases[branchExprs, False], True];
+        If[branchExprs === {},
+            common,
+            <|"Rules" -> common,
+              "Equations" -> Simplify @ If[Length[branchExprs] === 1, First[branchExprs], Or @@ branchExprs]|>
+        ]
+    ];
+
 (* --- Solution validation --- *)
 
 Options[isValidSystemSolution] = {
@@ -425,10 +555,10 @@ isValidSystemSolution[sys_?mfgSystemQ, sol_, OptionsPattern[]] :=
         rules        = If[kind === "Determined", sol, Lookup[sol, "Rules", {}]];
         ruleExitVals = Normal @ systemData[sys, "RuleExitValues"];
 
-        (* For underdetermined: fail fast if residual equations are False *)
+        (* For underdetermined: fail fast if residual equations are inconsistent. *)
         If[kind === "Underdetermined",
             With[{eqs = Lookup[sol, "Equations", True]},
-                If[eqs === False,
+                If[eqs === False || TrueQ[Quiet @ Check[Simplify[eqs] === False, False]],
                     Return[If[returnReportQ,
                         <|"Valid" -> False, "Kind" -> kind,
                           "Reason" -> "InconsistentResidual", "BlockChecks" -> <||>|>,
@@ -494,41 +624,70 @@ checkBlock[expr_Or, tol_] :=
     ];
 
 checkBlock[lhs_ == rhs_, tol_] :=
-    With[{d = Quiet @ Check[N[lhs - rhs], $Failed]},
+    With[{s = Quiet @ Check[Simplify[lhs == rhs], $Failed]},
         Which[
-            d === $Failed,     Indeterminate,
-            NumericQ[d],       Abs[d] <= tol,
-            True,              With[{s = Quiet @ Check[Simplify[lhs == rhs], $Failed]},
-                                   Which[s === True, True, s === False, False, True, Indeterminate]]
+            s === True,  True,
+            s === False, False,
+            True,        With[{d = Quiet @ Check[N[lhs - rhs], $Failed]},
+                             Which[
+                                 d === $Failed, Indeterminate,
+                                 NumericQ[d],   Abs[d] <= tol,
+                                 True,          Indeterminate
+                             ]]
         ]
     ];
 
 checkBlock[lhs_ >= rhs_, tol_] :=
-    With[{d = Quiet @ Check[N[lhs - rhs], $Failed]},
-        Which[d === $Failed, Indeterminate, NumericQ[d], d >= -tol, True, Indeterminate]
+    With[{s = Quiet @ Check[Simplify[lhs >= rhs], $Failed]},
+        Which[
+            s === True,  True,
+            s === False, False,
+            True,        With[{d = Quiet @ Check[N[lhs - rhs], $Failed]},
+                             Which[d === $Failed, Indeterminate, NumericQ[d], d >= -tol, True, Indeterminate]]
+        ]
     ];
 
 checkBlock[lhs_ <= rhs_, tol_] :=
-    With[{d = Quiet @ Check[N[rhs - lhs], $Failed]},
-        Which[d === $Failed, Indeterminate, NumericQ[d], d >= -tol, True, Indeterminate]
+    With[{s = Quiet @ Check[Simplify[lhs <= rhs], $Failed]},
+        Which[
+            s === True,  True,
+            s === False, False,
+            True,        With[{d = Quiet @ Check[N[rhs - lhs], $Failed]},
+                             Which[d === $Failed, Indeterminate, NumericQ[d], d >= -tol, True, Indeterminate]]
+        ]
     ];
 
 checkBlock[lhs_ > rhs_, tol_] :=
-    With[{d = Quiet @ Check[N[lhs - rhs], $Failed]},
-        Which[d === $Failed, Indeterminate, NumericQ[d], d > tol, True, Indeterminate]
+    With[{s = Quiet @ Check[Simplify[lhs > rhs], $Failed]},
+        Which[
+            s === True,  True,
+            s === False, False,
+            True,        With[{d = Quiet @ Check[N[lhs - rhs], $Failed]},
+                             Which[d === $Failed, Indeterminate, NumericQ[d], d > tol, True, Indeterminate]]
+        ]
     ];
 
 checkBlock[lhs_ < rhs_, tol_] :=
-    With[{d = Quiet @ Check[N[rhs - lhs], $Failed]},
-        Which[d === $Failed, Indeterminate, NumericQ[d], d > tol, True, Indeterminate]
+    With[{s = Quiet @ Check[Simplify[lhs < rhs], $Failed]},
+        Which[
+            s === True,  True,
+            s === False, False,
+            True,        With[{d = Quiet @ Check[N[rhs - lhs], $Failed]},
+                             Which[d === $Failed, Indeterminate, NumericQ[d], d > tol, True, Indeterminate]]
+        ]
     ];
 
 checkBlock[Inequality[a_, Less, b_, Less, c_], tol_] :=
-    With[{d1 = Quiet @ Check[N[b - a], $Failed], d2 = Quiet @ Check[N[c - b], $Failed]},
+    With[{s = Quiet @ Check[Simplify[a < b < c], $Failed]},
         Which[
-            d1 === $Failed || d2 === $Failed, Indeterminate,
-            NumericQ[d1] && NumericQ[d2],     d1 > tol && d2 > tol,
-            True,                             Indeterminate
+            s === True,  True,
+            s === False, False,
+            True,        With[{d1 = Quiet @ Check[N[b - a], $Failed], d2 = Quiet @ Check[N[c - b], $Failed]},
+                             Which[
+                                 d1 === $Failed || d2 === $Failed, Indeterminate,
+                                 NumericQ[d1] && NumericQ[d2],     d1 > tol && d2 > tol,
+                                 True,                             Indeterminate
+                             ]]
         ]
     ];
 

--- a/MFGraphs/systemTools.wl
+++ b/MFGraphs/systemTools.wl
@@ -435,7 +435,10 @@ buildHamiltonianData[s_?scenarioQ, topology_Association, flowData_mfgFlowData] :
 
         costCurrents = Table[Symbol["systemTools`Private`cpc" <> ToString[k]], {k, 1, EdgeCount[topology["Graph"]]}];
         eqGeneral = And @@ MapThread[
-            Equal[#1, If[alphaAtEdge[halfPairs[[#3]]] === 1, 0, #2]] &,
+            With[{edge = halfPairs[[#3]],
+                  eq = Equal[#1, If[alphaAtEdge[halfPairs[[#3]]] === 1, 0, #2]]},
+                (j @@ edge + j @@ Reverse[edge] == 0) || eq
+            ] &,
             {nlhs, costCurrents, Range[Length[halfPairs]]}
         ];
         costCurrents = AssociationThread[costCurrents, nrhs];

--- a/docs/planning/example7_findinstance_dnf_solver_behavior.md
+++ b/docs/planning/example7_findinstance_dnf_solver_behavior.md
@@ -1,0 +1,184 @@
+# Example 7 Solver Behavior: `dnfReduceSystem` vs `findInstanceSystem`
+
+Date: 2026-04-27
+
+This note records an exploratory comparison after adding `findInstanceSystem`.
+The goal was to compare solver behavior on edge flows only, ignoring transition
+flows, and to identify which `u` values differ when `findInstanceSystem`
+chooses a concrete feasible point.
+
+Update 2026-04-28: `dnfReduceSystem` now harvests equality solutions from the
+surviving final DNF branches. A later 2026-04-28 change relaxes each physical
+edge Hamiltonian equation behind a zero-total-flow alternative:
+
+```wolfram
+j[a, b] + j[b, a] == 0 || j[a, b] - j[b, a] + u[a, b] - u[b, a] == 0
+```
+
+That means current `dnfReduceSystem` may return branch-family associations where
+earlier runs returned one concrete harvested branch.
+
+## Benchmark
+
+Environment: Wolfram 14.3.0 for Mac OS X ARM, local `wolframscript`.
+Timeout per solve: 60 seconds.
+
+| Case | `dnfReduceSystem` repeated | `findInstanceSystem` repeated | Validity |
+|---|---:|---:|---|
+| `chain-2v` | 0.60 ms | 0.59 ms | both valid |
+| `chain-3v-1exit` | 0.92 ms | 0.90 ms | both valid |
+| `chain-3v-2exit` | 1.88 ms | 2.51 ms | both valid |
+| `example-7` | 3.52 ms | 21.61 ms | both valid |
+| `chain-5v-1exit` | 1.74 ms | 1.71 ms | both valid |
+| `example-12` | 258.69 ms | timed out at 60s | `dnfReduceSystem` valid; `findInstanceSystem` timed out |
+
+Conclusion from this run: `findInstanceSystem` is useful as a concretizer/oracle
+for one feasible point, but `dnfReduceSystem` is faster on branching examples.
+After the 2026-04-28 harvesting fix, `dnfReduceSystem` also returns concrete
+rules when the final DNF residual has a unique feasible branch.
+
+## Edge-Flow Comparison
+
+Transition flows `j[_, _, _]` were intentionally ignored. Edge flows were
+compared using `systemData[sys, "Js"]`.
+
+Before the harvesting fix, all non-timeout cases except `example-7` had matching
+returned edge-flow values. For `example-7`, the difference was not a
+contradiction: `dnfReduceSystem` left `j[2, 4]` free, while
+`findInstanceSystem` chose:
+
+```wolfram
+j[2, 4] -> 45
+j[2, 3] -> 55
+j[3, auxExit3] -> 55
+j[4, auxExit4] -> 45
+```
+
+The corresponding `dnfReduceSystem` parametric expressions are:
+
+```wolfram
+j[3, auxExit3] -> 100 - j[2, 4]
+j[4, auxExit4] -> j[2, 4]
+j[2, 3] -> 100 - j[2, 4]
+```
+
+Current behavior after zero-flow Hamiltonian relaxation: `dnfReduceSystem`
+returns the common parametric rules and a residual branch family. The concrete
+values above are still one branch, but no longer the only branch represented by
+the public result.
+
+## Flow Oracle Check
+
+An oracle check asserted the edge-flow values chosen by `findInstanceSystem`
+back into the accumulated full system and called `FindInstance` for feasibility.
+
+| Case | Flow assignments | Oracle status |
+|---|---:|---|
+| `chain-2v` | 4 | feasible |
+| `chain-3v-1exit` | 6 | feasible |
+| `chain-3v-2exit` | 7 | feasible |
+| `example-7` | 9 | feasible |
+| `chain-5v-1exit` | 10 | feasible |
+| `example-12` | 0 | skipped because `findInstanceSystem` timed out |
+
+This supports interpreting the `example-7` flow difference as one feasible
+instantiation of the `dnfReduceSystem` family, not as a solver disagreement.
+
+## Different `u` Values
+
+For `chain-3v-2exit`, differences are due to unassigned symbolic values in the
+DNF result:
+
+```wolfram
+u[2, 3]: dnf unassigned, findInstanceSystem -> 0
+u[3, 2]: dnf -> u[2, 3], findInstanceSystem -> 0
+```
+
+Before the harvesting fix, `dnfReduceSystem` left several `example-7` value
+variables symbolic, while `findInstanceSystem` chose the following concrete
+values:
+
+```wolfram
+u[auxEntry1, 1]: dnf -> 100 + u[1, 2], findInstanceSystem -> 155
+u[1, 2]:        dnf unassigned,       findInstanceSystem -> 55
+u[2, 3]:        dnf unassigned,       findInstanceSystem -> 0
+u[2, 4]:        dnf unassigned,       findInstanceSystem -> 10
+u[2, 1]:        dnf -> 100 + u[1, 2], findInstanceSystem -> 155
+u[3, 2]:        dnf -> 100 - j[2, 4] + u[2, 3], findInstanceSystem -> 55
+u[4, 2]:        dnf -> j[2, 4] + u[2, 4],       findInstanceSystem -> 55
+```
+
+Substituting the concrete choices
+
+```wolfram
+j[2, 4] -> 45
+u[1, 2] -> 55
+u[2, 3] -> 0
+u[2, 4] -> 10
+```
+
+into the DNF parametric expressions reproduces the `findInstanceSystem` values.
+
+Current behavior after zero-flow Hamiltonian relaxation: `dnfReduceSystem`
+keeps the concrete `u` values above inside one residual branch instead of
+collapsing the whole result to that branch.
+
+## Chain-3v-2exit Underdetermined Residual Check
+
+Run on 2026-04-28:
+
+```wolfram
+s = gridScenario[{3}, {{1, 5}}, {{2, 10}, {3, 0}}];
+sys = makeSystem[s];
+```
+
+This is the `chain-3v-2exit` shape with inflow smaller than the exit value at
+vertex 2 and zero exit value at vertex 3.
+
+The raw DNF result, before final branch harvesting, is still useful for studying
+underdetermined solver behavior:
+
+```wolfram
+rulesAcc:
+  j[2, "auxExit2"] -> 5 - j[2, 3]
+  j[3, "auxExit3"] -> j[2, 3]
+  u[2, 1] -> 5 + u[1, 2]
+  u[3, 2] -> j[2, 3] + u[2, 3]
+  u["auxEntry1", 1] -> 5 + u[1, 2]
+
+remaining vars:
+  {j[2, 3], u[1, 2], u[2, 3]}
+
+raw DNF:
+  (5 - j[2, 3] == 0 && 5 == 5 + u[2, 3] && -5 + u[1, 2] == 0)
+  ||
+  (10 <= u[2, 3] && u[2, 3] <= 10 && u[2, 3] <= 10 &&
+   u[2, 3] <= 0 && u[1, 2] == 10 && j[2, 3] == 0)
+```
+
+Using the old `parseReduceResult` path on that raw DNF keeps the result as an
+underdetermined association with the residual above. The current public
+`dnfReduceSystem` discards the contradictory second branch and harvests the
+first branch into concrete rules:
+
+```wolfram
+j[2, "auxExit2"] -> 0
+j[3, "auxExit3"] -> 5
+j[2, 3] -> 5
+u[1, 2] -> 5
+u[2, 3] -> 0
+u[3, 2] -> 5
+```
+
+`findInstanceSystem` returns one concrete branch. After the zero-flow Hamiltonian
+relaxation, public `dnfReduceSystem` preserves multiple branches for this case:
+
+```wolfram
+(j[2, "auxExit2"] == 5 && u[2, 1] == 15 && u[3, 2] == 10 && u[2, 3] <= 0)
+||
+(j[2, "auxExit2"] == 0 && u[2, 1] == 10 && u[2, 3] == 0 && u[3, 2] == 5)
+```
+
+The first branch is the newly admitted zero-flow-edge branch where all mass exits
+at vertex 2 and `u[2,3]` is bounded but not pinned by the edge equation. The
+second branch is the previous all-to-vertex-3 solution.


### PR DESCRIPTION
## Summary
- relax physical edge Hamiltonian equations behind a zero-total-flow alternative
- preserve DNF branch families and reject inconsistent residuals
- add FindInstance solver coverage and branch-behavior tests
- save solver behavior notes for example 7 and related chain cases

## Validation
- wolframscript -file Scripts/RunSingleTest.wls MFGraphs/Tests/reduce-system.mt
- wolframscript -file Scripts/RunTests.wls fast
- example-12 with 2000 ms cap: dnfReduceSystem completed in ~1838 ms; findInstanceSystem timed out