### PR TITLE
Remove Hamiltonian default duplication

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -52,7 +52,7 @@ deriveAuxPairs[topology] returns the list of all directed edge pairs {u, v} in t
 
 ## makeScenario
 
-makeScenario[assoc] constructs a typed scenario from a raw association. The input must contain a "Model" key whose value is a network topology association (required keys: "Vertices", "Adjacency", "Entries", "Exits", "Switching"). If "Model" contains a Wolfram Graph under key "Graph", missing "Vertices" and/or "Adjacency" are derived automatically. Optional keys: "Hamiltonian" (<|"Alpha" -> a, "V" -> v, "G" -> g, "EdgeAlpha" -> <|{u,v} -> a_uv, ...|>, "EdgeV" -> <|{u,v} -> v_uv, ...|>, "EdgeG" -> <|{u,v} -> g_uv, ...|>|>), "Identity" (name, version), "Benchmark" (tier, timeout), "Visualization", "Inheritance". Default Hamiltonian is Alpha=1 and V=0 on all edges, with G[z]=-1/z (overridable globally and per edge). V/G/EdgeV/EdgeG are validated and preserved for future density and visualization work, but current system construction applies only Alpha/EdgeAlpha. Boundary values must be numeric; switching-cost values must be numeric or Infinity. Returns a scenario[...] object on success or Failure[...] on error.
+makeScenario[assoc] constructs a typed scenario from a raw association. The input must contain a "Model" key whose value is a network topology association (required keys: "Vertices", "Adjacency", "Entries", "Exits", "Switching"). If "Model" contains a Wolfram Graph under key "Graph", missing "Vertices" and/or "Adjacency" are derived automatically. Optional keys: "Hamiltonian" (<|"Alpha" -> a, "V" -> v, "G" -> g, "EdgeAlpha" -> <|{u,v} -> a_uv, ...|>, "EdgeV" -> <|{u,v} -> v_uv, ...|>, "EdgeG" -> <|{u,v} -> g_uv, ...|>|>), "Identity" (name, version), "Benchmark" (tier, timeout), "Visualization", "Inheritance". Default Hamiltonian is Alpha=1 and V=-1 on all edges, with G[z]=-1/z (overridable globally and per edge). V/G/EdgeV/EdgeG are validated and preserved for future density and visualization work, but current system construction applies only Alpha/EdgeAlpha. Boundary values must be numeric; switching-cost values must be numeric or Infinity. Returns a scenario[...] object on success or Failure[...] on error.
 
 ## scenario
 
@@ -80,7 +80,11 @@ cycleScenario[n, entries, exits] creates a scenario on n-cycle connections, vert
 
 ## getExampleScenario
 
-getExampleScenario[n] returns a 6-arg factory Function[{entries,exits,sc,alpha,V,g}, scenario[...]] for built-in example n. Topology is baked in; all parameters are caller-supplied. getExampleScenario[n, entries, exits] calls the factory using the canonical switching costs for that case (sc=Automatic resolves via $CaseDefaultSC, defaulting to {} if none defined) and standard Hamiltonian defaults (alpha=1, V=0, g=Function[z,-1/z]). V/G are preserved on the scenario for future density and visualization work, but are not applied by current system construction. Additional optional arguments override each default in order: sc, alpha, V, g. Pass sc={} explicitly to force no switching costs. entries={{vertex,flow},...}, exits={{vertex,cost},...}, sc={{i,k,j,cost},...}. Returns $Failed for unknown keys.
+getExampleScenario[n] returns a 6-arg factory Function[{entries,exits,sc,alpha,V,g}, scenario[...]] for built-in example n. Topology is baked in; all parameters are caller-supplied. getExampleScenario[n, entries, exits] calls the factory using the canonical switching costs for that case (sc=Automatic resolves via $CaseDefaultSC, defaulting to {} if none defined) and makeScenario-supplied Hamiltonian defaults. V/G are preserved on the scenario for future density and visualization work, but are not applied by current system construction. Additional optional arguments override each default in order: sc, alpha, V, g. Pass sc={} explicitly to force no switching costs. entries={{vertex,flow},...}, exits={{vertex,cost},...}, sc={{i,k,j,cost},...}. Returns $Failed for unknown keys.
+
+## getExampleScenarioMetadata
+
+getExampleScenarioMetadata[key] returns metadata for a built-in example scenario, including source/provenance details when available. Returns $Failed for unknown keys.
 
 ## graphScenario
 
@@ -88,7 +92,7 @@ graphScenario[graph, entries, exits] creates a scenario from any WL Graph object
 
 ## gridScenario
 
-gridScenario[dims, entries, exits] creates a scenario on GridGraph[dims] connections. {n} gives a chain with vertices 1..n; {r,c} gives an r×c grid with vertices 1..r*c (row-major). Topology is symmetrized into undirected network edges before system construction. Optional: sc (switching costs, default {}), alpha, V, g (Hamiltonian defaults from $DefaultHamiltonian; V/G are preserved but not applied by current system construction).
+gridScenario[dims, entries, exits] creates a scenario on GridGraph[dims] connections. {n} gives a chain with vertices 1..n; {r,c} gives an r×c grid with vertices 1..r*c (row-major). Topology is symmetrized into undirected network edges before system construction. Optional: sc (switching costs, default {}), alpha, V, g (Hamiltonian defaults are supplied by makeScenario; V/G are preserved but not applied by current system construction).
 
 ## makeSymbolicUnknowns
 
@@ -218,10 +222,6 @@ mfgSystem[assoc] is the typed head for an MFG structural equation system. Use ma
 
 mfgSystemQ[x] returns True if x is a typed mfgSystem[assoc_Association] object, False otherwise.
 
-## roundValues
-
-roundValues[x] rounds numerical values in x to a standard precision (10^-10).
-
 ## switchingCostLookup
 
 switchingCostLookup[sc] returns a function f such that f[r, i, w] gives the switching cost for the transition from e_{r,i} to e_{i,w}, defaulting to 0 if absent.
@@ -286,17 +286,25 @@ augmentAuxiliaryGraph[sys] constructs the road-traffic augmented infrastructure 
 
 mfgAugmentedPlot[s, sys, sol, opts] plots the augmented road-traffic infrastructure graph built by augmentAuxiliaryGraph. Blue edges represent flow variables j[a,b]; red edges represent transition variables j[r,i,w]. Use PlotLabel, GraphLayout, and ImageSize options to control display.
 
+## mfgDensityPlot
+
+mfgDensityPlot[s, sys, sol, opts] plots real network edges with agent density inferred from solved signed spatial flow and the scenario Hamiltonian density equation. Use PlotLabel, GraphLayout, and ImageSize options to control display.
+
 ## mfgFlowPlot
 
 mfgFlowPlot[s, sys, sol, opts] plots a flow-only solution graph with real and auxiliary edges. Edges are displayed as directed, and edge labels show only j flow values. Use PlotLabel, GraphLayout, and ImageSize options to control display.
 
 ## mfgSolutionPlot
 
