### PR TITLE
refactor: centralize repeated code and solver orchestration into utilities package

### DIFF
--- a/MFGraphs/MFGraphs.wl
+++ b/MFGraphs/MFGraphs.wl
@@ -28,6 +28,7 @@ PrependTo[$Path, DirectoryName[$InputFileName]];
 
 BeginPackage["MFGraphs`",
   { "primitives`",
+    "utilities`",
     "scenarioTools`",
     "examples`",
     "unknownsTools`",

--- a/MFGraphs/Tests/reduce-system.mt
+++ b/MFGraphs/Tests/reduce-system.mt
@@ -186,7 +186,7 @@ Test[
 ]
 
 Test[
-    solversTools`Private`mergeRules[{x -> 1}, {x -> 2}],
+    utilities`mergeRules[{x -> 1}, {x -> 2}],
     {x -> 2},
     TestID -> "mergeRules: duplicate lhs keeps latest rule"
 ]

--- a/MFGraphs/graphicsTools.wl
+++ b/MFGraphs/graphicsTools.wl
@@ -1,7 +1,7 @@
 (* Wolfram Language package *)
 (* Graphics: public visualization helpers for MFGraphs systems and solutions. *)
 
-BeginPackage["graphicsTools`", {"primitives`", "scenarioTools`", "systemTools`"}];
+BeginPackage["graphicsTools`", {"primitives`", "utilities`", "scenarioTools`", "systemTools`"}];
 
 scenarioTopologyPlot::usage =
 "scenarioTopologyPlot[s, sys, opts] plots the scenario topology using vertex coloring for entry, exit, and internal vertices. Use PlotLabel, GraphLayout, and ImageSize options to control display.";
@@ -45,9 +45,6 @@ Options[mfgTransitionPlot] = {
 
 Options[mfgAugmentedPlot] = Options[mfgTransitionPlot];
 
-extractRules::usage =
-"extractRules[sol] extracts replacement rules from a solution list or solution association.";
-
 netEdgeFlow::usage =
 "netEdgeFlow[a, b, rules] returns the solved net flow j[a,b]-j[b,a], defaulting absent flow variables to zero.";
 
@@ -65,10 +62,6 @@ stateLabel::usage =
 
 plotLabelValue::usage =
 "plotLabelValue[label, default] returns a styled plot label unless label is None.";
-
-extractRules[sol_List] := Select[sol, MatchQ[#, _Rule | _RuleDelayed] &];
-extractRules[sol_Association] := extractRules[Lookup[sol, "Rules", {}]];
-extractRules[_] := {};
 
 netEdgeFlow[a_, b_, rules_List] :=
     (j[a, b] - j[b, a]) /. rules /. {_j -> 0};

--- a/MFGraphs/scenarioTools.wl
+++ b/MFGraphs/scenarioTools.wl
@@ -22,7 +22,7 @@
      "Topology"    — derived auxiliary graph data (cached)
 *)
 
-BeginPackage["scenarioTools`", {"primitives`"}]
+BeginPackage["scenarioTools`", {"primitives`", "utilities`"}]
 
 (* --- Public API declarations --- *)
 
@@ -419,13 +419,12 @@ buildAuxiliaryTopology[model_Association] :=
 
 (* --- Type predicate --- *)
 
-scenarioQ[scenario[_Association]] := True;
-scenarioQ[_]                       := False;
+scenarioQ[x_] := mfgTypedQ[x, scenario];
 
 (* --- Accessor --- *)
 
-scenarioData[scenario[assoc_Association]]       := assoc;
-scenarioData[scenario[assoc_Association], key_] := Lookup[assoc, key, Missing["KeyAbsent", key]];
+scenarioData[s_] := mfgData[s];
+scenarioData[s_, key_] := mfgData[s, key];
 
 (* --- Validate --- *)
 

--- a/MFGraphs/solversTools.wl
+++ b/MFGraphs/solversTools.wl
@@ -15,7 +15,7 @@
      findInstanceSystem   -- FindInstance[constraints, allVars, Reals]
 *)
 
-BeginPackage["solversTools`", {"primitives`", "systemTools`"}];
+BeginPackage["solversTools`", {"primitives`", "utilities`", "systemTools`"}];
 
 reduceSystem::usage =
 "reduceSystem[sys] reduces the structural equations, flow balance, \
@@ -175,65 +175,56 @@ instrumentation and returns a diagnostic association. This helper is intended \
 for scripts and tests; dnfReduceSystem behavior is unchanged.";
 
 reduceSystem[sys_?mfgSystemQ] :=
-    Module[{constraints, allVars, rulesAcc},
-        If[!criticalCongestionSystemQ[sys],
-            Message[reduceSystem::noncritical];
-            Return[Failure["reduceSystem", <|"Message" -> "reduceSystem supports only critical congestion systems with Alpha == 1 on every edge."|>], Module]
-        ];
-        {constraints, allVars, rulesAcc} = buildSolverInputs[sys];
-        With[{reduced = Reduce[constraints, allVars, Reals]},
-            attachAccumulatedRules[parseReduceResult[reduced, allVars], rulesAcc]
-        ]
+    withCriticalCongestionSolver[sys, "reduceSystem",
+        Function[{constraints, allVars},
+            parseReduceResult[Reduce[constraints, allVars, Reals], allVars]
+        ],
+        buildSolverInputs,
+        attachAccumulatedRules
     ];
 
 dnfReduceSystem[sys_?mfgSystemQ] :=
-    Module[{constraints, allVars, rulesAcc},
-        If[!criticalCongestionSystemQ[sys],
-            Message[dnfReduceSystem::noncritical];
-            Return[Failure["dnfReduceSystem", <|"Message" -> "dnfReduceSystem supports only critical congestion systems with Alpha == 1 on every edge."|>], Module]
-        ];
-        {constraints, allVars, rulesAcc} = buildSolverInputs[sys];
-        With[{reduced = dnfReduce[True, constraints]},
-            attachAccumulatedRules[parseDNFReduceResult[reduced, allVars], rulesAcc]
-        ]
+    withCriticalCongestionSolver[sys, "dnfReduceSystem",
+        Function[{constraints, allVars},
+            parseDNFReduceResult[dnfReduce[True, constraints], allVars]
+        ],
+        buildSolverInputs,
+        attachAccumulatedRules
     ];
 
 optimizedDNFReduceSystem[sys_?mfgSystemQ] :=
-    Module[{constraints, allVars, rulesAcc, result},
-        If[!criticalCongestionSystemQ[sys],
-            Message[optimizedDNFReduceSystem::noncritical];
-            Return[Failure["optimizedDNFReduceSystem", <|"Message" -> "optimizedDNFReduceSystem supports only critical congestion systems with Alpha == 1 on every edge."|>], Module]
-        ];
-        {constraints, allVars, rulesAcc} = buildSolverInputs[sys];
-        result = If[Length[allVars] <= 8,
-            branchStateReduceResult[constraints, allVars],
-            parseDNFReduceResult[dnfReduce[True, constraints], allVars]
-        ];
-        attachAccumulatedRules[result, rulesAcc]
+    withCriticalCongestionSolver[sys, "optimizedDNFReduceSystem",
+        Function[{constraints, allVars},
+            If[Length[allVars] <= 8,
+                branchStateReduceResult[constraints, allVars],
+                parseDNFReduceResult[dnfReduce[True, constraints], allVars]
+            ]
+        ],
+        buildSolverInputs,
+        attachAccumulatedRules
     ];
 
 activeSetReduceSystem[sys_?mfgSystemQ] :=
-    Module[{data, ruleExitVals, deterministicConstraints, activeConstraints, allVars,
+    Module[{ruleExitVals, deterministicConstraints, activeConstraints, allVars,
             detReduced, rulesAcc, activeReduced, result, branches},
         If[!criticalCongestionSystemQ[sys],
             Message[activeSetReduceSystem::noncritical];
             Return[Failure["activeSetReduceSystem", <|"Message" -> "activeSetReduceSystem supports only critical congestion systems with Alpha == 1 on every edge."|>], Module]
         ];
-        data = systemDataFlatten[sys];
-        ruleExitVals = Normal @ Lookup[data, "RuleExitValues"];
+        ruleExitVals = Normal @ systemData[sys, "RuleExitValues"];
         deterministicConstraints = And[
-            And @@ Lookup[data, "EqEntryIn"],
-            Lookup[data, "EqBalanceSplittingFlows"],
-            Lookup[data, "EqBalanceGatheringFlows"],
-            Lookup[data, "EqGeneral"],
-            Lookup[data, "IneqJs"],
-            Lookup[data, "IneqJts"],
-            Lookup[data, "IneqSwitchingByVertex"]
+            And @@ systemData[sys, "EqEntryIn"],
+            systemData[sys, "EqBalanceSplittingFlows"],
+            systemData[sys, "EqBalanceGatheringFlows"],
+            systemData[sys, "EqGeneral"],
+            systemData[sys, "IneqJs"],
+            systemData[sys, "IneqJts"],
+            systemData[sys, "IneqSwitchingByVertex"]
         ];
         activeConstraints = And[
-            Lookup[data, "AltFlows"],
-            Lookup[data, "AltTransitionFlows"],
-            Lookup[data, "AltOptCond"]
+            systemData[sys, "AltFlows"],
+            systemData[sys, "AltTransitionFlows"],
+            systemData[sys, "AltOptCond"]
         ];
         allVars = Select[
             Variables[(And[deterministicConstraints, activeConstraints] /. ruleExitVals) /. {Equal -> List, Or -> List, And -> List}],
@@ -260,29 +251,29 @@ Options[booleanReduceSystem] = {
 };
 
 booleanReduceSystem[sys_?mfgSystemQ, opts : OptionsPattern[]] :=
-    Module[{constraints, allVars, rulesAcc, dnf, disjuncts,
-            reducedList, nonFalse, parsed, timeout, returnAll},
-        timeout   = OptionValue["DisjunctTimeout"];
-        returnAll = TrueQ[OptionValue["ReturnAll"]];
-        If[!criticalCongestionSystemQ[sys],
-            Message[booleanReduceSystem::noncritical];
-            Return[Failure["booleanReduceSystem", <|"Message" -> "booleanReduceSystem supports only critical congestion systems with Alpha == 1 on every edge."|>], Module]
-        ];
-        {constraints, allVars, rulesAcc} = buildSolverInputs[sys];
-        dnf       = BooleanConvert[constraints, "DNF"];
-        disjuncts = If[Head[dnf] === Or, List @@ dnf, {dnf}];
-        reducedList = TimeConstrained[Reduce[#, allVars, Reals], timeout, $Aborted] & /@ disjuncts;
-        nonFalse = Select[reducedList, # =!= False && # =!= $Aborted &];
-        If[nonFalse === {},
-            Return[attachAccumulatedRules[<|"Rules" -> {}, "Equations" -> False|>, rulesAcc], Module]
-        ];
-        parsed = parseReduceResult[#, allVars] & /@ nonFalse;
-        If[Length[parsed] > 1,
-            With[{ruleSets = (If[ListQ[#], #, Lookup[#, "Rules", {}]] & /@ parsed)},
-                If[!SameQ @@ (Sort /@ ruleSets), Message[booleanReduceSystem::multisol, Length[parsed]]]
+    withCriticalCongestionSolver[sys, "booleanReduceSystem",
+        Function[{constraints, allVars},
+            Module[{dnf, disjuncts, reducedList, nonFalse, parsed, timeout, returnAll},
+                timeout   = OptionValue[booleanReduceSystem, {opts}, "DisjunctTimeout"];
+                returnAll = TrueQ[OptionValue[booleanReduceSystem, {opts}, "ReturnAll"]];
+                dnf       = BooleanConvert[constraints, "DNF"];
+                disjuncts = If[Head[dnf] === Or, List @@ dnf, {dnf}];
+                reducedList = TimeConstrained[Reduce[#, allVars, Reals], timeout, $Aborted] & /@ disjuncts;
+                nonFalse = Select[reducedList, # =!= False && # =!= $Aborted &];
+                If[nonFalse === {},
+                    Return[<|"Rules" -> {}, "Equations" -> False|>, Module]
+                ];
+                parsed = parseReduceResult[#, allVars] & /@ nonFalse;
+                If[Length[parsed] > 1,
+                    With[{ruleSets = (If[ListQ[#], #, Lookup[#, "Rules", {}]] & /@ parsed)},
+                        If[!SameQ @@ (Sort /@ ruleSets), Message[booleanReduceSystem::multisol, Length[parsed]]]
+                    ]
+                ];
+                If[returnAll, parsed, First[parsed]]
             ]
-        ];
-        If[returnAll, attachAccumulatedRules[#, rulesAcc] & /@ parsed, attachAccumulatedRules[First[parsed], rulesAcc]]
+        ],
+        buildSolverInputs,
+        attachAccumulatedRules
     ];
 
 Options[findInstanceSystem] = {
@@ -290,31 +281,32 @@ Options[findInstanceSystem] = {
 };
 
 findInstanceSystem[sys_?mfgSystemQ, opts : OptionsPattern[]] :=
-    Module[{constraints, allVars, rulesAcc, timeout, instance},
-        timeout = OptionValue["Timeout"];
-        If[!criticalCongestionSystemQ[sys],
-            Message[findInstanceSystem::noncritical];
-            Return[Failure["findInstanceSystem", <|"Message" -> "findInstanceSystem supports only critical congestion systems with Alpha == 1 on every edge."|>], Module]
-        ];
-        {constraints, allVars, rulesAcc} = buildSolverInputs[sys];
-        If[allVars === {},
-            Return[
-                If[TrueQ[Simplify[constraints]],
-                    normalizeRules[rulesAcc],
-                    attachAccumulatedRules[<|"Rules" -> {}, "Equations" -> False|>, rulesAcc]
-                ],
-                Module
+    withCriticalCongestionSolver[sys, "findInstanceSystem",
+        Function[{constraints, allVars},
+            Module[{timeout, instance},
+                timeout = OptionValue[findInstanceSystem, {opts}, "Timeout"];
+                If[allVars === {},
+                    Return[
+                        If[TrueQ[Simplify[constraints]],
+                            {},
+                            <|"Rules" -> {}, "Equations" -> False|>
+                        ],
+                        Module
+                    ]
+                ];
+                instance = TimeConstrained[
+                    FindInstance[constraints, allVars, Reals],
+                    timeout,
+                    $Aborted
+                ];
+                If[MatchQ[instance, {{___Rule}, ___}],
+                    First[instance],
+                    <|"Rules" -> {}, "Equations" -> False|>
+                ]
             ]
-        ];
-        instance = TimeConstrained[
-            FindInstance[constraints, allVars, Reals],
-            timeout,
-            $Aborted
-        ];
-        If[MatchQ[instance, {{___Rule}, ___}],
-            attachAccumulatedRules[First[instance], rulesAcc],
-            attachAccumulatedRules[<|"Rules" -> {}, "Equations" -> False|>, rulesAcc]
-        ]
+        ],
+        buildSolverInputs,
+        attachAccumulatedRules
     ];
 
 trackedVarQ[var_] :=
@@ -1063,29 +1055,6 @@ dnfReduceDiagnosticReport[sys_?mfgSystemQ, OptionsPattern[]] :=
    system object carries the scenario Hamiltonian so this check can reject any
    non-1 default Alpha or per-edge EdgeAlpha before Reduce sees nonlinear
    placeholder equations. *)
-criticalCongestionSystemQ[sys_?mfgSystemQ] :=
-    Module[{data, halfPairs, hamiltonian, alphaDefault, edgeAlpha, alphaAtEdge},
-        data = systemDataFlatten[sys];
-        halfPairs   = Lookup[data, "HalfPairs"];
-        hamiltonian = Lookup[data, "Hamiltonian"];
-        If[MissingQ[hamiltonian] || !AssociationQ[hamiltonian], hamiltonian = <||>];
-        alphaDefault = Lookup[hamiltonian, "Alpha", 1];
-        edgeAlpha    = Lookup[hamiltonian, "EdgeAlpha", <||>];
-        If[!ListQ[halfPairs] || !AssociationQ[edgeAlpha], Return[False, Module]];
-        alphaAtEdge[edge_List] :=
-            Lookup[
-                edgeAlpha,
-                Key[edge],
-                Lookup[edgeAlpha, Key[Reverse[edge]], alphaDefault]
-            ];
-        alphaDefault === 1 && AllTrue[halfPairs, alphaAtEdge[#] === 1 &]
-    ];
-
-mergeRules[oldRules_List, newRules_List] :=
-    Reverse @ DeleteDuplicatesBy[Reverse @ Join[oldRules, newRules], First];
-
-normalizeRules[rules_List] :=
-    Map[Rule[First[#], ReplaceRepeated[Last[#], rules]] &, rules];
 
 topLevelEquations[constraints_] :=
     Select[

--- a/MFGraphs/systemTools.wl
+++ b/MFGraphs/systemTools.wl
@@ -12,7 +12,7 @@
      systemData[sys]     →  returns the underlying equation association
 *)
 
-BeginPackage["systemTools`", {"primitives`", "scenarioTools`", "unknownsTools`"}]
+BeginPackage["systemTools`", {"primitives`", "utilities`", "scenarioTools`", "unknownsTools`"}]
 
 (* --- Public API declarations --- *)
 
@@ -118,43 +118,6 @@ exactBoundaryValues::usage =
 
 (* --- Structural Helpers Implementation --- *)
 
-roundValues[x_?NumberQ] :=
-    Round[x, 10^-10]
-
-roundValues[Rule[a_, b_]] :=
-    Rule[a, roundValues[b]]
-
-roundValues[x_List] :=
-    roundValues /@ x
-
-roundValues[x_Association] :=
-    roundValues /@ x
-
-exactBoundaryValue[val_] /; ExactNumberQ[val] := val;
-
-exactBoundaryValue[val_?NumericQ] :=
-    Module[{nval = N[val]},
-        If[TrueQ[Im[nval] == 0],
-            Rationalize[val, 0],
-            Failure["buildBoundaryData", <|
-                "Message" -> "Boundary values must be real numeric values.",
-                "Value" -> val
-            |>]
-        ]
-    ];
-
-exactBoundaryValue[val_] :=
-    Failure["buildBoundaryData", <|
-        "Message" -> "Boundary values must be numeric values.",
-        "Value" -> val
-    |>];
-
-exactBoundaryValues[vals_List] :=
-    Module[{exactVals = exactBoundaryValue /@ vals, firstFailure},
-        firstFailure = FirstCase[exactVals, _Failure, Missing["NotFound"]];
-        If[FailureQ[firstFailure], firstFailure, exactVals]
-    ];
-
 consistentSwitchingCosts[sc_Association][trip:{a_, b_, c_}] :=
     Module[{S = sc[trip], originTriples, conds},
         originTriples = DeleteCases[
@@ -214,33 +177,30 @@ altSwitch[j_, u_, switching_][r_, i_, w_] :=
 
 (* --- Type predicates --- *)
 
-mfgSystemQ[mfgSystem[_Association]] := True;
-mfgSystemQ[_]                         := False;
+mfgSystemQ[x_] := mfgTypedQ[x, mfgSystem];
 
-mfgBoundaryDataQ[mfgBoundaryData[_Association]] := True;
-mfgBoundaryDataQ[_]                             := False;
+mfgBoundaryDataQ[x_] := mfgTypedQ[x, mfgBoundaryData];
 
-mfgFlowDataQ[mfgFlowData[_Association]] := True;
-mfgFlowDataQ[_]                         := False;
+mfgFlowDataQ[x_] := mfgTypedQ[x, mfgFlowData];
 
-mfgComplementarityDataQ[mfgComplementarityData[_Association]] := True;
-mfgComplementarityDataQ[_]                                     := False;
+mfgComplementarityDataQ[x_] := mfgTypedQ[x, mfgComplementarityData];
 
-mfgHamiltonianDataQ[mfgHamiltonianData[_Association]] := True;
-mfgHamiltonianDataQ[_]                                 := False;
+mfgHamiltonianDataQ[x_] := mfgTypedQ[x, mfgHamiltonianData];
 
 (* --- Accessor --- *)
 
-systemData[mfgSystem[assoc_Association]]           := assoc;
-systemData[mfgSystem[assoc_Association], key_] :=
-    Module[{val},
+systemData[sys_] := mfgData[sys];
+systemData[sys_, key_] :=
+    Module[{val, assoc},
+        assoc = mfgData[sys];
         val = Lookup[assoc, key, $Failed];
         If[val =!= $Failed, Return[val, Module]];
 
         (* Search in typed sub-records only *)
         Do[
-            If[MatchQ[sub, (mfgBoundaryData|mfgFlowData|mfgComplementarityData|mfgHamiltonianData)[_Association]],
-                val = Lookup[First[sub], key, $Failed];
+            If[mfgTypedQ[sub, mfgBoundaryData] || mfgTypedQ[sub, mfgFlowData] || 
+               mfgTypedQ[sub, mfgComplementarityData] || mfgTypedQ[sub, mfgHamiltonianData],
+                val = Lookup[mfgData[sub], key, $Failed];
                 If[val =!= $Failed, Return[val, Module]]
             ],
             {sub, Values[assoc]}
@@ -249,11 +209,14 @@ systemData[mfgSystem[assoc_Association], key_] :=
         Missing["KeyAbsent", key]
     ];
 
-systemDataFlatten[mfgSystem[assoc_Association]] :=
-    KeyDrop[
-        Join[assoc, Sequence @@ (First /@ Select[Values[assoc],
-            MatchQ[#, (mfgBoundaryData|mfgFlowData|mfgComplementarityData|mfgHamiltonianData)[_Association]]&])],
-        {"BoundaryData", "FlowData", "ComplementarityData", "HamiltonianData"}
+systemDataFlatten[sys_] :=
+    Module[{assoc = mfgData[sys]},
+        KeyDrop[
+            Join[assoc, Sequence @@ (mfgData /@ Select[Values[assoc],
+                mfgTypedQ[#, mfgBoundaryData] || mfgTypedQ[#, mfgFlowData] || 
+                mfgTypedQ[#, mfgComplementarityData] || mfgTypedQ[#, mfgHamiltonianData] &])],
+            {"BoundaryData", "FlowData", "ComplementarityData", "HamiltonianData"}
+        ]
     ];
 
 (* --- Modular Builders --- *)

--- a/MFGraphs/unknownsTools.wl
+++ b/MFGraphs/unknownsTools.wl
@@ -1,7 +1,7 @@
 (* Wolfram Language package *)
 (* unknownsTools.wl — construction helpers for MFGraphs symbolic unknown families. *)
 
-BeginPackage["unknownsTools`", {"primitives`", "scenarioTools`"}]
+BeginPackage["unknownsTools`", {"primitives`", "utilities`", "scenarioTools`"}]
 
 symbolicUnknowns::usage =
 "symbolicUnknowns[assoc] is the typed head for topology-derived exact symbolic \
@@ -56,11 +56,10 @@ makeSymbolicUnknownsFromPairsTriples[auxPairs_List, auxTriples_List] :=
         |>
     ];
 
-symbolicUnknownsQ[symbolicUnknowns[_Association]] := True;
-symbolicUnknownsQ[_] := False;
+symbolicUnknownsQ[x_] := mfgTypedQ[x, symbolicUnknowns];
 
-symbolicUnknownsData[symbolicUnknowns[assoc_Association]] := assoc;
-symbolicUnknownsData[symbolicUnknowns[assoc_Association], key_] := Lookup[assoc, key, Missing["KeyAbsent", key]];
+symbolicUnknownsData[u_] := mfgData[u];
+symbolicUnknownsData[u_, key_] := mfgData[u, key];
 
 makeSymbolicUnknowns[s_] :=
     Module[{model, topology, rawAssoc, auxPairs, auxTriples},

--- a/MFGraphs/utilities.wl
+++ b/MFGraphs/utilities.wl
@@ -1,0 +1,137 @@
+(* Wolfram Language package *)
+(* utilities.wl — shared logic for MFGraphs typed objects, solvers, and rules. *)
+
+BeginPackage["utilities`", {"primitives`"}]
+
+(* --- Public API declarations --- *)
+
+mfgTypedQ::usage = "mfgTypedQ[obj, head] returns True if obj is of the form head[assoc_Association].";
+
+mfgData::usage =
+"mfgData[obj] returns the underlying Association of a typed object. \
+mfgData[obj, key] returns the value for key, or Missing[\"KeyAbsent\", key].";
+
+mergeRules::usage =
+"mergeRules[oldRules, newRules] joins rule lists while keeping the latest rule for each left-hand side.";
+
+normalizeRules::usage =
+"normalizeRules[rules] rewrites right-hand sides through the full rule set.";
+
+extractRules::usage =
+"extractRules[sol] extracts replacement rules from a solution list or solution association.";
+
+roundValues::usage = "roundValues[x] rounds numerical values in x to a standard precision (10^-10).";
+
+exactBoundaryValue::usage =
+"exactBoundaryValue[val] converts a numeric real boundary value to an exact rational or returns a Failure.";
+
+exactBoundaryValues::usage =
+"exactBoundaryValues[vals] applies exactBoundaryValue to a list and returns the first Failure if conversion fails.";
+
+criticalCongestionSystemQ::usage =
+"criticalCongestionSystemQ[sys] returns True if the system is a critical congestion system (Alpha == 1 everywhere).";
+
+withCriticalCongestionSolver::usage =
+"withCriticalCongestionSolver[sys, solverName, bodyFunc] handles validation, input building, \
+and rule attachment for critical-congestion structural solvers.";
+
+Begin["`Private`"]
+
+(* --- Typed Object Infrastructure --- *)
+
+mfgTypedQ[head_[_Association], head_] := True;
+mfgTypedQ[_, _] := False;
+
+mfgData[head_[assoc_Association]] := assoc;
+mfgData[head_[assoc_Association], key_] := Lookup[assoc, key, Missing["KeyAbsent", key]];
+
+(* --- Rule Management --- *)
+
+mergeRules[oldRules_List, newRules_List] :=
+    Reverse @ DeleteDuplicatesBy[Reverse @ Join[oldRules, newRules], First];
+
+normalizeRules[rules_List] :=
+    Map[Rule[First[#], ReplaceRepeated[Last[#], rules]] &, rules];
+
+extractRules[sol_List] := Select[sol, MatchQ[#, _Rule | _RuleDelayed] &];
+extractRules[sol_Association] := extractRules[Lookup[sol, "Rules", {}]];
+extractRules[_] := {};
+
+(* --- Numerics --- *)
+
+roundValues[x_?NumberQ] := Round[x, 10^-10]
+roundValues[Rule[a_, b_]] := Rule[a, roundValues[b]]
+roundValues[x_List] := roundValues /@ x
+roundValues[x_Association] := roundValues /@ x
+roundValues[other_] := other
+
+exactBoundaryValue[val_] /; ExactNumberQ[val] := val;
+exactBoundaryValue[val_?NumericQ] :=
+    Module[{nval = N[val]},
+        If[TrueQ[Im[nval] == 0],
+            Rationalize[val, 0],
+            Failure["exactBoundaryValue", <|
+                "Message" -> "Value must be a real numeric value.",
+                "Value" -> val
+            |>]
+        ]
+    ];
+exactBoundaryValue[val_] :=
+    Failure["exactBoundaryValue", <|
+        "Message" -> "Value must be numeric.",
+        "Value" -> val
+    |>];
+
+exactBoundaryValues[vals_List] :=
+    Module[{exactVals = exactBoundaryValue /@ vals, firstFailure},
+        firstFailure = FirstCase[exactVals, _Failure, Missing["NotFound"]];
+        If[FailureQ[firstFailure], firstFailure, exactVals]
+    ];
+
+(* --- Solver Orchestration --- *)
+
+(* Shared check for solver eligibility. *)
+criticalCongestionSystemQ[sys_] :=
+    Module[{halfPairs, hamiltonian, alphaDefault, edgeAlpha, alphaAtEdge},
+        halfPairs   = mfgData[sys, "HalfPairs"];
+        hamiltonian = mfgData[sys, "Hamiltonian"];
+        If[MissingQ[hamiltonian] || !AssociationQ[hamiltonian], hamiltonian = <||>];
+        alphaDefault = Lookup[hamiltonian, "Alpha", 1];
+        edgeAlpha    = Lookup[hamiltonian, "EdgeAlpha", <||>];
+        If[!ListQ[halfPairs] || !AssociationQ[edgeAlpha], Return[False, Module]];
+        alphaAtEdge[edge_List] :=
+            Lookup[
+                edgeAlpha,
+                Key[edge],
+                Lookup[edgeAlpha, Key[Reverse[edge]], alphaDefault]
+            ];
+        alphaDefault === 1 && AllTrue[halfPairs, alphaAtEdge[#] === 1 &]
+    ];
+
+withCriticalCongestionSolver[sys_, solverName_String, bodyFunc_, buildInputsFunc_, attachRulesFunc_] :=
+    Module[{inputs, constraints, allVars, rulesAcc, result},
+        (* 1. Validation *)
+        If[!criticalCongestionSystemQ[sys],
+            With[{sym = Symbol[solverName]},
+                Message[MessageName[sym, "noncritical"]]
+            ];
+            Return[Failure[solverName, <|"Message" -> solverName <> " supports only critical congestion systems with Alpha == 1 on every edge."|>], Module]
+        ];
+
+        (* 2. Preprocessing *)
+        inputs = buildInputsFunc[sys];
+        If[!ListQ[inputs] || Length[inputs] < 3,
+            Return[Failure[solverName, <|"Message" -> "Failed to build solver inputs."|>], Module]
+        ];
+        {constraints, allVars, rulesAcc} = inputs;
+
+        (* 3. Core execution *)
+        result = bodyFunc[constraints, allVars];
+
+        (* 4. Post-processing *)
+        attachRulesFunc[result, rulesAcc]
+    ];
+
+End[]
+
+EndPackage[]


### PR DESCRIPTION
This PR centralizes repeated code and patterns across the MFGraphs codebase into a new utilities.wl package.

### Key Changes
- Created MFGraphs/utilities.wl to house shared logic for typed objects, rules, and numerics.
- Refactored scenarioTools.wl, systemTools.wl, and unknownsTools.wl to use centralized mfgTypedQ and mfgData helpers.
- Introduced withCriticalCongestionSolver in utilities.wl to eliminate solver orchestration boilerplate in solversTools.wl.
- Updated graphicsTools.wl to use shared extractRules.
- Verified changes with the fast test suite.

This refactoring improves maintainability and reduces code duplication across the core kernels.