-mfgSolutionPlot[s, sys, sol, opts] plots a combined solution graph with real and auxiliary edges. Edge labels include both j and u values, and real-edge directions follow solved net flow orientation. Use PlotLabel, GraphLayout, and ImageSize options to control display.
+mfgSolutionPlot[s, sys, sol, opts] plots coordinated solution views: flows, value samples, and agent density. Use PlotLabel, GraphLayout, and ImageSize options to control display.
 
 ## mfgTransitionPlot
 
 mfgTransitionPlot[s, sys, sol, opts] plots the transition graph of the solution. Nodes are AuxPair states {r,i}->{i,w}; directed edges represent transition flows j[r,i,w]. Nodes are labeled with internal values u where available. Use PlotLabel, GraphLayout, and ImageSize options to control display.
+
+## mfgValuePlot
+
+mfgValuePlot[s, sys, sol, opts] plots real network edges with endpoint value variables u[a,b], u[b,a] and linearly interpolated interior samples at 1/4, 1/2, and 3/4. Use PlotLabel, GraphLayout, and ImageSize options to control display.
 
 ## scenarioTopologyPlot
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,8 +143,10 @@ All public solver entrypoints share a common preprocessing pipeline (`buildSolve
 
 ### Graphics (`graphicsTools`)
 - `scenarioTopologyPlot` — entry/exit/internal vertex coloring
-- `mfgSolutionPlot` — network-centric plot (j and u labels)
+- `mfgSolutionPlot` — coordinated grid of flow, value, and density views
 - `mfgFlowPlot` — flow-only network plot with directed real and auxiliary edges
+- `mfgValuePlot` — real-edge endpoint and interpolated interior value labels
+- `mfgDensityPlot` — real-edge inferred agent density labels and styling
 - `mfgTransitionPlot` — transition graph (nodes = edges, edges = j[a,b,c])
 - `augmentAuxiliaryGraph` — road-traffic graph derived from AuxPairs/AuxTriples
 - `mfgAugmentedPlot` — paper infrastructure graph (nodes = (e,v) pairs)
@@ -204,8 +206,7 @@ isValidSystemSolution[sys, sol]
 Example factory usage:
 
 ```mathematica
-f = getExampleScenario[12];
-s = f[{{1, 100}}, {{4, 0}}, {}, 1, 0, Function[z, -1/z]];
+s = getExampleScenario[12, {{1, 100}}, {{4, 0}}];
 ```
 
 ## Testing

--- a/MFGraphs/Tests/graphicsTools.mt
+++ b/MFGraphs/Tests/graphicsTools.mt
@@ -2,7 +2,8 @@
 
 Test[
     NameQ["graphicsTools`scenarioTopologyPlot"] && NameQ["graphicsTools`mfgSolutionPlot"] &&
-    NameQ["graphicsTools`mfgFlowPlot"] && NameQ["graphicsTools`mfgTransitionPlot"] &&
+    NameQ["graphicsTools`mfgFlowPlot"] && NameQ["graphicsTools`mfgValuePlot"] &&
+    NameQ["graphicsTools`mfgDensityPlot"] && NameQ["graphicsTools`mfgTransitionPlot"] &&
     NameQ["graphicsTools`mfgAugmentedPlot"] && NameQ["graphicsTools`augmentAuxiliaryGraph"],
     True,
     TestID -> "GraphicsTools: public symbols exist"
@@ -11,7 +12,8 @@ Test[
 Test[
     Module[{names, globalNames},
         names = {"scenarioTopologyPlot", "mfgSolutionPlot", "mfgFlowPlot",
-            "mfgTransitionPlot", "mfgAugmentedPlot", "augmentAuxiliaryGraph"};
+            "mfgValuePlot", "mfgDensityPlot", "mfgTransitionPlot",
+            "mfgAugmentedPlot", "augmentAuxiliaryGraph"};
         globalNames = ("Global`" <> #) & /@ names;
         Scan[If[NameQ[#], Remove[#]] &, globalNames];
         Needs["MFGraphs`"];
@@ -29,22 +31,11 @@ Test[
         topoPlot = scenarioTopologyPlot[s, sys];
         solPlot = mfgSolutionPlot[s, sys, sol];
         flowPlot = mfgFlowPlot[s, sys, sol];
-        MatchQ[topoPlot, _Graph] && MatchQ[solPlot, _Graph] && MatchQ[flowPlot, _Graph]
+        MatchQ[topoPlot, _Graph] && MatchQ[solPlot, _Graphics | _GraphicsGrid] &&
+        MatchQ[flowPlot, _Graph]
     ],
     True,
-    TestID -> "GraphicsTools: topology, solution, and flow plots return Graph"
-]
-
-Test[
-    Module[{s, sys, sol, edges},
-        s = gridScenario[{3}, {{1, 120}}, {{2, 10}, {3, 0}}];
-        sys = makeSystem[s];
-        sol = solveScenario[s];
-        edges = EdgeList[mfgSolutionPlot[s, sys, sol]];
-        MemberQ[edges, DirectedEdge[1, 2]]
-    ],
-    True,
-    TestID -> "GraphicsTools: positive j[1,2] displays as DirectedEdge[1,2]"
+    TestID -> "GraphicsTools: topology, solution grid, and flow plots return renderable expressions"
 ]
 
 Test[
@@ -57,18 +48,6 @@ Test[
     ],
     True,
     TestID -> "GraphicsTools: mfgFlowPlot positive j[1,2] displays as DirectedEdge[1,2]"
-]
-
-Test[
-    Module[{s, sys, sol, edges},
-        s = gridScenario[{3}, {{3, 120.0}}, {{1, 0.0}, {2, 10.0}}];
-        sys = makeSystem[s];
-        sol = {j[1, 2] -> 0, j[2, 1] -> 5};
-        edges = EdgeList[mfgSolutionPlot[s, sys, sol]];
-        MemberQ[edges, DirectedEdge[2, 1]]
-    ],
-    True,
-    TestID -> "GraphicsTools: negative net flow flips display direction to DirectedEdge[2,1]"
 ]
 
 Test[
@@ -148,19 +127,24 @@ Test[
                 PlotLabel -> "Solution option", ImageSize -> Medium],
             mfgFlowPlot[s, sys, sol, GraphLayout -> "LayeredDigraphEmbedding",
                 PlotLabel -> "Flow option", ImageSize -> Medium],
+            mfgValuePlot[s, sys, sol, GraphLayout -> "LayeredDigraphEmbedding",
+                PlotLabel -> "Value option", ImageSize -> Medium],
+            mfgDensityPlot[s, sys, sol, GraphLayout -> "LayeredDigraphEmbedding",
+                PlotLabel -> "Density option", ImageSize -> Medium],
             mfgTransitionPlot[s, sys, sol, GraphLayout -> "LayeredDigraphEmbedding",
                 PlotLabel -> "Transition option", ImageSize -> Medium],
             mfgAugmentedPlot[s, sys, sol, GraphLayout -> "LayeredDigraphEmbedding",
                 PlotLabel -> "Augmented option", ImageSize -> Medium]
         };
-        AllTrue[plots, MatchQ[#, _Graph] &] &&
+        MatchQ[plots[[2]], _Graphics | _GraphicsGrid] &&
+        AllTrue[Delete[plots, 2], MatchQ[#, _Graph] &] &&
         And @@ MapThread[
             !FreeQ[AbsoluteOptions[#1, PlotLabel], #2] &,
             {plots, {"Topology option", "Solution option", "Flow option",
-                "Transition option", "Augmented option"}}
+                "Value option", "Density option", "Transition option", "Augmented option"}}
         ] &&
         AllTrue[
-            plots,
+            Delete[plots, 2],
             !FreeQ[AbsoluteOptions[#, GraphLayout], "LayeredDigraphEmbedding"] &
         ]
     ],
@@ -177,10 +161,13 @@ Test[
             scenarioTopologyPlot[s, sys, PlotLabel -> None],
             mfgSolutionPlot[s, sys, sol, PlotLabel -> None],
             mfgFlowPlot[s, sys, sol, PlotLabel -> None],
+            mfgValuePlot[s, sys, sol, PlotLabel -> None],
+            mfgDensityPlot[s, sys, sol, PlotLabel -> None],
             mfgTransitionPlot[s, sys, sol, PlotLabel -> None],
             mfgAugmentedPlot[s, sys, sol, PlotLabel -> None]
         };
-        AllTrue[plots, MatchQ[#, _Graph] &] &&
+        MatchQ[plots[[2]], _Graphics | _GraphicsGrid] &&
+        AllTrue[Delete[plots, 2], MatchQ[#, _Graph] &] &&
         AllTrue[plots, FreeQ[AbsoluteOptions[#, PlotLabel], _Style] &]
     ],
     True,
@@ -213,29 +200,130 @@ Test[
 ]
 
 Test[
+    Module[{s, sys, graph, labelText},
+        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
+        sys = makeSystem[s];
+        graph = mfgValuePlot[s, sys, {u[1, 2] -> 0., u[2, 1] -> 4.}];
+        labelText = ToString[InputForm[AbsoluteOptions[graph, EdgeLabels]]];
+        MatchQ[graph, _Graph] &&
+        StringContainsQ[labelText, "1/2"] &&
+        StringContainsQ[labelText, "2."]
+    ],
+    True,
+    TestID -> "GraphicsTools: mfgValuePlot labels include interpolated midpoint values"
+]
+
+Test[
+    Module[{s, sys, graph, labelText},
+        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
+        sys = makeSystem[s];
+        graph = mfgDensityPlot[s, sys, {j[1, 2] -> 0, j[2, 1] -> 0}];
+        labelText = ToString[InputForm[AbsoluteOptions[graph, EdgeLabels]]];
+        MatchQ[graph, _Graph] && StringContainsQ[labelText, "m="] &&
+        StringContainsQ[labelText, "0."]
+    ],
+    True,
+    TestID -> "GraphicsTools: mfgDensityPlot displays zero density for zero flow"
+]
+
+Test[
+    Module[{s, sys, graph, labelText},
+        s = makeScenario[<|"Model" -> <|
+            "Vertices" -> {1, 2},
+            "Adjacency" -> {{0, 1}, {1, 0}},
+            "Entries" -> {{1, 1}},
+            "Exits" -> {{2, 0}},
+            "Switching" -> {}
+        |>|>];
+        sys = makeSystem[s];
+        graph = mfgDensityPlot[s, sys, {j[1, 2] -> 2, j[2, 1] -> 0}];
+        labelText = ToString[InputForm[AbsoluteOptions[graph, EdgeLabels]]];
+        MatchQ[graph, _Graph] && StringContainsQ[labelText, "3."]
+    ],
+    True,
+    TestID -> "GraphicsTools: mfgDensityPlot solves positive density with default Hamiltonian"
+]
+
+Test[
+    Module[{s, sys, graph, labelText},
+        s = makeScenario[<|
+            "Model" -> <|
+                "Vertices" -> {1, 2},
+                "Adjacency" -> {{0, 1}, {1, 0}},
+                "Entries" -> {{1, 1}},
+                "Exits" -> {{2, 0}},
+                "Switching" -> {}
+            |>,
+            "Hamiltonian" -> <|
+                "Alpha" -> 1,
+                "V" -> -2,
+                "G" -> Function[z, -2/z]
+            |>
+        |>];
+        sys = makeSystem[s];
+        graph = mfgDensityPlot[s, sys, {j[1, 2] -> 2, j[2, 1] -> 0}];
+        labelText = ToString[InputForm[AbsoluteOptions[graph, EdgeLabels]]];
+        MatchQ[graph, _Graph] && StringContainsQ[labelText, "2."]
+    ],
+    True,
+    TestID -> "GraphicsTools: mfgDensityPlot uses scenario Hamiltonian defaults"
+]
+
+Test[
+    Module[{s, sBroken, sys, graph, labelText},
+        s = gridScenario[{2}, {{1, 10}}, {{2, 0}}];
+        sys = makeSystem[s];
+        sBroken = scenario[Join[scenarioData[s], <|"Hamiltonian" -> <||>|>]];
+        graph = mfgDensityPlot[sBroken, sys, {j[1, 2] -> 2, j[2, 1] -> 0}];
+        labelText = ToString[InputForm[AbsoluteOptions[graph, EdgeLabels]]];
+        MatchQ[graph, _Graph] && StringContainsQ[labelText, "?"]
+    ],
+    True,
+    TestID -> "GraphicsTools: mfgDensityPlot reports malformed Hamiltonian as unknown density"
+]
+
+Test[
+    Module[{s, sys, graph, labelText},
+        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
+        sys = makeSystem[s];
+        graph = mfgDensityPlot[s, sys, <||>];
+        labelText = ToString[InputForm[AbsoluteOptions[graph, EdgeLabels]]];
+        MatchQ[graph, _Graph] && StringContainsQ[labelText, "?"]
+    ],
+    True,
+    TestID -> "GraphicsTools: mfgDensityPlot renders missing solution rules as unknown density"
+]
+
+Test[
     Module[{s, sys, sol, rules},
         s = gridScenario[{3}, {{1, 120}}, {{2, 10}, {3, 0}}];
         sys = makeSystem[s];
         sol = solveScenario[s];
         rules = Replace[sol, a_Association :> Lookup[a, "Rules", {}]];
-        MatchQ[mfgSolutionPlot[s, sys, rules], _Graph] &&
-        MatchQ[mfgFlowPlot[s, sys, rules], _Graph]
+        MatchQ[mfgSolutionPlot[s, sys, rules], _Graphics | _GraphicsGrid] &&
+        MatchQ[mfgFlowPlot[s, sys, rules], _Graph] &&
+        MatchQ[mfgValuePlot[s, sys, rules], _Graph] &&
+        MatchQ[mfgDensityPlot[s, sys, rules], _Graph]
     ],
     True,
-    TestID -> "GraphicsTools: solution and flow plots accept raw rule list solution"
+    TestID -> "GraphicsTools: solution panels accept raw rule list solution"
 ]
 
 Test[
-    Module[{s, sys, graph, flowGraph},
+    Module[{s, sys, graph, flowGraph, valueGraph, densityGraph},
         s = gridScenario[{3}, {{1, 120}}, {{2, 10}, {3, 0}}];
         sys = makeSystem[s];
         graph = mfgSolutionPlot[s, sys, <||>];
         flowGraph = mfgFlowPlot[s, sys, <||>];
-        MatchQ[graph, _Graph] && Length[EdgeList[graph]] > 0 &&
-        MatchQ[flowGraph, _Graph] && Length[EdgeList[flowGraph]] > 0
+        valueGraph = mfgValuePlot[s, sys, <||>];
+        densityGraph = mfgDensityPlot[s, sys, <||>];
+        MatchQ[graph, _Graphics | _GraphicsGrid] &&
+        MatchQ[flowGraph, _Graph] && Length[EdgeList[flowGraph]] > 0 &&
+        MatchQ[valueGraph, _Graph] && Length[EdgeList[valueGraph]] > 0 &&
+        MatchQ[densityGraph, _Graph] && Length[EdgeList[densityGraph]] > 0
     ],
     True,
-    TestID -> "GraphicsTools: solution and flow plots handle missing Rules association without failure"
+    TestID -> "GraphicsTools: solution panels handle missing Rules association without failure"
 ]
 
 Test[

--- a/MFGraphs/Tests/scenario-kernel.mt
+++ b/MFGraphs/Tests/scenario-kernel.mt
@@ -84,7 +84,7 @@ Test[
         h = scenarioData[s, "Hamiltonian"];
         AssociationQ[h] &&
         h["Alpha"] === 1 &&
-        h["V"] === 0 &&
+        h["V"] === -1 &&
         MatchQ[h["G"], _Function] &&
         h["G"][2] === -1/2 &&
         h["EdgeAlpha"] === <||> &&
@@ -95,6 +95,62 @@ Test[
     True
     ,
     TestID -> "Scenario kernel: default Hamiltonian settings are present"
+]
+
+(* Test: example constructors delegate omitted Hamiltonian defaults to makeScenario *)
+Test[
+    Module[{s, h},
+        s = gridScenario[{2}, {{1, 10}}, {{2, 0}}];
+        h = scenarioData[s, "Hamiltonian"];
+        scenarioQ[s] && h["Alpha"] === 1 && h["V"] === -1 && h["G"][2] === -1/2
+    ],
+    True,
+    TestID -> "Scenario kernel: gridScenario uses makeScenario Hamiltonian defaults"
+]
+
+(* Test: positional Alpha override is preserved while omitted V/G use defaults *)
+Test[
+    Module[{s, h},
+        s = gridScenario[{2}, {{1, 10}}, {{2, 0}}, {}, 2];
+        h = scenarioData[s, "Hamiltonian"];
+        scenarioQ[s] && h["Alpha"] === 2 && h["V"] === -1 && h["G"][2] === -1/2
+    ],
+    True,
+    TestID -> "Scenario kernel: gridScenario preserves positional Alpha override"
+]
+
+(* Test: positional V override is preserved *)
+Test[
+    Module[{s, h},
+        s = gridScenario[{2}, {{1, 10}}, {{2, 0}}, {}, 1, 3];
+        h = scenarioData[s, "Hamiltonian"];
+        scenarioQ[s] && h["Alpha"] === 1 && h["V"] === 3 && h["G"][2] === -1/2
+    ],
+    True,
+    TestID -> "Scenario kernel: gridScenario preserves positional V override"
+]
+
+(* Test: positional G override is preserved *)
+Test[
+    Module[{s, h, g},
+        g = Function[z, -2/z];
+        s = gridScenario[{2}, {{1, 10}}, {{2, 0}}, {}, 1, 3, g];
+        h = scenarioData[s, "Hamiltonian"];
+        scenarioQ[s] && h["Alpha"] === 1 && h["V"] === 3 && h["G"][2] === -1
+    ],
+    True,
+    TestID -> "Scenario kernel: gridScenario preserves positional G override"
+]
+
+(* Test: getExampleScenario forwarding delegates omitted Hamiltonian defaults *)
+Test[
+    Module[{s, h},
+        s = getExampleScenario[2, {{1, 10}}, {{2, 0}}];
+        h = scenarioData[s, "Hamiltonian"];
+        scenarioQ[s] && h["Alpha"] === 1 && h["V"] === -1 && h["G"][2] === -1/2
+    ],
+    True,
+    TestID -> "Scenario kernel: getExampleScenario uses makeScenario Hamiltonian defaults"
 ]
 
 (* Test: user-supplied per-edge Hamiltonian parameters are preserved *)

--- a/MFGraphs/examples.wl
+++ b/MFGraphs/examples.wl
@@ -13,7 +13,7 @@
      getExampleScenario[8, {{1,80}}, {{3,0},{4,10}}, {}]  override: no SC
 
    All constructors accept optional trailing args: sc, alpha, V, g.
-   Defaults: sc={}, alpha=1, V=0, g=Function[z,-1/z] (from $DefaultHamiltonian).
+   Hamiltonian defaults are supplied by makeScenario.
    Edges are network connections; topology is symmetrized before system construction,
    and restrictions on movement should be encoded with switching costs such as Infinity.
    Numeric benchmark defaults are in Scripts/BenchmarkHelpers.wls. *)
@@ -26,7 +26,7 @@ gridScenario::usage =
 "gridScenario[dims, entries, exits] creates a scenario on GridGraph[dims] connections. \
 {n} gives a chain with vertices 1..n; {r,c} gives an r\[Times]c grid with vertices 1..r*c (row-major). \
 Topology is symmetrized into undirected network edges before system construction. \
-Optional: sc (switching costs, default {}), alpha, V, g (Hamiltonian defaults from $DefaultHamiltonian; V/G are preserved but not applied by current system construction).";
+Optional: sc (switching costs, default {}), alpha, V, g (Hamiltonian defaults are supplied by makeScenario; V/G are preserved but not applied by current system construction).";
 
 cycleScenario::usage =
 "cycleScenario[n, entries, exits] creates a scenario on n-cycle connections, vertices 1..n. \
@@ -50,7 +50,7 @@ getExampleScenario::usage =
 for built-in example n. Topology is baked in; all parameters are caller-supplied. \
 getExampleScenario[n, entries, exits] calls the factory using the canonical switching costs \
 for that case (sc=Automatic resolves via $CaseDefaultSC, defaulting to {} if none defined) \
-and standard Hamiltonian defaults (alpha=1, V=0, g=Function[z,-1/z]). \
+and makeScenario-supplied Hamiltonian defaults. \
 V/G are preserved on the scenario for future density and visualization work, but are not applied by current system construction. \
 Additional optional arguments override each default in order: sc, alpha, V, g. \
 Pass sc={} explicitly to force no switching costs. \
@@ -196,9 +196,13 @@ $CaseDefaultSC = <|
          {2,3,4,1},{4,3,2,1},{3,1,2,1},{2,1,3,1}}
 |>;
 
-$ExamplesDefaultAlpha = 1;
-$ExamplesDefaultV = 0;
-$ExamplesDefaultG = Function[z, -1/z];
+$ExamplesDefaultHamiltonianValue = Automatic;
+
+exampleHamiltonianSpec[alpha_, V_, g_] :=
+    Association @ Select[
+        {"Alpha" -> alpha, "V" -> V, "G" -> g},
+        Last[#] =!= $ExamplesDefaultHamiltonianValue &
+    ];
 
 scenarioFromGraph[graph_, entries_, exits_, sc_, alpha_, V_, g_] :=
     makeScenario[<|
@@ -208,35 +212,35 @@ scenarioFromGraph[graph_, entries_, exits_, sc_, alpha_, V_, g_] :=
             "Exits" -> exits,
             "Switching"                 -> sc
         |>,
-        "Hamiltonian" -> <|"Alpha" -> alpha, "V" -> V, "G" -> g|>
+        "Hamiltonian" -> exampleHamiltonianSpec[alpha, V, g]
     |>];
 
 gridScenario[dims_List, entries_, exits_,
         sc_    : {},
-        alpha_ : $ExamplesDefaultAlpha,
-        V_     : $ExamplesDefaultV,
-        g_     : $ExamplesDefaultG] :=
+        alpha_ : $ExamplesDefaultHamiltonianValue,
+        V_     : $ExamplesDefaultHamiltonianValue,
+        g_     : $ExamplesDefaultHamiltonianValue] :=
     scenarioFromGraph[GridGraph[dims, DirectedEdges -> True], entries, exits, sc, alpha, V, g];
 
 cycleScenario[n_Integer, entries_, exits_,
         sc_    : {},
-        alpha_ : $ExamplesDefaultAlpha,
-        V_     : $ExamplesDefaultV,
-        g_     : $ExamplesDefaultG] :=
+        alpha_ : $ExamplesDefaultHamiltonianValue,
+        V_     : $ExamplesDefaultHamiltonianValue,
+        g_     : $ExamplesDefaultHamiltonianValue] :=
     scenarioFromGraph[CycleGraph[n, DirectedEdges -> True], entries, exits, sc, alpha, V, g];
 
 graphScenario[graph_, entries_, exits_,
         sc_    : {},
-        alpha_ : $ExamplesDefaultAlpha,
-        V_     : $ExamplesDefaultV,
-        g_     : $ExamplesDefaultG] :=
+        alpha_ : $ExamplesDefaultHamiltonianValue,
+        V_     : $ExamplesDefaultHamiltonianValue,
+        g_     : $ExamplesDefaultHamiltonianValue] :=
     scenarioFromGraph[graph, entries, exits, sc, alpha, V, g];
 
 amScenario[vl_, am_, entries_, exits_,
         sc_    : {},
-        alpha_ : $ExamplesDefaultAlpha,
-        V_     : $ExamplesDefaultV,
-        g_     : $ExamplesDefaultG] :=
+        alpha_ : $ExamplesDefaultHamiltonianValue,
+        V_     : $ExamplesDefaultHamiltonianValue,
+        g_     : $ExamplesDefaultHamiltonianValue] :=
     makeScenario[<|
         "Model" -> <|
             "Vertices"                   -> vl,
@@ -245,7 +249,7 @@ amScenario[vl_, am_, entries_, exits_,
             "Exits" -> exits,
             "Switching"                 -> sc
         |>,
-        "Hamiltonian" -> <|"Alpha" -> alpha, "V" -> V, "G" -> g|>
+        "Hamiltonian" -> exampleHamiltonianSpec[alpha, V, g]
     |>];
 
 (* --- Private factory helpers — thin wrappers used by $ExampleScenarios --- *)
@@ -482,7 +486,7 @@ $ExampleScenarios = Association[
                                 edge === DirectedEdge[3,6] || edge === DirectedEdge[1,4], j/100,
                                 True, 0]]
                 |>,
-                "Hamiltonian" -> <|"Alpha" -> alpha, "V" -> V, "G" -> g|>
+                "Hamiltonian" -> exampleHamiltonianSpec[alpha, V, g]
             |>]]],
 
     "Big Braess split" -> makeAmFactory[Range[10], {
@@ -552,9 +556,9 @@ getExampleScenarioMetadata[n_] := Lookup[$ExampleScenarioMetadata, n, $Failed];
 (* sc=Automatic resolves to the canonical SC via $CaseDefaultSC, or {} if undefined. *)
 getExampleScenario[n_, entries_, exits_,
         sc_    : Automatic,
-        alpha_ : $ExamplesDefaultAlpha,
-        V_     : $ExamplesDefaultV,
-        g_     : $ExamplesDefaultG] :=
+        alpha_ : $ExamplesDefaultHamiltonianValue,
+        V_     : $ExamplesDefaultHamiltonianValue,
+        g_     : $ExamplesDefaultHamiltonianValue] :=
     Module[{f = Lookup[$ExampleScenarios, n, $Failed]},
         If[f === $Failed, Return[$Failed]];
         f[entries, exits,

--- a/MFGraphs/graphicsTools.wl
+++ b/MFGraphs/graphicsTools.wl
@@ -7,10 +7,16 @@ scenarioTopologyPlot::usage =
 "scenarioTopologyPlot[s, sys, opts] plots the scenario topology using vertex coloring for entry, exit, and internal vertices. Use PlotLabel, GraphLayout, and ImageSize options to control display.";
 
 mfgSolutionPlot::usage =
-"mfgSolutionPlot[s, sys, sol, opts] plots a combined solution graph with real and auxiliary edges. Edge labels include both j and u values, and real-edge directions follow solved net flow orientation. Use PlotLabel, GraphLayout, and ImageSize options to control display.";
+"mfgSolutionPlot[s, sys, sol, opts] plots coordinated solution views: flows, value samples, and agent density. Use PlotLabel, GraphLayout, and ImageSize options to control display.";
 
 mfgFlowPlot::usage =
 "mfgFlowPlot[s, sys, sol, opts] plots a flow-only solution graph with real and auxiliary edges. Edges are displayed as directed, and edge labels show only j flow values. Use PlotLabel, GraphLayout, and ImageSize options to control display.";
+
+mfgValuePlot::usage =
+"mfgValuePlot[s, sys, sol, opts] plots real network edges with endpoint value variables u[a,b], u[b,a] and linearly interpolated interior samples at 1/4, 1/2, and 3/4. Use PlotLabel, GraphLayout, and ImageSize options to control display.";
+
+mfgDensityPlot::usage =
+"mfgDensityPlot[s, sys, sol, opts] plots real network edges with agent density inferred from solved signed spatial flow and the scenario Hamiltonian density equation. Use PlotLabel, GraphLayout, and ImageSize options to control display.";
 
 mfgTransitionPlot::usage =
 "mfgTransitionPlot[s, sys, sol, opts] plots the transition graph of the solution. Nodes are AuxPair states {r,i}->{i,w}; directed edges represent transition flows j[r,i,w]. Nodes are labeled with internal values u where available. Use PlotLabel, GraphLayout, and ImageSize options to control display.";
@@ -37,6 +43,10 @@ Options[mfgSolutionPlot] = {
 
 Options[mfgFlowPlot] = Options[mfgSolutionPlot];
 
+Options[mfgValuePlot] = Options[mfgSolutionPlot];
+
+Options[mfgDensityPlot] = Options[mfgSolutionPlot];
+
 Options[mfgTransitionPlot] = {
     GraphLayout -> Automatic,
     PlotLabel -> Automatic,
@@ -62,6 +72,21 @@ stateLabel::usage =
 
 plotLabelValue::usage =
 "plotLabelValue[label, default] returns a styled plot label unless label is None.";
+
+realNetworkVertexStyle::usage =
+"realNetworkVertexStyle[s] returns vertex styles for real entry, exit, and internal network vertices.";
+
+realNetworkVertexSize::usage =
+"realNetworkVertexSize[s] returns vertex sizes for real network vertices.";
+
+edgeHamiltonianValue::usage =
+"edgeHamiltonianValue[ham, key, edge] returns scenario Hamiltonian data for an edge with reverse-edge fallback.";
+
+edgeDensityValue::usage =
+"edgeDensityValue[s, sys, edge, rules] computes inferred density for a real edge.";
+
+formatPlotNumber::usage =
+"formatPlotNumber[value] formats numeric plot labels and returns ? for unavailable values.";
 
 netEdgeFlow[a_, b_, rules_List] :=
     (j[a, b] - j[b, a]) /. rules /. {_j -> 0};
@@ -101,6 +126,86 @@ plotLabelValue[label_, default_String] :=
         None -> None,
         other_ :> Style[other, 14, Bold]
     }];
+
+realNetworkVertexStyle[s_?scenarioQ] :=
+    Module[{model, entryV, exitV, realV, internalV},
+        model     = scenarioData[s, "Model"];
+        entryV    = First /@ model["Entries"];
+        exitV     = First /@ model["Exits"];
+        realV     = model["Vertices"];
+        internalV = Complement[realV, entryV, exitV];
+        Normal @ Join[
+            AssociationThread[entryV,    RGBColor[0.22, 0.6, 0.3]],
+            AssociationThread[exitV,     RGBColor[0.82, 0.27, 0.2]],
+            AssociationThread[internalV, GrayLevel[0.72]]
+        ]
+    ];
+
+realNetworkVertexSize[s_?scenarioQ] :=
+    AssociationThread[scenarioData[s, "Model"]["Vertices"], 0.38];
+
+formatPlotNumber[value_?NumericQ] := NumberForm[N[value], {5, 2}];
+formatPlotNumber[_] := "?";
+
+edgeHamiltonianValue[ham_Association, key_String, edge_List] :=
+    Module[{edgeAssoc, globalValue},
+        edgeAssoc = Lookup[ham, "Edge" <> key, <||>];
+        globalValue = Lookup[ham, key, Missing["MissingHamiltonianKey", key]];
+        If[!AssociationQ[edgeAssoc] || MissingQ[globalValue],
+            Missing["InvalidHamiltonian"],
+            Lookup[
+                edgeAssoc,
+                Key[edge],
+                Lookup[edgeAssoc, Key[Reverse[edge]], globalValue]
+            ]
+        ]
+    ];
+
+edgeGExpression[g_?NumericQ, m_] := g;
+edgeGExpression[g_Function, m_] := g[m];
+edgeGExpression[_, _] := Missing["InvalidG"];
+
+edgeSignedFlowValue[sys_?mfgSystemQ, edge_List, rules_List] :=
+    Module[{signedFlows, expr},
+        signedFlows = systemData[sys, "SignedFlows"];
+        If[!AssociationQ[signedFlows], Return[Missing["MissingSignedFlows"], Module]];
+        expr = Lookup[signedFlows, Key[edge], Missing["MissingSignedFlow"]];
+        If[MissingQ[expr],
+            expr = Lookup[signedFlows, Key[Reverse[edge]], Missing["MissingSignedFlow"]];
+            If[MissingQ[expr], Return[expr, Module], expr = -expr]
+        ];
+        expr /. rules
+    ];
+
+edgeDensityValue[s_?scenarioQ, sys_?mfgSystemQ, edge_List, rules_List] :=
+    Module[{ham, alpha, v, g, jval, m, gexpr, equation, roots},
+        ham = scenarioData[s, "Hamiltonian"];
+        If[!AssociationQ[ham], Return[Missing["InvalidHamiltonian"], Module]];
+        alpha = edgeHamiltonianValue[ham, "Alpha", edge];
+        v     = edgeHamiltonianValue[ham, "V",     edge];
+        g     = edgeHamiltonianValue[ham, "G",     edge];
+        If[MissingQ[alpha] || MissingQ[v] || MissingQ[g],
+            Return[Missing["InvalidHamiltonian"], Module]
+        ];
+        jval  = edgeSignedFlowValue[sys, edge, rules];
+
+        If[!NumericQ[jval], Return[Missing["MissingFlow"], Module]];
+        If[Chop[N[jval]] == 0, Return[0, Module]];
+        If[!NumericQ[alpha] || !NumericQ[v], Return[Missing["InvalidHamiltonian"], Module]];
+
+        gexpr = edgeGExpression[g, m];
+        If[MissingQ[gexpr], Return[gexpr, Module]];
+        equation = N[jval]^2/(2 m^(2 - N[alpha])) - gexpr == -N[v];
+        roots = Quiet @ Check[
+            m /. NSolve[{equation, m > 0}, m, Reals],
+            $Failed
+        ];
+        If[roots === $Failed || roots === {} || !ListQ[roots],
+            Missing["DensityNotSolved"],
+            FirstCase[N @ roots, value_?NumericQ /; value > 0,
+                Missing["DensityNotSolved"]]
+        ]
+    ];
 
 augmentAuxiliaryGraph[sys_?mfgSystemQ] :=
     Module[{auxPairs, triples, flowEdges, transitionEdges, allEdges, edgeVariables,
@@ -162,80 +267,145 @@ mfgSolutionPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title : Except[_Rule | _Rul
     mfgSolutionPlot[s, sys, sol, PlotLabel -> title, opts];
 
 mfgSolutionPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
-    Module[{model, entryV, exitV, realV, auxV, internalV, edges, dispEdges, rules,
-            edgeStyles, edgeLabels, numericJ, maxJ, auxEntryV, auxExitV},
-        model     = scenarioData[s, "Model"];
-        entryV    = First /@ model["Entries"];
-        exitV     = First /@ model["Exits"];
-        realV     = model["Vertices"];
-        auxV      = Complement[systemData[sys, "AuxVertices"], realV];
-        internalV = Complement[realV, entryV, exitV];
-        edges     = systemData[sys, "AuxEdges"];
-        rules     = extractRules[sol];
-        dispEdges = directedDisplayEdges[edges, rules];
-        numericJ  = Cases[edgeJValue @@@ (List @@@ dispEdges), _?NumericQ, Infinity];
-        maxJ      = Max[Append[Abs @ numericJ, 1]];
+    Show[
+        GraphicsGrid[
+            {{
+                mfgFlowPlot[s, sys, sol,
+                    GraphLayout -> OptionValue[GraphLayout],
+                    PlotLabel -> "Flows",
+                    ImageSize -> Medium],
+                mfgValuePlot[s, sys, sol,
+                    GraphLayout -> OptionValue[GraphLayout],
+                    PlotLabel -> "Values",
+                    ImageSize -> Medium],
+                mfgDensityPlot[s, sys, sol,
+                    GraphLayout -> OptionValue[GraphLayout],
+                    PlotLabel -> "Agent density",
+                    ImageSize -> Medium]
+            }},
+            ImageSize -> OptionValue[ImageSize]
+        ],
+        PlotLabel -> plotLabelValue[OptionValue[PlotLabel], "Solution views"],
+        ImageSize -> OptionValue[ImageSize]
+    ];
+
+mfgValuePlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title : Except[_Rule | _RuleDelayed], opts : OptionsPattern[]] :=
+    mfgValuePlot[s, sys, sol, PlotLabel -> title, opts];
+
+mfgValuePlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
+    Module[{model, realV, edges, rules, edgeLabels, valueAt},
+        model = scenarioData[s, "Model"];
+        realV = model["Vertices"];
+        edges = systemData[sys, "Edges"];
+        rules = extractRules[sol];
+
+        valueAt[a_, b_, t_] :=
+            Module[{ua, ub},
+                ua = u[a, b] /. rules;
+                ub = u[b, a] /. rules;
+                If[NumericQ[ua] && NumericQ[ub],
+                    (1 - t) N[ua] + t N[ub],
+                    Missing["MissingValue"]
+                ]
+            ];
+
+        edgeLabels = Association @ Map[
+            Module[{a, b, ua, ub, q1, q2, q3},
+                {a, b} = List @@ #;
+                ua = u[a, b] /. rules;
+                ub = u[b, a] /. rules;
+                q1 = valueAt[a, b, 1/4];
+                q2 = valueAt[a, b, 1/2];
+                q3 = valueAt[a, b, 3/4];
+                # -> Placed[
+                    Style[
+                        Column[{
+                            Row[{"u[", a, ",", b, "]=", formatPlotNumber[ua]}],
+                            Row[{"1/4=", formatPlotNumber[q1],
+                                 "  1/2=", formatPlotNumber[q2],
+                                 "  3/4=", formatPlotNumber[q3]}],
+                            Row[{"u[", b, ",", a, "]=", formatPlotNumber[ub]}]
+                        }, Center, Spacings -> 0.15],
+                        8, Black, Background -> White
+                    ],
+                    Center
+                ]
+            ] &,
+            edges
+        ];
+
+        Graph[realV, edges,
+            VertexLabels -> Placed["Name", Center],
+            VertexStyle  -> realNetworkVertexStyle[s],
+            VertexSize   -> Normal @ realNetworkVertexSize[s],
+            EdgeStyle    -> Directive[RGBColor[0.36, 0.38, 0.42], AbsoluteThickness[2.2], Opacity[0.9]],
+            EdgeLabels   -> Normal[edgeLabels],
+            GraphLayout  -> OptionValue[GraphLayout],
+            PlotLabel    -> plotLabelValue[OptionValue[PlotLabel], "Values"],
+            ImageSize    -> OptionValue[ImageSize]
+        ]
+    ];
+
+mfgDensityPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title : Except[_Rule | _RuleDelayed], opts : OptionsPattern[]] :=
+    mfgDensityPlot[s, sys, sol, PlotLabel -> title, opts];
+
+mfgDensityPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
+    Module[{model, realV, edges, rules, densities, numericDensities, maxDensity,
+            edgeStyles, edgeLabels},
+        model = scenarioData[s, "Model"];
+        realV = model["Vertices"];
+        edges = systemData[sys, "Edges"];
+        rules = extractRules[sol];
+
+        densities = Association @ Map[
+            With[{edge = List @@ #},
+                # -> edgeDensityValue[s, sys, edge, rules]
+            ] &,
+            edges
+        ];
+        numericDensities = Cases[Values[densities], _?NumericQ, Infinity];
+        maxDensity = Max[Append[Abs @ numericDensities, 1]];
 
         edgeStyles = Association @ Map[
-            Module[{a, b, jv, auxQ},
-                {a, b} = List @@ #;
-                jv = edgeJValue[a, b, rules];
-                auxQ = MemberQ[auxV, a] || MemberQ[auxV, b];
+            With[{density = densities[#]},
                 # -> Directive[
-                    Which[
-                        auxQ, RGBColor[0.35, 0.35, 0.35],
-                        NumericQ[jv] && jv > 0, RGBColor[0.12, 0.45, 0.78],
-                        NumericQ[jv] && jv < 0, RGBColor[0.82, 0.39, 0.2],
-                        True, GrayLevel[0.45]
+                    If[NumericQ[density] && density > 0,
+                        RGBColor[0.1, 0.5, 0.42],
+                        GrayLevel[0.48]
                     ],
                     AbsoluteThickness[
-                        If[NumericQ[jv], Rescale[Abs[jv], {0, maxJ}, {1.5, 7}], 2.0]
+                        If[NumericQ[density],
+                            Rescale[Abs[density], {0, maxDensity}, {1.5, 7}],
+                            2.0
+                        ]
                     ],
                     Opacity[0.9]
                 ]
             ] &,
-            dispEdges
+            edges
         ];
 
         edgeLabels = Association @ Map[
-            Module[{a, b, jv, uv},
-                {a, b} = List @@ #;
-                jv = edgeJValue[a, b, rules];
-                uv = edgeUValue[a, b, rules];
+            With[{density = densities[#]},
                 # -> Placed[
                     Style[
-                        Row[{
-                            "j=", If[NumericQ[jv], NumberForm[N[jv], {5, 1}], "?"],
-                            "  |  u=", If[NumericQ[uv], NumberForm[N[uv], {5, 1}], "?"]
-                        }],
+                        Row[{"m=", formatPlotNumber[density]}],
                         9, Black, Background -> White
                     ],
                     Center
                 ]
             ] &,
-            dispEdges
+            edges
         ];
 
-        auxEntryV = systemData[sys, "AuxEntryVertices"];
-        auxExitV  = systemData[sys, "AuxExitVertices"];
-
-        Graph[Join[realV, auxV], dispEdges,
+        Graph[realV, edges,
             VertexLabels -> Placed["Name", Center],
-            VertexStyle  -> Normal @ Join[
-                AssociationThread[entryV,    RGBColor[0.22, 0.6, 0.3]],
-                AssociationThread[exitV,     RGBColor[0.82, 0.27, 0.2]],
-                AssociationThread[internalV, GrayLevel[0.72]],
-                AssociationThread[Intersection[auxV, auxEntryV], RGBColor[0.38, 0.74, 0.9]],
-                AssociationThread[Intersection[auxV, auxExitV],  RGBColor[0.95, 0.7, 0.4]]
-            ],
-            VertexSize   -> Normal @ Join[
-                AssociationThread[realV, 0.38],
-                AssociationThread[auxV, 0.28]
-            ],
+            VertexStyle  -> realNetworkVertexStyle[s],
+            VertexSize   -> Normal @ realNetworkVertexSize[s],
             EdgeStyle    -> Normal[edgeStyles],
             EdgeLabels   -> Normal[edgeLabels],
             GraphLayout  -> OptionValue[GraphLayout],
-            PlotLabel    -> plotLabelValue[OptionValue[PlotLabel], "Solution graph: flows and values"],
+            PlotLabel    -> plotLabelValue[OptionValue[PlotLabel], "Agent density"],
             ImageSize    -> OptionValue[ImageSize]
         ]
     ];
@@ -287,7 +457,7 @@ mfgFlowPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
         Graph[Join[realV, auxV], dispEdges,
             VertexLabels -> Placed["Name", Center],
             VertexStyle  -> Normal @ Join[
-                AssociationThread[realV, GrayLevel[0.72]],
+                Association @ realNetworkVertexStyle[s],
                 AssociationThread[Intersection[auxV, auxEntryV], RGBColor[0.38, 0.74, 0.9]],
                 AssociationThread[Intersection[auxV, auxExitV],  RGBColor[0.95, 0.7, 0.4]]
             ],

--- a/MFGraphs/scenarioTools.wl
+++ b/MFGraphs/scenarioTools.wl
@@ -45,7 +45,7 @@ Optional keys: \
 \"EdgeAlpha\" -> <|{u,v} -> a_uv, ...|>, \"EdgeV\" -> <|{u,v} -> v_uv, ...|>, \
 \"EdgeG\" -> <|{u,v} -> g_uv, ...|>|>), \
 \"Identity\" (name, version), \"Benchmark\" (tier, timeout), \"Visualization\", \
-\"Inheritance\". Default Hamiltonian is Alpha=1 and V=0 on all edges, with \
+\"Inheritance\". Default Hamiltonian is Alpha=1 and V=-1 on all edges, with \
 G[z]=-1/z (overridable globally and per edge). V/G/EdgeV/EdgeG are validated \
 and preserved for future density and visualization work, but current system \
 construction applies only Alpha/EdgeAlpha. Boundary values must be numeric; \
@@ -134,10 +134,10 @@ $RequiredModelKeys = {
 $DefaultBenchmarkTier    = "core";
 $DefaultBenchmarkTimeout = 300;
 (* Default Hamiltonian:
-   alpha = 1 on all edges, V = 0 on all edges, and g(z) = -1/z. *)
+   alpha = 1 on all edges, V = -1 on all edges, and g(z) = -1/z. *)
 $DefaultHamiltonian = <|
     "Alpha" -> 1,
-    "V" -> 0,
+    "V" -> -1,
     "G" -> Function[z, -1 / z],
     "EdgeAlpha" -> <||>,
     "EdgeV" -> <||>,

--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ isValidSystemSolution[sys, sol]
 Example factory workflow:
 
 ```mathematica
-f = getExampleScenario[12];
-s = f[{{1, 100}}, {{4, 0}}, {}, 1, 0, Function[z, -1/z]];
+s = getExampleScenario[12, {{1, 100}}, {{4, 0}}];
 ```
 
 ## Active API (current phase)

--- a/docs/latex/package_module_docs/examples.tex
+++ b/docs/latex/package_module_docs/examples.tex
@@ -67,7 +67,7 @@ This design separates topology from boundary-condition choice. The registry stor
 
 \section{Registry data and constants}
 
-The file also defines several important constants. \texttt{\$Y1In2OutAM}, \texttt{\$Y2In1OutAM}, and \texttt{\$Attraction4AM} are reusable adjacency patterns for benchmark families. \texttt{\$CaseDefaultSC} stores canonical switching-cost sets keyed by example number or example name. \texttt{\$ExamplesDefaultAlpha}, \texttt{\$ExamplesDefaultV}, and \texttt{\$ExamplesDefaultG} define the default Hamiltonian parameters used when example calls omit overrides.
+The file also defines several important constants. \texttt{\$Y1In2OutAM}, \texttt{\$Y2In1OutAM}, and \texttt{\$Attraction4AM} are reusable adjacency patterns for benchmark families. \texttt{\$CaseDefaultSC} stores canonical switching-cost sets keyed by example number or example name. Omitted Hamiltonian parameters use an \texttt{Automatic} sentinel in the example layer and are delegated to \texttt{makeScenario}, which is the canonical source for concrete Hamiltonian defaults.
 
 The large \texttt{\$ExampleScenarios} association is not itself a function, but it is central to the file's behavior. It maps numeric and string identifiers to factories for chains, Y-cases, attraction cases, Braess variants, Jamarat-style examples, paper examples, inconsistent-switching validation cases, and larger grids.
 
@@ -79,8 +79,7 @@ Representative usage patterns are:
 
 \begin{verbatim}
 s1 = gridScenario[{3}, {{1,10}}, {{3,0}}];
-f  = getExampleScenario[12];
-s2 = f[{{1,100}}, {{4,0}}, {}, 1, 0, Function[z, -1/z]];
+s2 = getExampleScenario[12, {{1,100}}, {{4,0}}];
 s3 = getExampleScenario[8, {{1,80}}, {{3,0},{4,10}}];
 \end{verbatim}
 


### PR DESCRIPTION
## Summary
- remove graphics-local Hamiltonian fallback constants from density inference
- keep example constructors delegating omitted Hamiltonian parameters to makeScenario
- refresh README, CLAUDE, LaTeX module docs, and generated API reference
- add graphics coverage for scenario-supplied Hamiltonian data and malformed Hamiltonian handling

## Validation
- wolframscript -file Scripts/RunSingleTest.wls MFGraphs/Tests/graphicsTools.mt
- wolframscript -file Scripts/RunSingleTest.wls MFGraphs/Tests/scenario-kernel.mt
- wolframscript -file Scripts/RunTests.wls fast
- rg -n "ExamplesDefaultAlpha|ExamplesDefaultV|ExamplesDefaultG|V=0|standard Hamiltonian defaults|Function\\[z, -1/z\\]|\\"V\\" -> -1" MFGraphs README.md CLAUDE.md API_REFERENCE.md docs/latex/package_module_docs