### PR TITLE
feat(graphics): consolidate to rawNetworkPlot/richNetworkPlot + Tawaf helix

### DIFF
--- a/MFGraphs/Getting started.wl
+++ b/MFGraphs/Getting started.wl
@@ -151,7 +151,7 @@ EdgeModelPlot[s_?scenarioQ, sys_?mfgSystemQ, opts : OptionsPattern[]] :=
             modelEdges
         ];
         Graph[
-            scenarioTopologyPlot[s, sys, PlotLabel -> None,
+            rawNetworkPlot[s, sys, PlotLabel -> None,
                 GraphLayout -> OptionValue[GraphLayout],
                 ImageSize -> OptionValue[ImageSize]],
             EdgeLabels -> Normal[edgeLabels],
@@ -293,8 +293,8 @@ edgeModelSystem = makeSystem[edgeModelScenario];
 Column[{
     DescribeOutput[
         "Topology plot from graphicsTools",
-        "scenarioTopologyPlot shows the network while preserving entry/exit coloring.",
-        scenarioTopologyPlot[edgeModelScenario, edgeModelSystem,
+        "rawNetworkPlot shows the physical network. Vertices are gray; aux entry/exit vertices appear in their category colors when shown.",
+        rawNetworkPlot[edgeModelScenario, edgeModelSystem,
             PlotLabel -> "Example network for per-edge model parameters",
             ImageSize -> Large]
     ],
@@ -416,14 +416,14 @@ Column[{
 Column[{
     DescribeOutput[
         "Chain topology \[LongDash] no switching costs",
-        "Green = entry, red = exits, gray = internal.",
-        scenarioTopologyPlot[chain2ExNoSC, sysNoSC,
+        "All physical vertices gray. Add ShowAuxiliaryVertices -> True to also show auxiliary entry/exit nodes (blue/orange).",
+        rawNetworkPlot[chain2ExNoSC, sysNoSC,
             PlotLabel -> "Chain 1\[Rule]2\[Rule]3 (no SC)"]
     ],
     DescribeOutput[
         "Chain topology \[LongDash] with switching cost {1,2,3}=2.0",
         "Same topology; SC at vertex 2 penalises continuing from edge 1\[Rule]2 to 2\[Rule]3.",
-        scenarioTopologyPlot[chain2ExWithSC, sysWithSC,
+        rawNetworkPlot[chain2ExWithSC, sysWithSC,
             PlotLabel -> "Chain 1\[Rule]2\[Rule]3 (SC at 2)"]
     ]
 }]
@@ -465,15 +465,16 @@ Column[{
         isValidSystemSolution[sys1Ex, sol1Ex]
     ],
     DescribeOutput[
-        "Combined solution plot \[LongDash] chain 1\[Rule]2\[Rule]3, single exit",
-        "Directed edges show j-flow direction/magnitude; labels show both j and u. Auxiliary edges are included.",
-        mfgSolutionPlot[chain1Ex, sys1Ex, sol1Ex,
-            PlotLabel -> "Chain 1\[Rule]2\[Rule]3: combined solution (exit at 3, cost=0)"]
+        "Solution plot \[LongDash] chain 1\[Rule]2\[Rule]3, single exit",
+        "rawNetworkPlot with a solution shows directed edges by net flow with j-value labels. Combined views can be composed via GraphicsGrid using ShowValueLabels and ShowDensityLabels.",
+        rawNetworkPlot[chain1Ex, sys1Ex, sol1Ex,
+            PlotLabel -> "Chain 1\[Rule]2\[Rule]3: solution (exit at 3, cost=0)",
+            ShowAuxiliaryVertices -> True]
     ],
     DescribeOutput[
         "Flow-only plot \[LongDash] chain 1\[Rule]2\[Rule]3, single exit",
-        "Original vertices use one color. Edges have fixed width, and nearby labels show only j-flow values.",
-        mfgFlowPlot[chain1Ex, sys1Ex, sol1Ex,
+        "Same call without ShowValueLabels/ShowDensityLabels — only j-flow values appear on edges.",
+        rawNetworkPlot[chain1Ex, sys1Ex, sol1Ex,
             PlotLabel -> "Chain 1\[Rule]2\[Rule]3: flow values only"]
     ]
 }]
@@ -485,16 +486,18 @@ solNoSC = solveScenario[chain2ExNoSC];
 
 Column[{
     DescribeOutput[
-        "Combined solution plot \[LongDash] chain with two exits (no SC)",
-        "Edge {1,2} is directed 1\[Rule]2 (j[1,2]>0). Labels show j and u on real + auxiliary edges.",
-        mfgSolutionPlot[chain2ExNoSC, sysNoSC, solNoSC,
-            PlotLabel -> "Chain 1\[Rule]2\[Rule]3: combined solution (exits at 2 and 3)"]
+        "Solution plot \[LongDash] chain with two exits (no SC)",
+        "Edge {1,2} is directed 1\[Rule]2 (j[1,2]>0). rawNetworkPlot with ShowAuxiliaryVertices and ShowValueLabels overlays both flow and value information.",
+        rawNetworkPlot[chain2ExNoSC, sysNoSC, solNoSC,
+            PlotLabel -> "Chain 1\[Rule]2\[Rule]3: solution (exits at 2 and 3)",
+            ShowAuxiliaryVertices -> True, ShowValueLabels -> True]
     ],
     DescribeOutput[
         "Flow-only plot \[LongDash] chain with two exits (no SC)",
-        "Auxiliary entry/exit edges are included. Edges have fixed width, and nearby labels show only j-flow values.",
-        mfgFlowPlot[chain2ExNoSC, sysNoSC, solNoSC,
-            PlotLabel -> "Chain 1\[Rule]2\[Rule]3: flow values only (exits at 2 and 3)"]
+        "Auxiliary entry/exit edges are included via ShowAuxiliaryVertices. Edge labels show j-flow values only.",
+        rawNetworkPlot[chain2ExNoSC, sysNoSC, solNoSC,
+            PlotLabel -> "Chain 1\[Rule]2\[Rule]3: flow values only (exits at 2 and 3)",
+            ShowAuxiliaryVertices -> True]
     ]
 }]
 
@@ -515,36 +518,40 @@ Column[{
         |>
     ],
     DescribeOutput[
-        "Transition graph \[LongDash] gradient node coloring",
-        "mfgTransitionPlot now colors nodes on a Red\[Rule]Blue u-value gradient and draws edges as quadratic Bezier arcs. Anti-parallel arcs curve to opposite sides. A color bar legend is shown by default.",
-        mfgTransitionPlot[chain1Ex, sys1Ex, sol1Ex,
-            PlotLabel -> "Chain 1\[Rule]2\[Rule]3: transition graph"]
+        "Transition graph \[LongDash] richNetworkPlot[..., ShowFlowEdges -> False]",
+        "richNetworkPlot with ShowFlowEdges -> False suppresses j[a,b] flow arcs, leaving the transition graph (j[r,i,w]). Nodes are colored on a Red\[Rule]Blue u-value gradient when a solution is provided. A color bar legend is shown by default.",
+        richNetworkPlot[chain1Ex, sys1Ex, sol1Ex,
+            PlotLabel -> "Chain 1\[Rule]2\[Rule]3: transition graph",
+            ShowFlowEdges -> False]
     ],
     DescribeOutput[
         "Transition graph \[LongDash] BendFactor comparison",
         "BendFactor controls arc curvature as a fraction of edge length. BendFactor\[Rule]0 gives straight edges; higher values increase the arc.",
         Row[{
-            mfgTransitionPlot[chain1Ex, sys1Ex, sol1Ex,
-                PlotLabel -> "BendFactor \[Rule] 0 (straight)", ShowLegend -> False,
+            richNetworkPlot[chain1Ex, sys1Ex, sol1Ex,
+                PlotLabel -> "BendFactor \[Rule] 0 (straight)",
+                ShowFlowEdges -> False, ShowLegend -> False,
                 BendFactor -> 0, ImageSize -> 300],
-            mfgTransitionPlot[chain1Ex, sys1Ex, sol1Ex,
-                PlotLabel -> "BendFactor \[Rule] 0.15 (default)", ShowLegend -> False,
+            richNetworkPlot[chain1Ex, sys1Ex, sol1Ex,
+                PlotLabel -> "BendFactor \[Rule] 0.15 (default)",
+                ShowFlowEdges -> False, ShowLegend -> False,
                 BendFactor -> 0.15, ImageSize -> 300],
-            mfgTransitionPlot[chain1Ex, sys1Ex, sol1Ex,
-                PlotLabel -> "BendFactor \[Rule] 0.35", ShowLegend -> False,
+            richNetworkPlot[chain1Ex, sys1Ex, sol1Ex,
+                PlotLabel -> "BendFactor \[Rule] 0.35",
+                ShowFlowEdges -> False, ShowLegend -> False,
                 BendFactor -> 0.35, ImageSize -> 300]
         }, Spacer[12]]
     ],
     DescribeOutput[
         "Augmented infrastructure graph \[LongDash] with solution",
-        "Nodes are road-traffic edge-vertex states. Blue arcs are j[a,b] flows; red arcs are j[r,i,w] transitions. Anti-parallel flow arcs curve to opposite sides. Color gradient on nodes shows u-values.",
-        mfgAugmentedPlot[chain1Ex, sys1Ex, sol1Ex,
+        "richNetworkPlot shows the augmented state space. Blue arcs are j[a,b] flows; red arcs are j[r,i,w] transitions. Only nodes whose label position is an aux entry/exit vertex receive boundary colors.",
+        richNetworkPlot[chain1Ex, sys1Ex, sol1Ex,
             PlotLabel -> "Chain 1\[Rule]2\[Rule]3: augmented infrastructure (solved)"]
     ],
     DescribeOutput[
         "Augmented infrastructure graph \[LongDash] pre-solve with ShowBoundaryValues\[Rule]False",
-        "When ShowBoundaryValues\[Rule]False, boundary values are hidden but entry (green) and exit (red) nodes keep their category color. Internal nodes are gray until a solution is provided.",
-        mfgAugmentedPlot[chain1Ex, sys1Ex, <||>,
+        "When ShowBoundaryValues\[Rule]False, boundary values are hidden. Only nodes labeled \"in\"/\"out\" (label-position aux) keep their category color; all other state nodes are gray.",
+        richNetworkPlot[chain1Ex, sys1Ex,
             PlotLabel -> "Chain 1\[Rule]2\[Rule]3: structure only (ShowBoundaryValues\[Rule]False)",
             ShowBoundaryValues -> False]
     ]
@@ -585,8 +592,8 @@ Column[{
     ],
     DescribeOutput[
         "Figure 4-style augmented road-traffic graph",
-        "Blue edges are flow variables j[a,b]. Red edges are transition variables j[r,i,w].",
-        mfgAugmentedPlot[paperFig3Scenario, paperFig3System, <||>,
+        "richNetworkPlot draws blue flow arcs (j[a,b]) and red transition arcs (j[r,i,w]).",
+        richNetworkPlot[paperFig3Scenario, paperFig3System,
             PlotLabel -> "Paper-style augmented road-traffic graph",
             ShowBoundaryValues -> False]
     ],
@@ -626,15 +633,16 @@ Column[{
     ],
     DescribeOutput[
         "Jamaratv9 topology plot",
-        "scenarioTopologyPlot shows the original network with entry/exit coloring.",
-        scenarioTopologyPlot[jamaratScenario, jamaratSystem,
+        "rawNetworkPlot shows the physical network. ShowAuxiliaryVertices -> True adds the boundary aux nodes in their category colors.",
+        rawNetworkPlot[jamaratScenario, jamaratSystem,
             PlotLabel -> "Jamaratv9 topology",
+            ShowAuxiliaryVertices -> True,
             ImageSize -> Large]
     ],
     DescribeOutput[
         "Jamaratv9 augmented road-traffic graph (structure only)",
-        "ShowBoundaryValues\[Rule]False hides u-values but entry (green) and exit (red) nodes keep their category color so boundary topology remains readable.",
-        mfgAugmentedPlot[jamaratScenario, jamaratSystem, <||>,
+        "ShowBoundaryValues -> False hides u-values; only nodes whose label position is an aux entry/exit (\"in\"/\"out\" labels) keep their category color.",
+        richNetworkPlot[jamaratScenario, jamaratSystem,
             PlotLabel -> "Jamaratv9 augmented infrastructure (structure only)",
             ShowBoundaryValues -> False,
             ImageSize -> Large]

--- a/MFGraphs/Jamarat.wl
+++ b/MFGraphs/Jamarat.wl
@@ -243,7 +243,7 @@ Column[{
     DescribeOutput[
         "Simplified Jamarat augmented infrastructure",
         "Augmented graph before solving \[LongDash] structure only.",
-        mfgAugmentedPlot[jamaratEnd, jamaratEndSystem, <||>,
+        richNetworkPlot[jamaratEnd, jamaratEndSystem, <||>,
             PlotLabel -> "Simplified Jamarat infrastructure",
             ImageSize -> Large,
             ShowBoundaryValues -> False]
@@ -251,7 +251,7 @@ Column[{
     DescribeOutput[
         "Simplified Jamarat augmented solution",
         "Augmented graph with solved flow, transition, and u values.",
-        mfgAugmentedPlot[jamaratEnd, jamaratEndSystem, jamaratEndSol,
+        richNetworkPlot[jamaratEnd, jamaratEndSystem, jamaratEndSol,
             PlotLabel -> "Simplified Jamarat solution",
             ImageSize -> Large]
     ]
@@ -282,7 +282,7 @@ Column[{
     DescribeOutput[
         "Simplified Jamarat augmented infrastructure",
         "Augmented graph before solving \[LongDash] structure only.",
-        mfgAugmentedPlot[jamaratEnd, jamaratEndSystem, <||>,
+        richNetworkPlot[jamaratEnd, jamaratEndSystem, <||>,
             PlotLabel -> "Simplified Jamarat infrastructure",
             ImageSize -> Large,
             ShowBoundaryValues -> False]
@@ -290,7 +290,7 @@ Column[{
     DescribeOutput[
         "Simplified Jamarat augmented solution",
         "Augmented graph with solved flow, transition, and u values.",
-        mfgAugmentedPlot[jamaratEnd, jamaratEndSystem, jamaratEndSol,
+        richNetworkPlot[jamaratEnd, jamaratEndSystem, jamaratEndSol,
             PlotLabel -> "Simplified Jamarat solution",
             ImageSize -> Large]
     ]
@@ -326,7 +326,7 @@ Column[{
     DescribeOutput[
         "Jamaratv9 augmented road-traffic graph",
         "Augmented graph showing flow and transition edges before solving.",
-        mfgAugmentedPlot[jamaratScenario, jamaratSystem, <||>,
+        richNetworkPlot[jamaratScenario, jamaratSystem, <||>,
             PlotLabel -> "Jamaratv9 augmented infrastructure",
             ImageSize -> Large,
             ShowBoundaryValues -> False]
@@ -364,7 +364,7 @@ If[Head[jamaratSol] =!= Association, jamaratSol = <|"Rules" -> jamaratSol, "Resi
     DescribeOutput[
         "Jamaratv9 augmented infrastructure",
         "Augmented graph showing flow and transition edges before solving.",
-        mfgAugmentedPlot[
+        richNetworkPlot[
             jamaratScenario,
             jamaratSystem,
             <||>,
@@ -400,7 +400,7 @@ Column[{
     DescribeOutput[
         "Jamaratv9 higher-entry-flow augmented graph",
         "Augmented graph \[LongDash] same shape as before, only boundary data changes.",
-        mfgAugmentedPlot[
+        richNetworkPlot[
             jamaratHighEntryScenario,
             jamaratHighEntrySystem,
             <||>,
@@ -444,7 +444,7 @@ jamaratHighEntryScenario
 DescribeOutput[
         "Jamarat (High) augmented solution",
         "Augmented graph with solved flow, transition, and u values.",
-        mfgAugmentedPlot[jamaratHighEntryScenario, jamaratHighEntrySystem, jamaratHighEntryTimedSol,
+        richNetworkPlot[jamaratHighEntryScenario, jamaratHighEntrySystem, jamaratHighEntryTimedSol,
             PlotLabel -> "Jamarat solution",
             ImageSize -> Large]
     ]
@@ -475,7 +475,7 @@ Column[{
     DescribeOutput[
         "Jamaratv9 augmented road-traffic graph",
         "Augmented graph showing flow and transition edges before solving.",
-        mfgAugmentedPlot[jamaratScenario, jamaratSystem, <||>,
+        richNetworkPlot[jamaratScenario, jamaratSystem, <||>,
             PlotLabel -> "Jamaratv9 augmented infrastructure",
             ImageSize -> Large]
     ],

--- a/MFGraphs/TawafWorkbook.wl
+++ b/MFGraphs/TawafWorkbook.wl
@@ -66,6 +66,126 @@ TawafCouplingPreview[sys_?mfgSystemQ, maxEqs_:8] :=
         Take[eqs, UpTo[maxEqs]]
     ];
 
+ClearAll[tawafHelixPlot];
+
+Options[tawafHelixPlot] = {
+    "ShowEquivalenceLinks" -> True,
+    "ShowVertexLabels"     -> Automatic,
+    "Pitch"                -> 0.6,
+    "Radius"               -> 3.0,
+    "LayerGap"             -> 1.2,
+    "ColorByRound"         -> True,
+    "EdgeThicknessByFlow"  -> True,
+    PlotLabel              -> Automatic,
+    ImageSize              -> Large
+};
+
+(* 3D helix visualization for a Tawaf scenario.
+   Rounds stack vertically (one full turn of angular advance per round, height
+   advancing one tick per position-step), so equivalent (round-shifted) nodes
+   sit directly above each other. Layers become concentric helices. *)
+tawafHelixPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_:<||>, opts:OptionsPattern[]] :=
+    Module[{meta, rounds, npr, layers, dz, r0, dr, showLinks, showLabels,
+            colorByR, thickByJ, encode, coord, modelEdges, integerEdges,
+            equivEdges, vertexCoords, ruleList, flowVals, jMax, thicknessFor,
+            edgeStyleRules, vertexStyles, vertices, plotLabel, imgSize,
+            roundColor, totalNodes},
+        meta   = scenarioData[s, "Tawaf"];
+        If[!AssociationQ[meta],
+            Return[Failure["tawafHelixPlot",
+                <|"MessageTemplate" -> "Scenario lacks Tawaf metadata."|>]]];
+        rounds = meta["Rounds"]; npr = meta["NodesPerRound"]; layers = meta["Layers"];
+        totalNodes = rounds * npr * layers;
+
+        dz        = OptionValue["Pitch"];
+        r0        = OptionValue["Radius"];
+        dr        = OptionValue["LayerGap"];
+        showLinks = TrueQ[OptionValue["ShowEquivalenceLinks"]];
+        showLabels = Replace[OptionValue["ShowVertexLabels"],
+            Automatic :> (totalNodes <= 24)];
+        colorByR  = TrueQ[OptionValue["ColorByRound"]];
+        thickByJ  = TrueQ[OptionValue["EdgeThicknessByFlow"]];
+        plotLabel = Replace[OptionValue[PlotLabel], Automatic ->
+            StringTemplate["Tawaf helix ``\[Times]``\[Times]``"][rounds, npr, layers]];
+        imgSize   = OptionValue[ImageSize];
+
+        encode[r_, p_, l_] := (l - 1)*rounds*npr + (r - 1)*npr + p;
+        coord[r_, p_, l_]  := {
+            (r0 + (l - 1) dr) Cos[2 Pi (p - 1)/npr],
+            (r0 + (l - 1) dr) Sin[2 Pi (p - 1)/npr],
+            ((r - 1) npr + (p - 1)) dz
+        };
+
+        vertices = Flatten @ Table[encode[r, p, l],
+            {l, layers}, {r, rounds}, {p, npr}];
+
+        vertexCoords = Flatten[
+            Table[encode[r, p, l] -> coord[r, p, l],
+                {l, layers}, {r, rounds}, {p, npr}],
+            2];
+
+        modelEdges = EdgeList[scenarioData[s, "Model"]["Graph"]];
+        integerEdges = Select[modelEdges,
+            IntegerQ[#[[1]]] && IntegerQ[#[[2]]] &];
+
+        equivEdges = If[showLinks && rounds >= 2,
+            Flatten @ Table[
+                UndirectedEdge[encode[r, p, l], encode[r + 1, p, l]],
+                {l, layers}, {p, npr}, {r, rounds - 1}],
+            {}];
+
+        ruleList = Which[
+            sol === <||> || sol === {}, {},
+            AssociationQ[sol], Lookup[sol, "Rules", {}],
+            ListQ[sol], sol,
+            True, {}
+        ];
+
+        flowVals = If[ruleList === {}, <||>,
+            Association @ Cases[ruleList,
+                HoldPattern[j[a_Integer, b_Integer] -> v_?NumericQ] :>
+                    ({a, b} -> Abs[N[v]])]
+        ];
+        jMax = If[Length[flowVals] === 0, 1, Max[Values[flowVals], 1]];
+
+        thicknessFor[edge_] := With[{key = {edge[[1]], edge[[2]]}},
+            If[thickByJ && KeyExistsQ[flowVals, key],
+                AbsoluteThickness[1 + 5 flowVals[key]/jMax],
+                AbsoluteThickness[1.2]]];
+
+        edgeStyleRules = Join[
+            Map[Function[e,
+                e -> Directive[RGBColor[0.20, 0.40, 0.75], thicknessFor[e]]],
+                integerEdges],
+            Map[Function[e,
+                e -> Directive[GrayLevel[0.65], Dashed, AbsoluteThickness[0.6]]],
+                equivEdges]
+        ];
+
+        roundColor[r_] := Blend[
+            {RGBColor[0.85, 0.25, 0.25], RGBColor[0.25, 0.35, 0.85]},
+            If[rounds === 1, 0.5, (r - 1)/(rounds - 1)]];
+
+        vertexStyles = Flatten @ Table[
+            encode[r, p, l] -> If[colorByR, roundColor[r], GrayLevel[0.5]],
+            {l, layers}, {r, rounds}, {p, npr}];
+
+        Graph3D[
+            vertices,
+            Join[integerEdges, equivEdges],
+            VertexCoordinates -> vertexCoords,
+            VertexStyle       -> vertexStyles,
+            VertexSize        -> 0.18,
+            VertexLabels      -> If[showLabels,
+                                    Placed[Automatic, Center],
+                                    None],
+            EdgeStyle         -> edgeStyleRules,
+            PlotLabel         -> plotLabel,
+            ImageSize         -> imgSize,
+            Boxed             -> False
+        ]
+    ];
+
 
 (* ::Subsection:: *)
 (*Smallest coupled case: 2 rounds, 3 nodes per round, 1 layer*)
@@ -89,7 +209,7 @@ DescribeOutput[
 DescribeOutput[
     "2\[Times]3\[Times]1 physical network",
     "Six logical nodes arranged as two rounds. Entry at vertex 1, exit at vertex 6.",
-    scenarioTopologyPlot[tawaf2x3, tawaf2x3System,
+    rawNetworkPlot[tawaf2x3, tawaf2x3System,
         PlotLabel -> "Tawaf 2\[Times]3\[Times]1 \[LongDash] physical topology",
         ImageSize -> Medium]
 ]
@@ -98,7 +218,7 @@ DescribeOutput[
 DescribeOutput[
     "2\[Times]3\[Times]1 augmented infrastructure (structure only)",
     "Augmented road-traffic graph before solving. Anti-parallel arcs separate so both directions are visible.",
-    mfgAugmentedPlot[tawaf2x3, tawaf2x3System, <||>,
+    richNetworkPlot[tawaf2x3, tawaf2x3System,
         PlotLabel -> "Tawaf 2\[Times]3\[Times]1 \[LongDash] augmented (structure)",
         ShowBoundaryValues -> False,
         ImageSize -> Large]
@@ -125,7 +245,7 @@ DescribeOutput[
 DescribeOutput[
     "2\[Times]3\[Times]1 augmented infrastructure with solved flows",
     "Blue arcs are flow variables j[a,b]; red arcs are transition flows j[r,i,w]. Node colors show u-values on a Red\[Rule]Blue gradient.",
-    mfgAugmentedPlot[tawaf2x3, tawaf2x3System, tawaf2x3Sol,
+    richNetworkPlot[tawaf2x3, tawaf2x3System, tawaf2x3Sol,
         PlotLabel -> "Tawaf 2\[Times]3\[Times]1 \[LongDash] solved",
         ImageSize -> Large]
 ]
@@ -134,9 +254,26 @@ DescribeOutput[
 DescribeOutput[
     "2\[Times]3\[Times]1 flow plot",
     "Real network with auxiliary entry/exit; edge labels show solved j-values.",
-    mfgFlowPlot[tawaf2x3, tawaf2x3System, tawaf2x3Sol,
+    rawNetworkPlot[tawaf2x3, tawaf2x3System, tawaf2x3Sol,
+        ShowAuxiliaryVertices -> True,
         PlotLabel -> "Tawaf 2\[Times]3\[Times]1 \[LongDash] flow values",
         ImageSize -> Large]
+]
+
+
+DescribeOutput[
+    "2\[Times]3\[Times]1 helix view (structure, with equivalence links)",
+    "3D layout: angle = position, height = (round, position) in flattened sequence. Dashed gray edges connect equivalent (same position, different round) nodes.",
+    tawafHelixPlot[tawaf2x3, tawaf2x3System, <||>,
+        PlotLabel -> "Tawaf 2\[Times]3\[Times]1 \[LongDash] helix (structure)"]
+]
+
+
+DescribeOutput[
+    "2\[Times]3\[Times]1 helix view with solved flows",
+    "Edge thickness encodes |j[a,b]|; round is encoded by the red\[Rule]blue node gradient.",
+    tawafHelixPlot[tawaf2x3, tawaf2x3System, tawaf2x3Sol,
+        PlotLabel -> "Tawaf 2\[Times]3\[Times]1 \[LongDash] helix (solved)"]
 ]
 
 
@@ -161,7 +298,7 @@ DescribeOutput[
 DescribeOutput[
     "3\[Times]4\[Times]1 augmented infrastructure (structure only)",
     "Pre-solve augmented graph.",
-    mfgAugmentedPlot[tawaf3x4, tawaf3x4System, <||>,
+    richNetworkPlot[tawaf3x4, tawaf3x4System,
         PlotLabel -> "Tawaf 3\[Times]4\[Times]1 \[LongDash] augmented (structure)",
         ShowBoundaryValues -> False,
         ImageSize -> Large]
@@ -182,9 +319,17 @@ DescribeOutput[
 DescribeOutput[
     "3\[Times]4\[Times]1 augmented infrastructure with solved flows",
     "u-value gradient and flow-magnitude edge thickness reveal where congestion concentrates.",
-    mfgAugmentedPlot[tawaf3x4, tawaf3x4System, tawaf3x4Sol,
+    richNetworkPlot[tawaf3x4, tawaf3x4System, tawaf3x4Sol,
         PlotLabel -> "Tawaf 3\[Times]4\[Times]1 \[LongDash] solved",
         ImageSize -> Large]
+]
+
+
+DescribeOutput[
+    "3\[Times]4\[Times]1 helix view with solved flows",
+    "Three rounds, four positions per round. Dashed equivalence links climb vertically through each angular column.",
+    tawafHelixPlot[tawaf3x4, tawaf3x4System, tawaf3x4Sol,
+        PlotLabel -> "Tawaf 3\[Times]4\[Times]1 \[LongDash] helix (solved)"]
 ]
 
 
@@ -209,7 +354,7 @@ DescribeOutput[
 DescribeOutput[
     "2\[Times]3\[Times]2 augmented infrastructure (structure only)",
     "Pre-solve augmented graph for the multi-layer case.",
-    mfgAugmentedPlot[tawaf2x3x2, tawaf2x3x2System, <||>,
+    richNetworkPlot[tawaf2x3x2, tawaf2x3x2System,
         PlotLabel -> "Tawaf 2\[Times]3\[Times]2 \[LongDash] augmented (structure)",
         ShowBoundaryValues -> False,
         ImageSize -> Large]
@@ -224,11 +369,21 @@ If[Head[tawaf2x3x2Sol] =!= Symbol || tawaf2x3x2Sol =!= $TimedOut,
     DescribeOutput[
         "2\[Times]3\[Times]2 augmented infrastructure with solved flows",
         "Multi-layer solved system. Radial coupling distinguishes outward vs inward.",
-        mfgAugmentedPlot[tawaf2x3x2, tawaf2x3x2System, tawaf2x3x2Sol,
+        richNetworkPlot[tawaf2x3x2, tawaf2x3x2System, tawaf2x3x2Sol,
             PlotLabel -> "Tawaf 2\[Times]3\[Times]2 \[LongDash] solved",
             ImageSize -> Large]
     ],
     Print["2\[Times]3\[Times]2 solve timed out; skipping solved plot."]
+]
+
+
+DescribeOutput[
+    "2\[Times]3\[Times]2 helix view (concentric helices for layers)",
+    "Two concentric helices (one per layer). Radial edges connect adjacent layers at matching (round, position).",
+    tawafHelixPlot[tawaf2x3x2, tawaf2x3x2System,
+        If[Head[tawaf2x3x2Sol] === Symbol && tawaf2x3x2Sol === $TimedOut,
+            <||>, tawaf2x3x2Sol],
+        PlotLabel -> "Tawaf 2\[Times]3\[Times]2 \[LongDash] helix"]
 ]
 
 
@@ -254,10 +409,19 @@ DescribeOutput[
 DescribeOutput[
     "7\[Times]8\[Times]1 augmented infrastructure (structure only)",
     "Pre-solve augmented graph for the canonical case.",
-    mfgAugmentedPlot[tawaf7x8, tawaf7x8System, <||>,
+    richNetworkPlot[tawaf7x8, tawaf7x8System,
         PlotLabel -> "Tawaf 7\[Times]8\[Times]1 \[LongDash] augmented (structure)",
         ShowBoundaryValues -> False,
         ImageSize -> Large]
+]
+
+
+DescribeOutput[
+    "7\[Times]8\[Times]1 helix view (structure only)",
+    "Canonical 7-turn helix; equivalence links disabled to reduce clutter at 56 nodes.",
+    tawafHelixPlot[tawaf7x8, tawaf7x8System, <||>,
+        "ShowEquivalenceLinks" -> False,
+        PlotLabel -> "Tawaf 7\[Times]8\[Times]1 \[LongDash] helix (structure)"]
 ]
 
 
@@ -267,7 +431,7 @@ DescribeOutput[
 
 (* If you computed tawaf7x8Sol above and it is not $TimedOut, render with: *)
 (*
-mfgAugmentedPlot[tawaf7x8, tawaf7x8System, tawaf7x8Sol,
+richNetworkPlot[tawaf7x8, tawaf7x8System, tawaf7x8Sol,
     PlotLabel -> "Tawaf 7\[Times]8\[Times]1 \[LongDash] solved",
     ImageSize -> Large]
 *)

--- a/MFGraphs/Tests/graphicsTools.mt
+++ b/MFGraphs/Tests/graphicsTools.mt
@@ -1,19 +1,17 @@
-(* Tests for Graphics helpers *)
+(* Tests for the consolidated graphics surface: rawNetworkPlot, richNetworkPlot,
+   and augmentAuxiliaryGraph. *)
 
 Test[
-    NameQ["graphicsTools`scenarioTopologyPlot"] && NameQ["graphicsTools`mfgSolutionPlot"] &&
-    NameQ["graphicsTools`mfgFlowPlot"] && NameQ["graphicsTools`mfgValuePlot"] &&
-    NameQ["graphicsTools`mfgDensityPlot"] && NameQ["graphicsTools`mfgTransitionPlot"] &&
-    NameQ["graphicsTools`mfgAugmentedPlot"] && NameQ["graphicsTools`augmentAuxiliaryGraph"],
+    NameQ["graphicsTools`rawNetworkPlot"] &&
+    NameQ["graphicsTools`richNetworkPlot"] &&
+    NameQ["graphicsTools`augmentAuxiliaryGraph"],
     True,
     TestID -> "GraphicsTools: public symbols exist"
 ]
 
 Test[
     Module[{names, globalNames},
-        names = {"scenarioTopologyPlot", "mfgSolutionPlot", "mfgFlowPlot",
-            "mfgValuePlot", "mfgDensityPlot", "mfgTransitionPlot",
-            "mfgAugmentedPlot", "augmentAuxiliaryGraph"};
+        names = {"rawNetworkPlot", "richNetworkPlot", "augmentAuxiliaryGraph"};
         globalNames = ("Global`" <> #) & /@ names;
         Scan[If[NameQ[#], Remove[#]] &, globalNames];
         Needs["MFGraphs`"];
@@ -24,308 +22,287 @@ Test[
 ]
 
 Test[
-    Module[{s, sys, sol, topoPlot, solPlot, flowPlot},
+    Module[{names},
+        names = {"scenarioTopologyPlot", "mfgSolutionPlot", "mfgFlowPlot",
+                 "mfgValuePlot", "mfgDensityPlot", "mfgTransitionPlot",
+                 "mfgAugmentedPlot", "mfgAugmentedBoundaryPlot"};
+        AllTrue[names, !NameQ["graphicsTools`" <> #] &]
+    ],
+    True,
+    TestID -> "GraphicsTools: deprecated public symbols are removed"
+]
+
+Test[
+    Module[{s, sys, sol, plot},
         s = gridScenario[{3}, {{1, 120}}, {{2, 10}, {3, 0}}];
         sys = makeSystem[s];
         sol = solveScenario[s];
-        topoPlot = scenarioTopologyPlot[s, sys];
-        solPlot = mfgSolutionPlot[s, sys, sol];
-        flowPlot = mfgFlowPlot[s, sys, sol];
-        MatchQ[topoPlot, _Graph] && MatchQ[solPlot, _Graphics | _GraphicsGrid] &&
-        MatchQ[flowPlot, _Graph]
+        plot = rawNetworkPlot[s, sys, sol];
+        MatchQ[plot, _Graph | _Legended]
     ],
     True,
-    TestID -> "GraphicsTools: topology, solution grid, and flow plots return renderable expressions"
+    TestID -> "GraphicsTools: rawNetworkPlot returns renderable expression"
 ]
 
 Test[
-    Module[{s, sys, sol, edges},
+    Module[{s, sys, sol, plot},
         s = gridScenario[{3}, {{1, 120}}, {{2, 10}, {3, 0}}];
         sys = makeSystem[s];
         sol = solveScenario[s];
-        edges = EdgeList[mfgFlowPlot[s, sys, sol]];
-        MemberQ[edges, DirectedEdge[1, 2]]
+        plot = richNetworkPlot[s, sys, sol];
+        MatchQ[plot, _Graph | _Legended]
     ],
     True,
-    TestID -> "GraphicsTools: mfgFlowPlot positive j[1,2] displays as DirectedEdge[1,2]"
+    TestID -> "GraphicsTools: richNetworkPlot returns renderable expression"
 ]
 
 Test[
-    Module[{s, sys, sol, edges},
-        s = gridScenario[{3}, {{3, 120.0}}, {{1, 0.0}, {2, 10.0}}];
-        sys = makeSystem[s];
-        sol = {j[1, 2] -> 0, j[2, 1] -> 5};
-        edges = EdgeList[mfgFlowPlot[s, sys, sol]];
-        MemberQ[edges, DirectedEdge[2, 1]]
-    ],
-    True,
-    TestID -> "GraphicsTools: mfgFlowPlot negative net flow flips display direction to DirectedEdge[2,1]"
-]
-
-Test[
-    Module[{s, sys, sol, graph, edges},
+    Module[{s, sys, plot, vlist},
         s = gridScenario[{3}, {{1, 120}}, {{2, 10}, {3, 0}}];
         sys = makeSystem[s];
-        sol = solveScenario[s];
-        graph = mfgFlowPlot[s, sys, sol];
-        edges = EdgeList[graph];
-        AllTrue[edges, MatchQ[#, _DirectedEdge] &] &&
-        Length[edges] == Length[systemData[sys, "AuxEdges"]]
+        plot = rawNetworkPlot[s, sys];
+        vlist = VertexList[plot];
+        AllTrue[{1, 2, 3}, MemberQ[vlist, #] &] &&
+        AllTrue[vlist, NumericQ]
     ],
     True,
-    TestID -> "GraphicsTools: mfgFlowPlot displays every auxiliary edge as directed"
+    TestID -> "GraphicsTools: rawNetworkPlot without sol shows real vertices only"
 ]
 
 Test[
-    Module[{s, sys, sol, graph, labelText},
+    Module[{s, sys, plot, vlist},
         s = gridScenario[{3}, {{1, 120}}, {{2, 10}, {3, 0}}];
         sys = makeSystem[s];
-        sol = solveScenario[s];
-        graph = mfgFlowPlot[s, sys, sol];
-        labelText = ToString[InputForm[AbsoluteOptions[graph, EdgeLabels]]];
-        StringContainsQ[labelText, "EdgeLabels"] && !StringContainsQ[labelText, "u="]
+        plot = rawNetworkPlot[s, sys, ShowAuxiliaryVertices -> True];
+        vlist = VertexList[plot];
+        MemberQ[vlist, "auxEntry1"] && MemberQ[vlist, "auxExit2"] &&
+        MemberQ[vlist, "auxExit3"]
     ],
     True,
-    TestID -> "GraphicsTools: mfgFlowPlot edge labels omit value functions"
+    TestID -> "GraphicsTools: ShowAuxiliaryVertices includes auxiliary vertices"
 ]
 
 Test[
-    Module[{s, sys, sol, graph, edgeStyleText},
+    Module[{s, sys, plot, vlist},
         s = gridScenario[{3}, {{1, 120}}, {{2, 10}, {3, 0}}];
         sys = makeSystem[s];
-        sol = solveScenario[s];
-        graph = mfgFlowPlot[s, sys, sol];
-        edgeStyleText = ToString[InputForm[AbsoluteOptions[graph, EdgeStyle]]];
-        StringContainsQ[edgeStyleText, "AbsoluteThickness[2."]
+        (* ShowBoundaryData should force aux visibility *)
+        plot = rawNetworkPlot[s, sys, ShowBoundaryData -> True,
+                              ShowAuxiliaryVertices -> False];
+        vlist = VertexList[plot];
+        MemberQ[vlist, "auxEntry1"]
     ],
     True,
-    TestID -> "GraphicsTools: mfgFlowPlot uses fixed edge thickness"
+    TestID -> "GraphicsTools: ShowBoundaryData forces aux visibility"
 ]
 
 Test[
-    Module[{s, sys, topoPlot, solPlot},
+    Module[{s, sys, plot, styles, vstyle, entryColor, exitColor, internalColor},
         s = gridScenario[{3}, {{1, 120}}, {{2, 10}, {3, 0}}];
         sys = makeSystem[s];
-        topoPlot = scenarioTopologyPlot[s, sys, "Topology custom title"];
-        solPlot = mfgSolutionPlot[s, sys, <||>, "Solution custom title"];
-        !FreeQ[AbsoluteOptions[topoPlot, PlotLabel], "Topology custom title"] &&
-        !FreeQ[AbsoluteOptions[solPlot, PlotLabel], "Solution custom title"]
+        plot = rawNetworkPlot[s, sys];
+        vstyle = AbsoluteOptions[plot, VertexStyle][[1, 2]];
+        styles = Association[vstyle];
+        entryColor = Lookup[styles, 1, Missing[]];
+        exitColor = Lookup[styles, 2, Missing[]];
+        internalColor = Lookup[styles, 3, Missing[]];
+        (* All real vertices should be gray (GrayLevel) *)
+        MatchQ[entryColor, _GrayLevel] &&
+        MatchQ[exitColor, _GrayLevel] &&
+        MatchQ[internalColor, _GrayLevel]
     ],
     True,
-    TestID -> "GraphicsTools: custom titles propagate to PlotLabel"
+    TestID -> "GraphicsTools: rawNetworkPlot real vertices are gray (no solution)"
 ]
 
 Test[
-    Module[{s, sys, sol, plots},
+    Module[{s, sys, sol, plot, vstyle, styles, entryColor},
         s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
         sys = makeSystem[s];
         sol = solveScenario[s];
-        plots = {
-            scenarioTopologyPlot[s, sys, GraphLayout -> "LayeredDigraphEmbedding",
-                PlotLabel -> "Topology option", ImageSize -> Medium],
-            mfgSolutionPlot[s, sys, sol, GraphLayout -> "LayeredDigraphEmbedding",
-                PlotLabel -> "Solution option", ImageSize -> Medium],
-            mfgFlowPlot[s, sys, sol, GraphLayout -> "LayeredDigraphEmbedding",
-                PlotLabel -> "Flow option", ImageSize -> Medium],
-            mfgValuePlot[s, sys, sol, GraphLayout -> "LayeredDigraphEmbedding",
-                PlotLabel -> "Value option", ImageSize -> Medium],
-            mfgDensityPlot[s, sys, sol, GraphLayout -> "LayeredDigraphEmbedding",
-                PlotLabel -> "Density option", ImageSize -> Medium],
-            mfgTransitionPlot[s, sys, sol, GraphLayout -> "LayeredDigraphEmbedding",
-                PlotLabel -> "Transition option", ImageSize -> Medium,
-                ShowLegend -> False],
-            mfgAugmentedPlot[s, sys, sol, GraphLayout -> "LayeredDigraphEmbedding",
-                PlotLabel -> "Augmented option", ImageSize -> Medium,
-                ShowLegend -> False]
-        };
-        MatchQ[plots[[2]], _Graphics | _GraphicsGrid] &&
-        AllTrue[Delete[plots, 2], MatchQ[#, _Graph] &] &&
-        And @@ MapThread[
-            !FreeQ[AbsoluteOptions[#1, PlotLabel], #2] &,
-            {plots, {"Topology option", "Solution option", "Flow option",
-                "Value option", "Density option", "Transition option", "Augmented option"}}
-        ] &&
-        AllTrue[
-            Delete[plots, 2],
-            !FreeQ[AbsoluteOptions[#, GraphLayout], "LayeredDigraphEmbedding"] &
-        ]
+        plot = rawNetworkPlot[s, sys, sol];
+        vstyle = AbsoluteOptions[
+            Replace[plot, Legended[g_, _] :> g], VertexStyle][[1, 2]];
+        styles = Association[vstyle];
+        entryColor = Lookup[styles, 1, Missing[]];
+        (* Real vertex 1 must remain gray even with a solution *)
+        MatchQ[entryColor, _GrayLevel]
     ],
     True,
-    TestID -> "GraphicsTools: graph helpers accept PlotLabel GraphLayout and ImageSize options"
+    TestID -> "GraphicsTools: rawNetworkPlot real vertices stay gray with solution"
 ]
 
 Test[
-    Module[{s, sys, sol, plots},
-        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
-        sys = makeSystem[s];
-        sol = solveScenario[s];
-        plots = {
-            scenarioTopologyPlot[s, sys, PlotLabel -> None],
-            mfgSolutionPlot[s, sys, sol, PlotLabel -> None],
-            mfgFlowPlot[s, sys, sol, PlotLabel -> None],
-            mfgValuePlot[s, sys, sol, PlotLabel -> None],
-            mfgDensityPlot[s, sys, sol, PlotLabel -> None],
-            mfgTransitionPlot[s, sys, sol, PlotLabel -> None, ShowLegend -> False],
-            mfgAugmentedPlot[s, sys, sol, PlotLabel -> None, ShowLegend -> False]
-        };
-        MatchQ[plots[[2]], _Graphics | _GraphicsGrid] &&
-        AllTrue[Delete[plots, 2], MatchQ[#, _Graph] &] &&
-        AllTrue[plots, FreeQ[AbsoluteOptions[#, PlotLabel], _Style] &]
-    ],
-    True,
-    TestID -> "GraphicsTools: PlotLabel -> None suppresses styled label for all plot helpers"
-]
-
-Test[
-    Module[{s, sys, sol, transitionPlot, augmentedPlot, transitionFile,
-            augmentedFile, transitionDims, augmentedDims},
-        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
-        sys = makeSystem[s];
-        sol = solveScenario[s];
-        transitionPlot = mfgTransitionPlot[s, sys, sol,
-            GraphLayout -> "LayeredDigraphEmbedding"];
-        augmentedPlot = mfgAugmentedPlot[s, sys, sol,
-            GraphLayout -> "LayeredDigraphEmbedding"];
-        transitionFile = FileNameJoin[{$TemporaryDirectory, "mfg-transition-render-test.png"}];
-        augmentedFile = FileNameJoin[{$TemporaryDirectory, "mfg-augmented-render-test.png"}];
-        Export[transitionFile, transitionPlot];
-        Export[augmentedFile, augmentedPlot];
-        transitionDims = ImageDimensions @ Import[transitionFile];
-        augmentedDims = ImageDimensions @ Import[augmentedFile];
-        MatchQ[transitionPlot, _Graph | _Legended] &&
-        MatchQ[augmentedPlot, _Graph | _Legended] &&
-        Min[transitionDims] > 100 &&
-        Min[augmentedDims] > 100
-    ],
-    True,
-    TestID -> "GraphicsTools: transition and augmented plots render to nontrivial images"
-]
-
-Test[
-    Module[{s, sys, graph, labelText},
-        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
-        sys = makeSystem[s];
-        graph = mfgValuePlot[s, sys, {u[1, 2] -> 0., u[2, 1] -> 4.}];
-        labelText = ToString[InputForm[AbsoluteOptions[graph, EdgeLabels]]];
-        MatchQ[graph, _Graph] &&
-        StringContainsQ[labelText, "1/2"] &&
-        StringContainsQ[labelText, "2."]
-    ],
-    True,
-    TestID -> "GraphicsTools: mfgValuePlot labels include interpolated midpoint values"
-]
-
-Test[
-    Module[{s, sys, graph, labelText},
-        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
-        sys = makeSystem[s];
-        graph = mfgDensityPlot[s, sys, {j[1, 2] -> 0, j[2, 1] -> 0}];
-        labelText = ToString[InputForm[AbsoluteOptions[graph, EdgeLabels]]];
-        MatchQ[graph, _Graph] && StringContainsQ[labelText, "m="] &&
-        StringContainsQ[labelText, "0."]
-    ],
-    True,
-    TestID -> "GraphicsTools: mfgDensityPlot displays zero density for zero flow"
-]
-
-Test[
-    Module[{s, sys, graph, labelText},
-        s = makeScenario[<|"Model" -> <|
-            "Vertices" -> {1, 2},
-            "Adjacency" -> {{0, 1}, {1, 0}},
-            "Entries" -> {{1, 1}},
-            "Exits" -> {{2, 0}},
-            "Switching" -> {}
-        |>|>];
-        sys = makeSystem[s];
-        graph = mfgDensityPlot[s, sys, {j[1, 2] -> 2, j[2, 1] -> 0}];
-        labelText = ToString[InputForm[AbsoluteOptions[graph, EdgeLabels]]];
-        MatchQ[graph, _Graph] && StringContainsQ[labelText, "3."]
-    ],
-    True,
-    TestID -> "GraphicsTools: mfgDensityPlot solves positive density with default Hamiltonian"
-]
-
-Test[
-    Module[{s, sys, graph, labelText},
-        s = makeScenario[<|
-            "Model" -> <|
-                "Vertices" -> {1, 2},
-                "Adjacency" -> {{0, 1}, {1, 0}},
-                "Entries" -> {{1, 1}},
-                "Exits" -> {{2, 0}},
-                "Switching" -> {}
-            |>,
-            "Hamiltonian" -> <|
-                "Alpha" -> 1,
-                "V" -> -2,
-                "G" -> Function[z, -2/z]
-            |>
-        |>];
-        sys = makeSystem[s];
-        graph = mfgDensityPlot[s, sys, {j[1, 2] -> 2, j[2, 1] -> 0}];
-        labelText = ToString[InputForm[AbsoluteOptions[graph, EdgeLabels]]];
-        MatchQ[graph, _Graph] && StringContainsQ[labelText, "2."]
-    ],
-    True,
-    TestID -> "GraphicsTools: mfgDensityPlot uses scenario Hamiltonian defaults"
-]
-
-Test[
-    Module[{s, sBroken, sys, graph, labelText},
-        s = gridScenario[{2}, {{1, 10}}, {{2, 0}}];
-        sys = makeSystem[s];
-        sBroken = scenario[Join[scenarioData[s], <|"Hamiltonian" -> <||>|>]];
-        graph = mfgDensityPlot[sBroken, sys, {j[1, 2] -> 2, j[2, 1] -> 0}];
-        labelText = ToString[InputForm[AbsoluteOptions[graph, EdgeLabels]]];
-        MatchQ[graph, _Graph] && StringContainsQ[labelText, "?"]
-    ],
-    True,
-    TestID -> "GraphicsTools: mfgDensityPlot reports malformed Hamiltonian as unknown density"
-]
-
-Test[
-    Module[{s, sys, graph, labelText},
-        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
-        sys = makeSystem[s];
-        graph = mfgDensityPlot[s, sys, <||>];
-        labelText = ToString[InputForm[AbsoluteOptions[graph, EdgeLabels]]];
-        MatchQ[graph, _Graph] && StringContainsQ[labelText, "?"]
-    ],
-    True,
-    TestID -> "GraphicsTools: mfgDensityPlot renders missing solution rules as unknown density"
-]
-
-Test[
-    Module[{s, sys, sol, rules},
+    Module[{s, sys, plot, vstyle, styles, entryColor, exitColor},
         s = gridScenario[{3}, {{1, 120}}, {{2, 10}, {3, 0}}];
         sys = makeSystem[s];
-        sol = solveScenario[s];
-        rules = Replace[sol, a_Association :> Lookup[a, "Rules", {}]];
-        MatchQ[mfgSolutionPlot[s, sys, rules], _Graphics | _GraphicsGrid] &&
-        MatchQ[mfgFlowPlot[s, sys, rules], _Graph] &&
-        MatchQ[mfgValuePlot[s, sys, rules], _Graph] &&
-        MatchQ[mfgDensityPlot[s, sys, rules], _Graph]
+        plot = rawNetworkPlot[s, sys, ShowAuxiliaryVertices -> True];
+        vstyle = AbsoluteOptions[plot, VertexStyle][[1, 2]];
+        styles = Association[vstyle];
+        entryColor = Lookup[styles, "auxEntry1", Missing[]];
+        exitColor = Lookup[styles, "auxExit3", Missing[]];
+        MatchQ[entryColor, _RGBColor] && MatchQ[exitColor, _RGBColor]
     ],
     True,
-    TestID -> "GraphicsTools: solution panels accept raw rule list solution"
+    TestID -> "GraphicsTools: aux vertices receive category colors when shown"
 ]
 
 Test[
-    Module[{s, sys, graph, flowGraph, valueGraph, densityGraph},
-        s = gridScenario[{3}, {{1, 120}}, {{2, 10}, {3, 0}}];
+    Module[{s, sys, sol, ruleList, assoc, plotA, plotB},
+        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
         sys = makeSystem[s];
-        graph = mfgSolutionPlot[s, sys, <||>];
-        flowGraph = mfgFlowPlot[s, sys, <||>];
-        valueGraph = mfgValuePlot[s, sys, <||>];
-        densityGraph = mfgDensityPlot[s, sys, <||>];
-        MatchQ[graph, _Graphics | _GraphicsGrid] &&
-        MatchQ[flowGraph, _Graph] && Length[EdgeList[flowGraph]] > 0 &&
-        MatchQ[valueGraph, _Graph] && Length[EdgeList[valueGraph]] > 0 &&
-        MatchQ[densityGraph, _Graph] && Length[EdgeList[densityGraph]] > 0
+        sol = solveScenario[s];
+        ruleList = Replace[sol, a_Association :> Lookup[a, "Rules", {}]];
+        assoc = <|"Rules" -> ruleList, "Residual" -> True|>;
+        plotA = rawNetworkPlot[s, sys, ruleList];
+        plotB = rawNetworkPlot[s, sys, assoc];
+        MatchQ[plotA, _Graph | _Legended] && MatchQ[plotB, _Graph | _Legended]
     ],
     True,
-    TestID -> "GraphicsTools: solution panels handle missing Rules association without failure"
+    TestID -> "GraphicsTools: rawNetworkPlot accepts rule list and association forms"
+]
+
+Test[
+    Module[{s, sys, plot, edges},
+        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
+        sys = makeSystem[s];
+        plot = richNetworkPlot[s, sys];
+        edges = EdgeList[Replace[plot, Legended[g_, _] :> g]];
+        MemberQ[edges, DirectedEdge[{1, "auxEntry1"}, {"auxEntry1", 1}]] &&
+        MemberQ[edges, DirectedEdge[{"auxEntry1", 1}, {2, 1}]]
+    ],
+    True,
+    TestID -> "GraphicsTools: richNetworkPlot includes flow and transition edges by default"
+]
+
+Test[
+    Module[{s, sys, plot, edges, kinds},
+        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
+        sys = makeSystem[s];
+        plot = richNetworkPlot[s, sys, ShowFlowEdges -> False];
+        edges = EdgeList[Replace[plot, Legended[g_, _] :> g]];
+        (* Without flow edges, the entry-flow self-loop arc should not appear *)
+        !MemberQ[edges, DirectedEdge[{1, "auxEntry1"}, {"auxEntry1", 1}]] &&
+        Length[edges] > 0
+    ],
+    True,
+    TestID -> "GraphicsTools: richNetworkPlot ShowFlowEdges->False yields transition-only graph"
+]
+
+Test[
+    Module[{s, sys, plot, vstyle, styles, inNode, otherNode},
+        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
+        sys = makeSystem[s];
+        plot = richNetworkPlot[s, sys];
+        vstyle = AbsoluteOptions[
+            Replace[plot, Legended[g_, _] :> g], VertexStyle][[1, 2]];
+        styles = Association[vstyle];
+        (* {realV, auxEntry} is the "in" node — should be green RGBColor *)
+        inNode = Lookup[styles, Key[{1, "auxEntry1"}], Missing[]];
+        (* {auxEntry, realV} has aux at position 1 — should be gray *)
+        otherNode = Lookup[styles, Key[{"auxEntry1", 1}], Missing[]];
+        MatchQ[inNode, _RGBColor] && MatchQ[otherNode, _GrayLevel]
+    ],
+    True,
+    TestID -> "GraphicsTools: richNetworkPlot only colors label-position aux nodes"
+]
+
+Test[
+    Module[{s, sys, sol, plot, ruleList},
+        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
+        sys = makeSystem[s];
+        sol = solveScenario[s];
+        ruleList = Replace[sol, a_Association :> Lookup[a, "Rules", {}]];
+        plot = richNetworkPlot[s, sys, ruleList];
+        MatchQ[plot, _Graph | _Legended]
+    ],
+    True,
+    TestID -> "GraphicsTools: richNetworkPlot accepts rule list solution"
+]
+
+Test[
+    Module[{s, sys, plotA, plotB},
+        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
+        sys = makeSystem[s];
+        plotA = rawNetworkPlot[s, sys, "Custom raw title"];
+        plotB = richNetworkPlot[s, sys, "Custom rich title"];
+        !FreeQ[AbsoluteOptions[Replace[plotA, Legended[g_, _] :> g], PlotLabel],
+               "Custom raw title"] &&
+        !FreeQ[AbsoluteOptions[Replace[plotB, Legended[g_, _] :> g], PlotLabel],
+               "Custom rich title"]
+    ],
+    True,
+    TestID -> "GraphicsTools: positional title argument propagates to PlotLabel"
+]
+
+Test[
+    Module[{s, sys, sol, plot},
+        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
+        sys = makeSystem[s];
+        sol = solveScenario[s];
+        plot = rawNetworkPlot[s, sys, sol,
+            GraphLayout -> "LayeredDigraphEmbedding",
+            PlotLabel -> "Layout test",
+            ImageSize -> Medium,
+            ShowLegend -> False];
+        !FreeQ[AbsoluteOptions[Replace[plot, Legended[g_, _] :> g], GraphLayout],
+               "LayeredDigraphEmbedding"]
+    ],
+    True,
+    TestID -> "GraphicsTools: GraphLayout / PlotLabel / ImageSize options propagate"
+]
+
+Test[
+    Module[{s, sys, plot},
+        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
+        sys = makeSystem[s];
+        plot = rawNetworkPlot[s, sys, PlotLabel -> None];
+        FreeQ[AbsoluteOptions[plot, PlotLabel], _Style]
+    ],
+    True,
+    TestID -> "GraphicsTools: PlotLabel -> None suppresses styled label"
+]
+
+Test[
+    Module[{s, sys, plot, file, dims},
+        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
+        sys = makeSystem[s];
+        plot = richNetworkPlot[s, sys, GraphLayout -> "LayeredDigraphEmbedding"];
+        file = FileNameJoin[{$TemporaryDirectory, "rich-render-test.png"}];
+        Export[file, plot];
+        dims = ImageDimensions @ Import[file];
+        Min[dims] > 100
+    ],
+    True,
+    TestID -> "GraphicsTools: richNetworkPlot renders to nontrivial image"
+]
+
+Test[
+    Module[{s, sys, plot, labelText},
+        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
+        sys = makeSystem[s];
+        plot = rawNetworkPlot[s, sys, {u[1, 2] -> 0., u[2, 1] -> 4.},
+                              ShowFlowLabels -> False, ShowValueLabels -> True];
+        labelText = ToString[InputForm[
+            AbsoluteOptions[Replace[plot, Legended[g_, _] :> g], EdgeLabels]]];
+        StringContainsQ[labelText, "1/2"]
+    ],
+    True,
+    TestID -> "GraphicsTools: rawNetworkPlot ShowValueLabels shows interpolated u midpoints"
+]
+
+Test[
+    Module[{s, sys, plot, labelText},
+        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
+        sys = makeSystem[s];
+        plot = rawNetworkPlot[s, sys, {j[1, 2] -> 0, j[2, 1] -> 0},
+                              ShowFlowLabels -> False, ShowDensityLabels -> True];
+        labelText = ToString[InputForm[
+            AbsoluteOptions[Replace[plot, Legended[g_, _] :> g], EdgeLabels]]];
+        StringContainsQ[labelText, "m="]
+    ],
+    True,
+    TestID -> "GraphicsTools: rawNetworkPlot ShowDensityLabels shows m= prefix"
 ]
 
 Test[
@@ -392,19 +369,4 @@ Test[
     ],
     True,
     TestID -> "GraphicsTools: augmentAuxiliaryGraph records flow and transition edge kinds"
-]
-
-Test[
-    Module[{s, sys, graph, edges},
-        s = gridScenario[{3}, {{1, 10}}, {{3, 0}}];
-        sys = makeSystem[s];
-        graph = mfgAugmentedPlot[s, sys, <||>, ShowBoundaryValues -> False];
-        edges = EdgeList[graph];
-        MatchQ[graph, _Graph] &&
-        MemberQ[edges, DirectedEdge[{1, "auxEntry1"}, {"auxEntry1", 1}]] &&
-        MemberQ[edges, DirectedEdge[{"auxEntry1", 1}, {2, 1}]] &&
-        !MemberQ[edges, DirectedEdge[{1, "auxEntry1"}, {1, 2}]]
-    ],
-    True,
-    TestID -> "GraphicsTools: mfgAugmentedPlot uses augmented road-traffic graph"
 ]

--- a/MFGraphs/graphicsTools.wl
+++ b/MFGraphs/graphicsTools.wl
@@ -3,119 +3,109 @@
 
 BeginPackage["graphicsTools`", {"primitives`", "utilities`", "scenarioTools`", "systemTools`"}];
 
-scenarioTopologyPlot::usage =
-"scenarioTopologyPlot[s, sys, opts] plots the scenario topology using vertex coloring for entry (green), exit (red), and internal (gray) vertices. Options: PlotLabel (default Automatic), GraphLayout (default Automatic), ImageSize (default Medium).";
+rawNetworkPlot::usage =
+"rawNetworkPlot[s, sys, opts] and rawNetworkPlot[s, sys, sol, opts] render the physical network. Real network vertices are gray. Auxiliary entry/exit vertices and boundary edges are hidden by default. Options: ShowAuxiliaryVertices (default False), ShowBoundaryData (default False; when True forces ShowAuxiliaryVertices), ShowFlowLabels (default Automatic; True when sol provided), ShowValueLabels (default False; shows u-values with 1/4, 1/2, 3/4 interpolations), ShowDensityLabels (default False; shows inferred density m), ColorFunction (default Automatic; Red\[Rule]Blue blend over u-values), ShowLegend (default True), GraphLayout (default Automatic), PlotLabel (default Automatic), ImageSize (default Large). With a solution provided, auxiliary vertices (when shown) and shown vertex states are colored by u-value gradient; physical entry/exit vertices remain gray.";
 
-mfgSolutionPlot::usage =
-"mfgSolutionPlot[s, sys, sol, opts] plots coordinated solution views: flows, value samples, and agent density. Options: PlotLabel (default Automatic), GraphLayout (default Automatic), ImageSize (default Large).";
-
-mfgFlowPlot::usage =
-"mfgFlowPlot[s, sys, sol, opts] plots a flow-only solution graph with real and auxiliary directed edges; edge labels show j flow values. Options: PlotLabel (default Automatic), GraphLayout (default Automatic), ImageSize (default Large).";
-
-mfgValuePlot::usage =
-"mfgValuePlot[s, sys, sol, opts] plots real network edges with endpoint value variables u[a,b], u[b,a] and linearly interpolated interior samples at 1/4, 1/2, and 3/4. Options: PlotLabel (default Automatic), GraphLayout (default Automatic), ImageSize (default Large).";
-
-mfgDensityPlot::usage =
-"mfgDensityPlot[s, sys, sol, opts] plots real network edges with agent density inferred from solved signed spatial flow and the scenario Hamiltonian density equation. Options: PlotLabel (default Automatic), GraphLayout (default Automatic), ImageSize (default Large).";
-
-mfgTransitionPlot::usage =
-"mfgTransitionPlot[s, sys, sol, opts] plots the transition graph. Nodes are AuxPair states {r,i}; directed edges represent transition flows j[r,i,w] drawn as quadratic Bezier arcs so anti-parallel pairs appear on opposite sides. Nodes are colored on a u-value gradient when a solution is provided. Options: PlotLabel (default Automatic), GraphLayout (default Automatic), ImageSize (default Large), ColorFunction (default Automatic, a Red\[Rule]Blue blend applied to u-values), ShowLegend (default True, shows color bar when u-values are numeric), BendFactor (default 0.15, controls arc curvature as a fraction of edge length; 0 gives straight edges).";
-
-mfgAugmentedPlot::usage =
-"mfgAugmentedPlot[s, sys, sol, opts] plots the augmented infrastructure graph. Blue arcs are flow variables j[a,b]; red arcs are transition variables j[r,i,w]. Anti-parallel flow arcs curve to opposite sides so both directions are visible. Node colors show u-values on a gradient when a solution is provided; zero-flow arcs are invisible (Opacity 0). Options: PlotLabel (default Automatic), GraphLayout (default Automatic), ImageSize (default Large), ColorFunction (default Automatic, a Red\[Rule]Blue blend applied to u-values), ShowBoundaryValues (default True, shows entry/exit u-values on boundary nodes), ShowLegend (default True, shows color bar when u-values are numeric), BendFactor (default 0.15, controls arc curvature as a fraction of edge length; 0 gives straight edges).";
-
-mfgAugmentedBoundaryPlot::usage =
-"mfgAugmentedBoundaryPlot[s, sys, sol, opts] plots the augmented infrastructure graph with boundary data overlaid. In the augmented representation, edges correspond to flow and transition flow variables; vertices correspond to value variables. Entry flow edges are labeled with their fixed supply from boundary data; exit source vertices {exN,N} are annotated with their exit cost bound. Anti-parallel flow arcs curve to opposite sides so both directions are visible. Options: PlotLabel (default Automatic), GraphLayout (default Automatic), ImageSize (default Large), BendFactor (default 0.15, controls arc curvature as a fraction of edge length; 0 gives straight edges).";
+richNetworkPlot::usage =
+"richNetworkPlot[s, sys, opts] and richNetworkPlot[s, sys, sol, opts] render the augmented state-space graph. Nodes are pairs {a,b} representing oriented edge states; edges are flow arcs j[a,b] (blue) and transition arcs j[r,i,w] (red), drawn as quadratic Bezier curves so anti-parallel pairs separate. Only nodes whose label position (b) is an auxiliary entry/exit vertex receive boundary colors. Options: ShowFlowEdges (default True; False yields the transition-only graph), ShowBoundaryData (default False; overlays entry-flow and exit-cost labels), ShowBoundaryValues (default True; shows u/cost on boundary nodes), ShowFlowLabels (default Automatic), ShowValueLabels (default True), ColorFunction (default Automatic), ShowLegend (default True), BendFactor (default 0.15; arc curvature as fraction of edge length), GraphLayout (default Automatic), PlotLabel (default Automatic), ImageSize (default Large).";
 
 augmentAuxiliaryGraph::usage =
 "augmentAuxiliaryGraph[sys] constructs the road-traffic augmented infrastructure graph from a system's AuxPairs and AuxTriples. Returns an Association containing the Graph, Vertices, FlowEdges, TransitionEdges, EdgeVariables, and EdgeKinds.";
 
 Begin["`Private`"];
 
-Options[scenarioTopologyPlot] = {
-    GraphLayout -> Automatic,
-    PlotLabel -> Automatic,
-    ImageSize -> Medium
+(* ===========================================================
+   Options
+   =========================================================== *)
+
+Options[rawNetworkPlot] = {
+    ShowAuxiliaryVertices -> False,
+    ShowBoundaryData      -> False,
+    ShowFlowLabels        -> Automatic,
+    ShowValueLabels       -> False,
+    ShowDensityLabels     -> False,
+    ColorFunction         -> Automatic,
+    ShowLegend            -> True,
+    GraphLayout           -> Automatic,
+    PlotLabel             -> Automatic,
+    ImageSize             -> Large
 };
 
-Options[mfgSolutionPlot] = {
-    GraphLayout -> Automatic,
-    PlotLabel -> Automatic,
-    ImageSize -> Large
+Options[richNetworkPlot] = {
+    ShowFlowEdges         -> True,
+    ShowBoundaryData      -> False,
+    ShowBoundaryValues    -> True,
+    ShowFlowLabels        -> Automatic,
+    ShowValueLabels       -> True,
+    ColorFunction         -> Automatic,
+    ShowLegend            -> True,
+    BendFactor            -> 0.15,
+    GraphLayout           -> Automatic,
+    PlotLabel             -> Automatic,
+    ImageSize             -> Large
 };
 
-Options[mfgFlowPlot] = Options[mfgSolutionPlot];
+(* ===========================================================
+   Small formatting helpers
+   =========================================================== *)
 
-Options[mfgValuePlot] = Options[mfgSolutionPlot];
+formatPlotNumber[value_?NumericQ] := NumberForm[N[value], {5, 2}];
+formatPlotNumber[_] := "?";
 
-Options[mfgDensityPlot] = Options[mfgSolutionPlot];
+stateAtomLabel[x_] :=
+    StringReplace[ToString[x], {"auxEntry" -> "in", "auxExit" -> "out"}];
 
-Options[mfgTransitionPlot] = {
-    GraphLayout -> Automatic,
-    PlotLabel -> Automatic,
-    ImageSize -> Large,
-    ColorFunction -> Automatic,
-    ShowLegend -> True,
-    BendFactor -> 0.15
-};
+stateLabel[{a_, b_}] := stateAtomLabel[b];
 
-Options[mfgAugmentedPlot] = Join[Options[mfgTransitionPlot], {ShowBoundaryValues -> True}];
+plotLabelValue[label_, default_String] :=
+    Replace[label, {
+        Automatic -> Style[default, 14, Bold],
+        None -> None,
+        other_ :> Style[other, 14, Bold]
+    }];
 
-Options[mfgAugmentedBoundaryPlot] = Options[mfgTransitionPlot];
+formatStateNodeLabel[state_, val_] :=
+    Placed[
+        Style[
+            If[NumericQ[val],
+                Column[{stateLabel[state], formatPlotNumber[val]}, Center, Spacings -> 0],
+                stateLabel[state]
+            ],
+            9, Black
+        ],
+        Center
+    ];
 
-netEdgeFlow::usage =
-"netEdgeFlow[a, b, rules] returns the solved net flow j[a,b]-j[b,a], defaulting absent flow variables to zero.";
+formatBoundaryExitLabel[state_, val_, cost_] :=
+    Placed[
+        Style[
+            If[NumericQ[val] && Abs[val] > 10^-5,
+                Column[{
+                    Row[{stateLabel[state], "  u=", formatPlotNumber[val]}],
+                    Style[Row[{"c\[LessEqual]", formatPlotNumber[cost]}], Italic]
+                }, Center, Spacings -> 0.1],
+                Column[{
+                    stateLabel[state],
+                    Style[Row[{"c\[LessEqual]", formatPlotNumber[cost]}], Italic]
+                }, Center, Spacings -> 0.1]
+            ],
+            9, Black
+        ],
+        Center
+    ];
 
-edgeJValue::usage =
-"edgeJValue[a, b, rules] returns the solved flow j[a,b], defaulting absent flow variables to zero.";
+(* Solution rules — accepts {rules}, <|"Rules" -> rules, ...|>, or <||> *)
+extractSolutionRules[sol_] := extractRules[sol];
 
-edgeUValue::usage =
-"edgeUValue[a, b, rules] returns the solved value variable for edge endpoints, or Missing[] when absent.";
-
-directedDisplayEdges::usage =
-"directedDisplayEdges[edges, rules] orients display edges using solved net flow values.";
-
-stateLabel::usage =
-"stateLabel[pair] returns a compact display label for an augmented graph state pair.";
-
-plotLabelValue::usage =
-"plotLabelValue[label, default] returns a styled plot label unless label is None.";
-
-realNetworkVertexStyle::usage =
-"realNetworkVertexStyle[s] returns vertex styles for real entry, exit, and internal network vertices.";
-
-realNetworkVertexSize::usage =
-"realNetworkVertexSize[s] returns vertex sizes for real network vertices.";
-
-edgeHamiltonianValue::usage =
-"edgeHamiltonianValue[ham, key, edge] returns scenario Hamiltonian data for an edge with reverse-edge fallback.";
-
-edgeDensityValue::usage =
-"edgeDensityValue[s, sys, edge, rules] computes inferred density for a real edge.";
-
-formatPlotNumber::usage =
-"formatPlotNumber[value] formats numeric plot labels and returns ? for unavailable values.";
-
-stateAtomLabel::usage =
-"stateAtomLabel[x] returns a compact string representation of an auxiliary or real vertex index.";
-
-edgeGExpression::usage =
-"edgeGExpression[g, m] evaluates the Hamiltonian congestion cost term G at mass m.";
-
-edgeSignedFlowValue::usage =
-"edgeSignedFlowValue[sys, edge, rules] returns the solved signed spatial flow for a real network edge.";
-
-stateVertexStyle::usage =
-"stateVertexStyle[vertices, sys] returns plot styles for augmented transition graph vertices.";
-
-formatStateNodeLabel::usage =
-"formatStateNodeLabel[state, val] formats a node label for the transition graph showing state and value.";
+(* ===========================================================
+   Edge-data helpers
+   =========================================================== *)
 
 netEdgeFlow[a_, b_, rules_List] :=
     (j[a, b] - j[b, a]) /. rules /. {_j -> 0};
 
 edgeJValue[a_, b_, rules_List] :=
-    (j[a, b] /. rules /. {_j -> 0});
+    j[a, b] /. rules /. {_j -> 0};
 
 edgeUValue[a_, b_, rules_List] :=
     Module[{v1, v2},
@@ -137,50 +127,14 @@ directedDisplayEdges[edges_List, rules_List] :=
         DirectedEdge[a_, b_] :> DirectedEdge[a, b]
     };
 
-stateAtomLabel[x_] :=
-    StringReplace[ToString[x], {"auxEntry" -> "in", "auxExit" -> "out"}];
-
-stateLabel[{a_, b_}] :=
-    stateAtomLabel[b];
-
-plotLabelValue[label_, default_String] :=
-    Replace[label, {
-        Automatic -> Style[default, 14, Bold],
-        None -> None,
-        other_ :> Style[other, 14, Bold]
-    }];
-
-realNetworkVertexStyle[s_?scenarioQ] :=
-    Module[{model, entryV, exitV, realV, internalV},
-        model     = scenarioData[s, "Model"];
-        entryV    = First /@ model["Entries"];
-        exitV     = First /@ model["Exits"];
-        realV     = model["Vertices"];
-        internalV = Complement[realV, entryV, exitV];
-        Normal @ Join[
-            AssociationThread[entryV,    RGBColor[0.22, 0.6, 0.3]],
-            AssociationThread[exitV,     RGBColor[0.82, 0.27, 0.2]],
-            AssociationThread[internalV, GrayLevel[0.72]]
-        ]
-    ];
-
-realNetworkVertexSize[s_?scenarioQ] :=
-    AssociationThread[scenarioData[s, "Model"]["Vertices"], 0.38];
-
-formatPlotNumber[value_?NumericQ] := NumberForm[N[value], {5, 2}];
-formatPlotNumber[_] := "?";
-
 edgeHamiltonianValue[ham_Association, key_String, edge_List] :=
     Module[{edgeAssoc, globalValue},
         edgeAssoc = Lookup[ham, "Edge" <> key, <||>];
         globalValue = Lookup[ham, key, Missing["MissingHamiltonianKey", key]];
         If[!AssociationQ[edgeAssoc] || MissingQ[globalValue],
             Missing["InvalidHamiltonian"],
-            Lookup[
-                edgeAssoc,
-                Key[edge],
-                Lookup[edgeAssoc, Key[Reverse[edge]], globalValue]
-            ]
+            Lookup[edgeAssoc, Key[edge],
+                Lookup[edgeAssoc, Key[Reverse[edge]], globalValue]]
         ]
     ];
 
@@ -208,27 +162,24 @@ edgeDensityValue[s_?scenarioQ, sys_?mfgSystemQ, edge_List, rules_List] :=
         v     = edgeHamiltonianValue[ham, "V",     edge];
         g     = edgeHamiltonianValue[ham, "G",     edge];
         If[MissingQ[alpha] || MissingQ[v] || MissingQ[g],
-            Return[Missing["InvalidHamiltonian"], Module]
-        ];
-        jval  = edgeSignedFlowValue[sys, edge, rules];
-
+            Return[Missing["InvalidHamiltonian"], Module]];
+        jval = edgeSignedFlowValue[sys, edge, rules];
         If[!NumericQ[jval], Return[Missing["MissingFlow"], Module]];
         If[Chop[N[jval]] == 0, Return[0, Module]];
         If[!NumericQ[alpha] || !NumericQ[v], Return[Missing["InvalidHamiltonian"], Module]];
-
         gexpr = edgeGExpression[g, m];
         If[MissingQ[gexpr], Return[gexpr, Module]];
         equation = N[jval]^2/(2 m^(2 - N[alpha])) - gexpr == -N[v];
-        roots = Quiet @ Check[
-            m /. NSolve[{equation, m > 0}, m, Reals],
-            $Failed
-        ];
+        roots = Quiet @ Check[m /. NSolve[{equation, m > 0}, m, Reals], $Failed];
         If[roots === $Failed || roots === {} || !ListQ[roots],
             Missing["DensityNotSolved"],
-            FirstCase[N @ roots, value_?NumericQ /; value > 0,
-                Missing["DensityNotSolved"]]
+            FirstCase[N @ roots, value_?NumericQ /; value > 0, Missing["DensityNotSolved"]]
         ]
     ];
+
+(* ===========================================================
+   Augmented graph construction (public)
+   =========================================================== *)
 
 augmentAuxiliaryGraph[sys_?mfgSystemQ] :=
     Module[{auxPairs, triples, flowEdges, transitionEdges, allEdges, edgeVariables,
@@ -260,91 +211,82 @@ augmentAuxiliaryGraph[sys_?mfgSystemQ] :=
         |>
     ];
 
-stateVertexStyle[vertices_, sys_?mfgSystemQ] :=
+(* ===========================================================
+   Vertex styling helpers (uniform coloring rules)
+   =========================================================== *)
+
+(* Real network vertices: always gray, regardless of entry/exit role. *)
+realVertexGrayMap[vertices_List] :=
+    AssociationThread[vertices, GrayLevel[0.72]];
+
+(* Auxiliary vertices (raw plot, when shown): green/red category colors. *)
+auxiliaryVertexColorMap[auxV_List, sys_?mfgSystemQ] :=
     Module[{auxEntryV, auxExitV},
         auxEntryV = systemData[sys, "AuxEntryVertices"];
         auxExitV  = systemData[sys, "AuxExitVertices"];
-        Normal @ Join[
-            AssociationThread[vertices, GrayLevel[0.72]],
-            AssociationThread[Select[vertices, Intersection[#, auxEntryV] =!= {} &], RGBColor[0.22, 0.6, 0.3]],
-            AssociationThread[Select[vertices, Intersection[#, auxExitV]  =!= {} &], RGBColor[0.82, 0.27, 0.2]]
+        Join[
+            AssociationThread[Intersection[auxV, auxEntryV], RGBColor[0.38, 0.74, 0.9]],
+            AssociationThread[Intersection[auxV, auxExitV],  RGBColor[0.95, 0.7, 0.4]]
         ]
     ];
 
-formatStateNodeLabel[state_, val_] :=
-    Placed[
-        Style[
-            If[NumericQ[val],
-                Column[{stateLabel[state], formatPlotNumber[val]}, Center, Spacings -> 0],
-                stateLabel[state]
-            ],
-            9, Black
-        ],
-        Center
+(* Augmented state-pair colors: only nodes where p[[2]] (label position) is aux entry/exit. *)
+stateNodeColorMap[vertices_List, sys_?mfgSystemQ] :=
+    Module[{auxEntryV, auxExitV, base, entryColored, exitColored},
+        auxEntryV = systemData[sys, "AuxEntryVertices"];
+        auxExitV  = systemData[sys, "AuxExitVertices"];
+        base = AssociationThread[vertices, GrayLevel[0.72]];
+        entryColored = AssociationThread[
+            Select[vertices, MemberQ[auxEntryV, #[[2]]] &],
+            RGBColor[0.22, 0.6, 0.3]
+        ];
+        exitColored = AssociationThread[
+            Select[vertices, MemberQ[auxExitV, #[[2]]] &],
+            RGBColor[0.82, 0.27, 0.2]
+        ];
+        Join[base, entryColored, exitColored]
     ];
 
-scenarioTopologyPlot[s_?scenarioQ, sys_?mfgSystemQ, title : Except[_Rule | _RuleDelayed], opts : OptionsPattern[]] :=
-    scenarioTopologyPlot[s, sys, PlotLabel -> title, opts];
-
-scenarioTopologyPlot[s_?scenarioQ, sys_?mfgSystemQ, opts : OptionsPattern[]] :=
-    Module[{model, entryV, exitV, internalV, allV, edges},
-        model    = scenarioData[s, "Model"];
-        entryV   = First /@ model["Entries"];
-        exitV    = First /@ model["Exits"];
-        allV     = model["Vertices"];
-        internalV = Complement[allV, entryV, exitV];
-        edges    = systemData[sys, "Edges"];
-        Graph[allV, edges,
-            VertexLabels -> Placed["Name", Center],
-            VertexStyle  -> Normal @ Join[
-                AssociationThread[entryV,    RGBColor[0.22, 0.6, 0.3]],
-                AssociationThread[exitV,     RGBColor[0.82, 0.27, 0.2]],
-                AssociationThread[internalV, GrayLevel[0.75]]
-            ],
-            VertexSize -> 0.3,
-            EdgeStyle  -> Directive[GrayLevel[0.5], AbsoluteThickness[2]],
-            GraphLayout -> OptionValue[GraphLayout],
-            PlotLabel  -> plotLabelValue[OptionValue[PlotLabel], "Network topology"],
-            ImageSize  -> OptionValue[ImageSize]
-        ]
+(* Gradient style from u-values, with a fallback association for vertices without u. *)
+gradientVertexStyle[vertices_List, uValues_Association, fallback_Association,
+                     colorFn_, uMin_, uMax_] :=
+    Association @ Map[
+        With[{vtx = #, uval = uValues[#]},
+            vtx -> If[NumericQ[uval],
+                colorFn[If[uMin == uMax, 0.5, Rescale[uval, {uMin, uMax}]]],
+                Lookup[fallback, Key[vtx], GrayLevel[0.72]]
+            ]
+        ] &,
+        vertices
     ];
 
-mfgSolutionPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title : Except[_Rule | _RuleDelayed], opts : OptionsPattern[]] :=
-    mfgSolutionPlot[s, sys, sol, PlotLabel -> title, opts];
+barLegendForU[uMin_, uMax_, colorFn_] :=
+    BarLegend[{colorFn[Rescale[#, {uMin, uMax}]] &, {uMin, uMax}},
+        LegendLabel -> Placed["u", Right],
+        LegendMarkerSize -> 200];
 
-mfgSolutionPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
-    Show[
-        GraphicsGrid[
-            {{
-                mfgFlowPlot[s, sys, sol,
-                    GraphLayout -> OptionValue[GraphLayout],
-                    PlotLabel -> "Flows",
-                    ImageSize -> Medium],
-                mfgValuePlot[s, sys, sol,
-                    GraphLayout -> OptionValue[GraphLayout],
-                    PlotLabel -> "Values",
-                    ImageSize -> Medium],
-                mfgDensityPlot[s, sys, sol,
-                    GraphLayout -> OptionValue[GraphLayout],
-                    PlotLabel -> "Agent density",
-                    ImageSize -> Medium]
-            }},
-            ImageSize -> OptionValue[ImageSize]
-        ],
-        PlotLabel -> plotLabelValue[OptionValue[PlotLabel], "Solution views"],
-        ImageSize -> OptionValue[ImageSize]
+(* ===========================================================
+   Edge-label builders (raw plot)
+   =========================================================== *)
+
+buildFlowLabels[edges_List, rules_List] :=
+    Association @ Map[
+        Module[{a, b, jv},
+            {a, b} = List @@ #;
+            jv = edgeJValue[a, b, rules];
+            # -> Placed[
+                Style[
+                    If[NumericQ[jv], NumberForm[N[jv], {5, 1}], "?"],
+                    9, Black, Background -> White
+                ],
+                0.6
+            ]
+        ] &,
+        edges
     ];
 
-mfgValuePlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title : Except[_Rule | _RuleDelayed], opts : OptionsPattern[]] :=
-    mfgValuePlot[s, sys, sol, PlotLabel -> title, opts];
-
-mfgValuePlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
-    Module[{model, realV, edges, rules, edgeLabels, valueAt},
-        model = scenarioData[s, "Model"];
-        realV = model["Vertices"];
-        edges = systemData[sys, "Edges"];
-        rules = extractRules[sol];
-
+buildValueLabels[edges_List, rules_List] :=
+    Module[{valueAt},
         valueAt[a_, b_, t_] :=
             Module[{ua, ub},
                 ua = u[a, b] /. rules;
@@ -354,8 +296,7 @@ mfgValuePlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
                     Missing["MissingValue"]
                 ]
             ];
-
-        edgeLabels = Association @ Map[
+        Association @ Map[
             Module[{a, b, ua, ub, q1, q2, q3},
                 {a, b} = List @@ #;
                 ua = u[a, b] /. rules;
@@ -378,279 +319,251 @@ mfgValuePlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
                 ]
             ] &,
             edges
-        ];
-
-        Graph[realV, edges,
-            VertexLabels -> Placed["Name", Center],
-            VertexStyle  -> realNetworkVertexStyle[s],
-            VertexSize   -> Normal @ realNetworkVertexSize[s],
-            EdgeStyle    -> Directive[RGBColor[0.36, 0.38, 0.42], AbsoluteThickness[2.2], Opacity[0.9]],
-            EdgeLabels   -> Normal[edgeLabels],
-            GraphLayout  -> OptionValue[GraphLayout],
-            PlotLabel    -> plotLabelValue[OptionValue[PlotLabel], "Values"],
-            ImageSize    -> OptionValue[ImageSize]
         ]
     ];
 
-mfgDensityPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title : Except[_Rule | _RuleDelayed], opts : OptionsPattern[]] :=
-    mfgDensityPlot[s, sys, sol, PlotLabel -> title, opts];
+buildDensityLabels[s_?scenarioQ, sys_?mfgSystemQ, edges_List, rules_List] :=
+    Association @ Map[
+        With[{edge = List @@ #, density = edgeDensityValue[s, sys, List @@ #, rules]},
+            # -> Placed[
+                Style[
+                    Row[{"m=", formatPlotNumber[density]}],
+                    9, Black, Background -> White
+                ],
+                Center
+            ]
+        ] &,
+        edges
+    ];
 
-mfgDensityPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
-    Module[{model, realV, edges, rules, densities, numericDensities, maxDensity,
-            edgeStyles, edgeLabels},
+(* Combine labels from multiple sources (each per-edge). *)
+mergeEdgeLabels[parts___] :=
+    Module[{nonempty},
+        nonempty = Cases[{parts}, _Association?(Length[#] > 0 &)];
+        If[nonempty === {}, <||>,
+            Association @ Map[
+                Function[edge,
+                    edge -> Placed[
+                        Column[
+                            Cases[
+                                Lookup[#, edge, Placed["", Center]] & /@ nonempty,
+                                Placed[content_, _] :> content
+                            ],
+                            Center, Spacings -> 0.2
+                        ],
+                        Center
+                    ]
+                ],
+                Union @@ (Keys /@ nonempty)
+            ]
+        ]
+    ];
+
+(* ===========================================================
+   rawNetworkPlot
+   =========================================================== *)
+
+rawNetworkPlot[s_?scenarioQ, sys_?mfgSystemQ, opts : OptionsPattern[]] :=
+    rawNetworkPlot[s, sys, <||>, opts];
+
+rawNetworkPlot[s_?scenarioQ, sys_?mfgSystemQ, title_String, opts : OptionsPattern[]] :=
+    rawNetworkPlot[s, sys, <||>, PlotLabel -> title, opts];
+
+rawNetworkPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title_String, opts : OptionsPattern[]] :=
+    rawNetworkPlot[s, sys, sol, PlotLabel -> title, opts];
+
+rawNetworkPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
+    Module[{rules, model, realV, auxEntryV, auxExitV, auxV, showAux, showBoundary,
+            showFlow, showValues, showDensity, showLegend, colorFn,
+            edges, vertices, edgeLabels, dispEdges,
+            entryDataAssoc, inAuxEntryPairs, exitCosts, entryEdgeMap,
+            uValues, numericU, uMin, uMax,
+            baseStyleMap, gradientStyle, vertexStyle, vertexLabels,
+            graph, legend, flowLabels, valueLabels, densityLabels, boundaryLabels,
+            edgeStyle},
+
+        rules = extractSolutionRules[sol];
         model = scenarioData[s, "Model"];
         realV = model["Vertices"];
-        edges = systemData[sys, "Edges"];
-        rules = extractRules[sol];
-
-        densities = Association @ Map[
-            With[{edge = List @@ #},
-                # -> edgeDensityValue[s, sys, edge, rules]
-            ] &,
-            edges
-        ];
-        numericDensities = Cases[Values[densities], _?NumericQ, Infinity];
-        maxDensity = Max[Append[Abs @ numericDensities, 1]];
-
-        edgeStyles = Association @ Map[
-            With[{density = densities[#]},
-                # -> Directive[
-                    If[NumericQ[density] && density > 0,
-                        RGBColor[0.1, 0.5, 0.42],
-                        GrayLevel[0.48]
-                    ],
-                    AbsoluteThickness[
-                        If[NumericQ[density],
-                            Rescale[Abs[density], {0, maxDensity}, {1.5, 7}],
-                            2.0
-                        ]
-                    ],
-                    Opacity[0.9]
-                ]
-            ] &,
-            edges
-        ];
-
-        edgeLabels = Association @ Map[
-            With[{density = densities[#]},
-                # -> Placed[
-                    Style[
-                        Row[{"m=", formatPlotNumber[density]}],
-                        9, Black, Background -> White
-                    ],
-                    Center
-                ]
-            ] &,
-            edges
-        ];
-
-        Graph[realV, edges,
-            VertexLabels -> Placed["Name", Center],
-            VertexStyle  -> realNetworkVertexStyle[s],
-            VertexSize   -> Normal @ realNetworkVertexSize[s],
-            EdgeStyle    -> Normal[edgeStyles],
-            EdgeLabels   -> Normal[edgeLabels],
-            GraphLayout  -> OptionValue[GraphLayout],
-            PlotLabel    -> plotLabelValue[OptionValue[PlotLabel], "Agent density"],
-            ImageSize    -> OptionValue[ImageSize]
-        ]
-    ];
-
-mfgFlowPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title : Except[_Rule | _RuleDelayed], opts : OptionsPattern[]] :=
-    mfgFlowPlot[s, sys, sol, PlotLabel -> title, opts];
-
-mfgFlowPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
-    Module[{model, realV, auxV, edges, dispEdges, rules, edgeStyles, edgeLabels,
-            auxEntryV, auxExitV},
-        model     = scenarioData[s, "Model"];
-        realV     = model["Vertices"];
-        auxV      = Complement[systemData[sys, "AuxVertices"], realV];
-        edges     = systemData[sys, "AuxEdges"];
-        rules     = extractRules[sol];
-        dispEdges = directedDisplayEdges[edges, rules];
-
-        edgeStyles = Association @ Map[
-            Module[{a, b, auxQ},
-                {a, b} = List @@ #;
-                auxQ = MemberQ[auxV, a] || MemberQ[auxV, b];
-                # -> Directive[
-                    If[auxQ, GrayLevel[0.35], RGBColor[0.12, 0.45, 0.78]],
-                    AbsoluteThickness[2.0],
-                    Opacity[0.9]
-                ]
-            ] &,
-            dispEdges
-        ];
-
-        edgeLabels = Association @ Map[
-            Module[{a, b, jv},
-                {a, b} = List @@ #;
-                jv = edgeJValue[a, b, rules];
-                # -> Placed[
-                    Style[
-                        If[NumericQ[jv], NumberForm[N[jv], {5, 1}], "?"],
-                        9, Black, Background -> White
-                    ],
-                    0.6
-                ]
-            ] &,
-            dispEdges
-        ];
 
         auxEntryV = systemData[sys, "AuxEntryVertices"];
         auxExitV  = systemData[sys, "AuxExitVertices"];
 
-        Graph[Join[realV, auxV], dispEdges,
-            VertexLabels -> Placed["Name", Center],
-            VertexStyle  -> Normal @ Join[
-                Association @ realNetworkVertexStyle[s],
-                AssociationThread[Intersection[auxV, auxEntryV], RGBColor[0.38, 0.74, 0.9]],
-                AssociationThread[Intersection[auxV, auxExitV],  RGBColor[0.95, 0.7, 0.4]]
+        showBoundary = TrueQ[OptionValue[ShowBoundaryData]];
+        showAux = TrueQ[OptionValue[ShowAuxiliaryVertices]] || showBoundary;
+        showFlow = Replace[OptionValue[ShowFlowLabels], Automatic :> rules =!= {}];
+        showValues = TrueQ[OptionValue[ShowValueLabels]];
+        showDensity = TrueQ[OptionValue[ShowDensityLabels]];
+        showLegend = TrueQ[OptionValue[ShowLegend]];
+        colorFn = Replace[OptionValue[ColorFunction], Automatic -> (Blend[{Red, Blue}, #] &)];
+
+        (* Choose vertex / edge sets based on whether aux is shown. *)
+        If[showAux,
+            edges = systemData[sys, "AuxEdges"];
+            auxV = Complement[systemData[sys, "AuxVertices"], realV];
+            vertices = Join[realV, auxV];
+            ,
+            edges = systemData[sys, "Edges"];
+            auxV = {};
+            vertices = realV
+        ];
+
+        (* Direct edges by net flow when flow info is being shown; else keep undirected. *)
+        dispEdges = If[TrueQ[showFlow], directedDisplayEdges[edges, rules], edges];
+
+        (* Vertex base styles: real vertices gray; aux vertices get category color. *)
+        baseStyleMap = Join[
+            realVertexGrayMap[realV],
+            auxiliaryVertexColorMap[auxV, sys]
+        ];
+
+        (* For aux vertices only, compute a u-value if available. Real vertices have no
+           single canonical u (u is per-edge orientation), so they stay gray. *)
+        uValues = Association @ Map[
+            Function[v,
+                v -> Module[{candidates},
+                    candidates = Cases[
+                        Join[(u[v, #] /. rules) & /@ realV,
+                             (u[#, v] /. rules) & /@ realV],
+                        _?NumericQ
+                    ];
+                    If[candidates === {}, Missing[], First[candidates]]
+                ]
             ],
+            auxV
+        ];
+        numericU = Select[uValues, NumericQ];
+        If[Length[numericU] > 0,
+            uMin = Min[Values[numericU]];
+            uMax = Max[Values[numericU]];
+            gradientStyle = gradientVertexStyle[
+                auxV, uValues, baseStyleMap, colorFn, uMin, uMax];
+            (* Real vertices stay gray; gradient overlays aux vertices only. *)
+            vertexStyle = Join[
+                realVertexGrayMap[realV],
+                gradientStyle
+            ];
+            legend = barLegendForU[uMin, uMax, colorFn];
+            ,
+            vertexStyle = baseStyleMap;
+            legend = None
+        ];
+
+        (* Vertex labels: standard "Name" placement. *)
+        vertexLabels = Placed["Name", Center];
+
+        (* Edge labels per option. *)
+        flowLabels = If[TrueQ[showFlow], buildFlowLabels[dispEdges, rules], <||>];
+        valueLabels = If[showValues, buildValueLabels[dispEdges, rules], <||>];
+        densityLabels = If[showDensity, buildDensityLabels[s, sys, dispEdges, rules], <||>];
+
+        (* Boundary labels for entry-flow / exit-cost (raw plot only labels real edges; we
+           overlay onto entry aux edges when ShowBoundaryData and aux are shown). *)
+        boundaryLabels = If[showBoundary && showAux,
+            entryDataAssoc = systemData[sys, "EntryDataAssociation"];
+            inAuxEntryPairs = systemData[sys, "InAuxEntryPairs"];
+            entryEdgeMap = Association @ Map[
+                With[{p = #}, DirectedEdge[p[[1]], p[[2]]] -> p] &,
+                inAuxEntryPairs
+            ];
+            Association @ Map[
+                Module[{e = #, a, b, pair, supply},
+                    {a, b} = List @@ e;
+                    pair = Lookup[entryEdgeMap, Key[DirectedEdge[a, b]], Missing[]];
+                    If[!MissingQ[pair],
+                        supply = Lookup[entryDataAssoc, Key[pair], Missing[]];
+                        If[!MissingQ[supply],
+                            e -> Placed[Style[Row[{"f=", formatPlotNumber[supply]}],
+                                              8, Black, Background -> White], Center],
+                            Nothing
+                        ],
+                        Nothing
+                    ]
+                ] &,
+                dispEdges
+            ]
+            ,
+            <||>
+        ];
+
+        edgeLabels = mergeEdgeLabels[flowLabels, valueLabels, densityLabels, boundaryLabels];
+
+        edgeStyle = Directive[GrayLevel[0.45], AbsoluteThickness[2], Opacity[0.9]];
+
+        graph = Graph[vertices, dispEdges,
+            VertexLabels -> vertexLabels,
+            VertexStyle  -> Normal[vertexStyle],
             VertexSize   -> Normal @ Join[
                 AssociationThread[realV, 0.38],
                 AssociationThread[auxV, 0.28]
             ],
-            EdgeStyle    -> Normal[edgeStyles],
+            EdgeStyle    -> edgeStyle,
             EdgeLabels   -> Normal[edgeLabels],
             GraphLayout  -> OptionValue[GraphLayout],
-            PlotLabel    -> plotLabelValue[OptionValue[PlotLabel], "Flow graph"],
-            ImageSize    -> OptionValue[ImageSize]
-        ]
-    ];
-
-mfgTransitionPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title : Except[_Rule | _RuleDelayed], opts : OptionsPattern[]] :=
-    mfgTransitionPlot[s, sys, sol, PlotLabel -> title, opts];
-
-mfgTransitionPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
-    Module[{triples, rules, transitionEdges, vertices, nodeLabels, edgeLabels,
-            numericJ, maxJ, colorFn, uValues, numericU, uMin, uMax,
-            vertexStyle, legend, graph, nSeg = 20},
-        triples = systemData[sys, "AuxTriples"];
-        rules   = extractRules[sol];
-
-        transitionEdges = DirectedEdge[{#[[1]], #[[2]]}, {#[[3]], #[[2]]}] & /@ triples;
-        vertices = DeleteDuplicates @ Flatten[List @@@ transitionEdges, 1];
-
-        numericJ = Cases[(j @@ # /. rules) & /@ triples, _?NumericQ, Infinity];
-        maxJ = Max[Append[Abs @ numericJ, 1]];
-
-        colorFn  = Replace[OptionValue[ColorFunction], Automatic -> (Blend[{Red, Blue}, #] &)];
-        uValues  = AssociationMap[(u @@ #) /. rules &, vertices];
-        numericU = Select[uValues, NumericQ];
-
-        If[Length[numericU] > 0,
-            uMin = Min[Values[numericU]];
-            uMax = Max[Values[numericU]];
-            vertexStyle = Association @ Map[
-                With[{vtx = #, uval = uValues[#]},
-                    vtx -> If[NumericQ[uval],
-                        colorFn[If[uMin == uMax, 0.5, Rescale[uval, {uMin, uMax}]]],
-                        GrayLevel[0.72]
-                    ]
-                ] &,
-                vertices
-            ];
-            legend = BarLegend[{colorFn[Rescale[#, {uMin, uMax}]] &, {uMin, uMax}},
-                LegendLabel -> Placed["u", Right],
-                LegendMarkerSize -> 200],
-            vertexStyle = stateVertexStyle[vertices, sys];
-            legend = None
-        ];
-
-        edgeLabels = Association @ Map[
-            With[{jv = (j @@ {#[[1, 1]], #[[1, 2]], #[[2, 1]]}) /. rules},
-                # -> Placed[
-                    Style[
-                        If[NumericQ[jv], NumberForm[N[jv], {5, 1}], "?"],
-                        9, Black, Background -> White
-                    ],
-                    Center
-                ]
-            ] &,
-            transitionEdges
-        ];
-
-        nodeLabels = Association @ Map[
-            # -> formatStateNodeLabel[#, (u @@ #) /. rules] &,
-            vertices
-        ];
-
-        graph = Graph[vertices, transitionEdges,
-            VertexLabels -> Normal[nodeLabels],
-            VertexSize   -> 0.55,
-            VertexStyle  -> Normal[vertexStyle],
-            EdgeShapeFunction -> Function[{pts, e},
-                With[{
-                    jv  = (j @@ {e[[1, 1]], e[[1, 2]], e[[2, 1]]}) /. rules,
-                    uS  = uValues[e[[1]]],
-                    uT  = uValues[e[[2]]],
-                    p1  = N[pts[[1]]],
-                    p2  = N[pts[[-1]]]
-                },
-                    Module[{op, thick, edgeColorAt, d, perp, ctrl, pAt},
-                        op    = If[NumericQ[jv] && jv == 0, 0, 0.9];
-                        thick = AbsoluteThickness[If[NumericQ[jv], Rescale[Abs[jv], {0, maxJ}, {1.5, 7}], 2.0]];
-                        d    = p2 - p1;
-                        perp = With[{len = Norm[d]}, If[len > 0, {-d[[2]], d[[1]]}/len, {0, 1}]];
-                        ctrl = 0.5*(p1 + p2) + OptionValue[BendFactor]*Norm[d]*perp;
-                        pAt  = Function[t, (1-t)^2*p1 + 2*(1-t)*t*ctrl + t^2*p2];
-                        edgeColorAt = If[NumericQ[uS] && NumericQ[uT] && Length[numericU] > 0,
-                            colorFn[Rescale[(1 - #)*uS + #*uT, {uMin, uMax}]] &,
-                            (Which[NumericQ[jv] && jv > 0, RGBColor[0.12, 0.45, 0.78],
-                                   NumericQ[jv] && jv < 0, RGBColor[0.82, 0.39, 0.2],
-                                   True, GrayLevel[0.45]]) &
-                        ];
-                        Join[
-                            Table[
-                                With[{t0 = k/nSeg, t1 = (k + 1)/nSeg},
-                                    {edgeColorAt[t0 + 0.5/nSeg], thick, Opacity[op],
-                                     Line[{pAt[t0], pAt[t1]}]}],
-                                {k, 0, nSeg - 1}],
-                            {{GrayLevel[0.3], Opacity[op], Arrowheads[{{0.02, 1}}],
-                              Arrow[{pAt[0.45], pAt[0.55]}]}}
-                        ]
-                    ]
-                ]
-            ],
-            EdgeLabels   -> Normal[edgeLabels],
-            GraphLayout  -> OptionValue[GraphLayout],
-            PlotLabel    -> plotLabelValue[OptionValue[PlotLabel], "Transition graph: flows and values"],
+            PlotLabel    -> plotLabelValue[OptionValue[PlotLabel], "Network"],
             ImageSize    -> OptionValue[ImageSize]
         ];
 
-        If[legend === None || !TrueQ[OptionValue[ShowLegend]], graph, Legended[graph, legend]]
+        If[legend === None || !showLegend, graph, Legended[graph, legend]]
     ];
 
-mfgAugmentedPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title : Except[_Rule | _RuleDelayed], opts : OptionsPattern[]] :=
-    mfgAugmentedPlot[s, sys, sol, PlotLabel -> title, opts];
+(* ===========================================================
+   richNetworkPlot
+   =========================================================== *)
 
-mfgAugmentedPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
-    Module[{augmented, vertices, flowEdges, transitionEdges, allAugEdges,
-            edgeLabels, nodeLabels, numericJ, maxJ,
-            edgeVariables, edgeKinds, rules, getU, getEffectiveU, auxEntryV, auxExitV,
-            exitCosts, effectiveFlows, uValues, numericU, uMin, uMax, vertexStyle,
-            colorFn, nSeg = 20, legend, graph},
+entryFlowEdge[pair_List] :=
+    DirectedEdge[{pair[[2]], pair[[1]]}, {pair[[1]], pair[[2]]}];
 
+richNetworkPlot[s_?scenarioQ, sys_?mfgSystemQ, opts : OptionsPattern[]] :=
+    richNetworkPlot[s, sys, <||>, opts];
+
+richNetworkPlot[s_?scenarioQ, sys_?mfgSystemQ, title_String, opts : OptionsPattern[]] :=
+    richNetworkPlot[s, sys, <||>, PlotLabel -> title, opts];
+
+richNetworkPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title_String, opts : OptionsPattern[]] :=
+    richNetworkPlot[s, sys, sol, PlotLabel -> title, opts];
+
+richNetworkPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
+    Module[{rules, augmented, allVertices, flowEdges, transitionEdges, edgeVariables,
+            edgeKinds, showFlowEdges, showBoundary, showBoundaryValues,
+            showFlowLabels, showValueLabels, showLegend, colorFn, bendFactor,
+            auxEntryV, auxExitV, exitCosts, entryDataAssoc, inAuxEntryPairs,
+            entryEdgeSet, edges, vertices, effectiveFlows, numericJ, maxJ,
+            getU, getEffectiveU, uValues, numericU, uMin, uMax, baseStyleMap,
+            gradientStyle, vertexStyle, edgeLabels, nodeLabels,
+            graph, legend, nSeg = 20},
+
+        rules = extractSolutionRules[sol];
         augmented = augmentAuxiliaryGraph[sys];
-        vertices = augmented["Vertices"];
+        allVertices = augmented["Vertices"];
         flowEdges = augmented["FlowEdges"];
         transitionEdges = augmented["TransitionEdges"];
-        allAugEdges = Join[flowEdges, transitionEdges];
         edgeVariables = augmented["EdgeVariables"];
         edgeKinds = augmented["EdgeKinds"];
-        rules     = extractRules[sol];
+
+        showFlowEdges = TrueQ[OptionValue[ShowFlowEdges]];
+        showBoundary = TrueQ[OptionValue[ShowBoundaryData]];
+        showBoundaryValues = TrueQ[OptionValue[ShowBoundaryValues]];
+        showFlowLabels = Replace[OptionValue[ShowFlowLabels], Automatic :> True];
+        showValueLabels = TrueQ[OptionValue[ShowValueLabels]];
+        showLegend = TrueQ[OptionValue[ShowLegend]];
+        colorFn = Replace[OptionValue[ColorFunction], Automatic -> (Blend[{Red, Blue}, #] &)];
+        bendFactor = OptionValue[BendFactor];
+
         auxEntryV = systemData[sys, "AuxEntryVertices"];
         auxExitV  = systemData[sys, "AuxExitVertices"];
         exitCosts = systemData[sys, "ExitCosts"];
 
+        (* Choose edge set: with/without flow arcs. Recompute vertex set from edges shown. *)
+        edges = If[showFlowEdges, Join[flowEdges, transitionEdges], transitionEdges];
+        vertices = DeleteDuplicates @ Flatten[List @@@ edges, 1];
+
         getU[p_] := (u @@ p) /. rules;
-        (* For aux exit vertices the solution may not include u — fall back to the exit cost.
-           Exit vertex label can sit at either position in the pair. *)
         getEffectiveU[p_] := With[{uv = getU[p]},
             If[NumericQ[uv], uv,
-                If[TrueQ[OptionValue[ShowBoundaryValues]],
-                    With[{cost = Lookup[exitCosts, p[[1]], Lookup[exitCosts, p[[2]], Missing[]]]},
+                If[showBoundaryValues,
+                    With[{cost = Lookup[exitCosts, p[[1]],
+                                        Lookup[exitCosts, p[[2]], Missing[]]]},
                         If[!MissingQ[cost], cost,
                             If[MemberQ[auxEntryV, p[[1]]] || MemberQ[auxEntryV, p[[2]]],
                                 With[{adjU = getU[Reverse[p]]},
@@ -666,68 +579,83 @@ mfgAugmentedPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :
         ];
 
         effectiveFlows = Association @ Map[
-            With[{v1 = If[rules =!= {},
-                edgeVariables[#] /. rules /. _j -> 0,
-                edgeVariables[#]
-            ]},
-                # -> v1
+            With[{var = edgeVariables[#],
+                  jv = If[rules =!= {}, edgeVariables[#] /. rules /. _j -> 0,
+                                        edgeVariables[#]]},
+                # -> jv
             ] &,
-            allAugEdges
+            edges
         ];
-
         numericJ = Cases[Values[effectiveFlows], _?NumericQ, Infinity];
         maxJ = Max[Append[numericJ, 1]];
 
-        edgeLabels = Association @ Map[
-            With[{jv = edgeVariables[#] /. rules},
-                # -> Placed[
-                    Style[
-                        If[NumericQ[jv] && jv != 0, NumberForm[N[jv], {5, 1}], ""],
-                        8, Black, Background -> White
-                    ],
-                    Center
-                ]
-            ] &,
-            allAugEdges
-        ];
-
-        nodeLabels = Association @ Map[
-            # -> formatStateNodeLabel[#, getEffectiveU[#]] &,
-            vertices
-        ];
-
-        colorFn = Replace[OptionValue[ColorFunction],
-            Automatic -> (Blend[{Red, Blue}, #] &)];
-
-        uValues  = AssociationMap[getEffectiveU, vertices];
+        (* Vertex coloring: state pairs with label-position aux get green/red; gradient
+           overlays where u-values exist. *)
+        baseStyleMap = stateNodeColorMap[vertices, sys];
+        uValues = AssociationMap[getEffectiveU, vertices];
         numericU = Select[uValues, NumericQ];
         If[Length[numericU] > 0,
             uMin = Min[Values[numericU]];
             uMax = Max[Values[numericU]];
-            vertexStyle = Association @ Map[
-                With[{vtx = #, uval = uValues[#]},
-                    vtx -> If[NumericQ[uval],
-                        colorFn[If[uMin == uMax, 0.5, Rescale[uval, {uMin, uMax}]]],
-                        Which[
-                            Intersection[vtx, auxEntryV] =!= {}, RGBColor[0.22, 0.6, 0.3],
-                            Intersection[vtx, auxExitV]  =!= {}, RGBColor[0.82, 0.27, 0.2],
-                            True, GrayLevel[0.72]
-                        ]
-                    ]
-                ] &,
-                vertices
-            ];
-            legend = BarLegend[{colorFn[Rescale[#, {uMin, uMax}]] &, {uMin, uMax}},
-                LegendLabel -> Placed["u", Right],
-                LegendMarkerSize -> 200],
-            vertexStyle = stateVertexStyle[vertices, sys];
+            gradientStyle = gradientVertexStyle[
+                vertices, uValues, baseStyleMap, colorFn, uMin, uMax];
+            vertexStyle = gradientStyle;
+            legend = barLegendForU[uMin, uMax, colorFn];
+            ,
+            vertexStyle = baseStyleMap;
             legend = None
         ];
 
-        graph = Graph[vertices, allAugEdges,
+        (* Node labels: u-value and (optionally) boundary cost overlays. *)
+        nodeLabels = Association @ Map[
+            Module[{vtx = #, head, uval, cost},
+                head = First[vtx];
+                uval = If[showValueLabels, getEffectiveU[vtx], Missing[]];
+                If[showBoundary && MemberQ[auxExitV, head],
+                    cost = Lookup[exitCosts, head, Missing[]];
+                    vtx -> formatBoundaryExitLabel[vtx, uval, cost],
+                    vtx -> formatStateNodeLabel[vtx, uval]
+                ]
+            ] &,
+            vertices
+        ];
+
+        (* Edge labels: j-values plus optional entry-flow boundary labels. *)
+        entryDataAssoc = If[showBoundary, systemData[sys, "EntryDataAssociation"], <||>];
+        inAuxEntryPairs = If[showBoundary, systemData[sys, "InAuxEntryPairs"], {}];
+        entryEdgeSet = If[showBoundary,
+            Association @ Thread[(entryFlowEdge /@ inAuxEntryPairs) -> inAuxEntryPairs],
+            <||>
+        ];
+
+        edgeLabels = Association @ Map[
+            With[{e = #, jv = effectiveFlows[#]},
+                Module[{entryPair, supply, body},
+                    entryPair = Lookup[entryEdgeSet, Key[e], Missing[]];
+                    body = Which[
+                        showBoundary && !MissingQ[entryPair],
+                            supply = Lookup[entryDataAssoc, Key[entryPair], Missing[]];
+                            If[!MissingQ[supply],
+                                Row[{"f=", formatPlotNumber[supply]}],
+                                If[showFlowLabels && NumericQ[jv] && jv != 0,
+                                    NumberForm[N[jv], {5, 1}], ""]],
+                        showFlowLabels && NumericQ[jv] && jv != 0,
+                            NumberForm[N[jv], {5, 1}],
+                        True, ""
+                    ];
+                    e -> Placed[
+                        Style[body, 8, Black, Background -> White],
+                        Center
+                    ]
+                ]
+            ] &,
+            edges
+        ];
+
+        graph = Graph[vertices, edges,
             VertexLabels -> Normal[nodeLabels],
             VertexSize   -> 0.58,
-            VertexStyle  -> vertexStyle,
+            VertexStyle  -> Normal[vertexStyle],
             EdgeShapeFunction -> Function[{pts, e},
                 With[{
                     uS   = uValues[e[[1]]],
@@ -737,22 +665,22 @@ mfgAugmentedPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :
                     p1   = N[pts[[1]]],
                     p2   = N[pts[[-1]]]
                 },
-                    Module[{
-                        op    = If[NumericQ[effJ] && effJ == 0, 0, 0.9],
-                        thick = AbsoluteThickness[If[NumericQ[effJ], Rescale[effJ, {0, maxJ}, {1.5, 7}], 2.0]],
-                        edgeColorAt, d, perp, ctrl, pAt
-                    },
+                    Module[{op, thick, edgeColorAt, d, perp, ctrl, pAt},
+                        op    = If[NumericQ[effJ] && effJ == 0, 0, 0.9];
+                        thick = AbsoluteThickness[
+                            If[NumericQ[effJ], Rescale[effJ, {0, maxJ}, {1.5, 7}], 2.0]];
                         d    = p2 - p1;
-                        perp = With[{len = Norm[d]}, If[len > 0, {-d[[2]], d[[1]]} / len, {0, 1}]];
-                        ctrl = 0.5*(p1 + p2) + OptionValue[BendFactor]*Norm[d]*perp;
-                        (* Quadratic Bezier curves each edge to the left of its direction;
-                           anti-parallel pairs curve to opposite sides and appear as distinct arcs. *)
+                        perp = With[{len = Norm[d]},
+                            If[len > 0, {-d[[2]], d[[1]]}/len, {0, 1}]];
+                        ctrl = 0.5*(p1 + p2) + bendFactor*Norm[d]*perp;
                         pAt  = Function[t, (1-t)^2*p1 + 2*(1-t)*t*ctrl + t^2*p2];
                         edgeColorAt = If[NumericQ[uS] && NumericQ[uT] && Length[numericU] > 0,
                             colorFn[Rescale[(1 - #)*uS + #*uT, {uMin, uMax}]] &,
-                            (Which[kind === "Flow", RGBColor[0.12, 0.45, 0.78],
-                                   kind === "Transition", RGBColor[0.86, 0.25, 0.22],
-                                   True, GrayLevel[0.45]]) &
+                            (Which[
+                                kind === "Flow", RGBColor[0.12, 0.45, 0.78],
+                                kind === "Transition", RGBColor[0.86, 0.25, 0.22],
+                                True, GrayLevel[0.45]
+                            ]) &
                         ];
                         Join[
                             Table[
@@ -768,142 +696,12 @@ mfgAugmentedPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :
             ],
             EdgeLabels   -> Normal[edgeLabels],
             GraphLayout  -> OptionValue[GraphLayout],
-            PlotLabel    -> plotLabelValue[OptionValue[PlotLabel], "Augmented infrastructure graph (Paper scheme)"],
+            PlotLabel    -> plotLabelValue[OptionValue[PlotLabel],
+                                            "Augmented infrastructure graph"],
             ImageSize    -> OptionValue[ImageSize]
         ];
 
-        If[legend === None || !TrueQ[OptionValue[ShowLegend]], graph, Legended[graph, legend]]
-    ];
-
-entryFlowEdge[pair_List] :=
-    DirectedEdge[{pair[[2]], pair[[1]]}, {pair[[1]], pair[[2]]}];
-
-formatBoundaryExitLabel[state_, val_, cost_] :=
-    Placed[
-        Style[
-            If[NumericQ[val] && Abs[val] > 10^-5,
-                Column[{
-                    Row[{stateLabel[state], "  u=", formatPlotNumber[val]}],
-                    Style[Row[{"c\[LessEqual]", formatPlotNumber[cost]}], Italic]
-                }, Center, Spacings -> 0.1],
-                Column[{
-                    stateLabel[state],
-                    Style[Row[{"c\[LessEqual]", formatPlotNumber[cost]}], Italic]
-                }, Center, Spacings -> 0.1]
-            ],
-            9, Black
-        ],
-        Center
-    ];
-
-mfgAugmentedBoundaryPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title : Except[_Rule | _RuleDelayed], opts : OptionsPattern[]] :=
-    mfgAugmentedBoundaryPlot[s, sys, sol, PlotLabel -> title, opts];
-
-mfgAugmentedBoundaryPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
-    Module[{augmented, vertices, flowEdges, transitionEdges, allAugEdges,
-            edgeLabels, nodeLabels, numericJ, maxJ,
-            edgeVariables, edgeKinds, rules, getU, auxEntryV, auxExitV,
-            exitCosts, entryDataAssoc, inAuxEntryPairs, entryEdgeSet,
-            effectiveFlows, nSeg = 20},
-
-        augmented = augmentAuxiliaryGraph[sys];
-        vertices        = augmented["Vertices"];
-        flowEdges       = augmented["FlowEdges"];
-        transitionEdges = augmented["TransitionEdges"];
-        allAugEdges     = Join[flowEdges, transitionEdges];
-        edgeVariables   = augmented["EdgeVariables"];
-        edgeKinds       = augmented["EdgeKinds"];
-        rules           = extractRules[sol];
-        auxEntryV       = systemData[sys, "AuxEntryVertices"];
-        auxExitV        = systemData[sys, "AuxExitVertices"];
-        exitCosts       = systemData[sys, "ExitCosts"];
-        entryDataAssoc  = systemData[sys, "EntryDataAssociation"];
-        inAuxEntryPairs = systemData[sys, "InAuxEntryPairs"];
-        entryEdgeSet    = Association @ Thread[(entryFlowEdge /@ inAuxEntryPairs) -> inAuxEntryPairs];
-
-        getU[p_] := (u @@ p) /. rules;
-
-        effectiveFlows = Association @ Map[
-            With[{jv = edgeVariables[#] /. rules /. _j -> 0}, # -> jv] &,
-            allAugEdges
-        ];
-        numericJ = Cases[Values[effectiveFlows], _?NumericQ, Infinity];
-        maxJ = Max[Append[Abs @ numericJ, 1]];
-
-        edgeLabels = Association @ Map[
-            With[{jv = effectiveFlows[#],
-                  entryPair = Lookup[entryEdgeSet, Key[#], Missing[]]},
-                # -> Placed[
-                    Style[
-                        Which[
-                            !MissingQ[entryPair],
-                                With[{supply = Lookup[entryDataAssoc, Key[entryPair], Missing[]]},
-                                    If[!MissingQ[supply],
-                                        Row[{"f=", formatPlotNumber[supply]}],
-                                        If[NumericQ[jv] && jv != 0, NumberForm[N[jv], {5, 1}], ""]
-                                    ]
-                                ],
-                            NumericQ[jv] && jv != 0,
-                                NumberForm[N[jv], {5, 1}],
-                            True, ""
-                        ],
-                        8, Black, Background -> White
-                    ],
-                    Center
-                ]
-            ] &,
-            allAugEdges
-        ];
-
-        nodeLabels = Association @ Map[
-            With[{uval = getU[#], head = First[#]},
-                # -> If[MemberQ[auxExitV, head],
-                    formatBoundaryExitLabel[#, uval, Lookup[exitCosts, head, Missing[]]],
-                    formatStateNodeLabel[#, uval]
-                ]
-            ] &,
-            vertices
-        ];
-
-        Graph[vertices, allAugEdges,
-            VertexLabels -> Normal[nodeLabels],
-            VertexSize   -> 0.58,
-            VertexStyle  -> stateVertexStyle[vertices, sys],
-            EdgeShapeFunction -> Function[{pts, e},
-                With[{
-                    jv   = effectiveFlows[e],
-                    kind = edgeKinds[e],
-                    p1   = N[pts[[1]]],
-                    p2   = N[pts[[-1]]]
-                },
-                    Module[{op, thick, color, d, perp, ctrl, pAt},
-                        op    = If[NumericQ[jv] && jv == 0, 0, 0.8];
-                        thick = AbsoluteThickness[If[NumericQ[jv], Rescale[Abs[jv], {0, maxJ}, {1.5, 7}], 2.0]];
-                        color = Which[
-                            kind === "Flow",       RGBColor[0.12, 0.45, 0.78],
-                            kind === "Transition", RGBColor[0.86, 0.25, 0.22],
-                            True,                 GrayLevel[0.45]
-                        ];
-                        d    = p2 - p1;
-                        perp = With[{len = Norm[d]}, If[len > 0, {-d[[2]], d[[1]]}/len, {0, 1}]];
-                        ctrl = 0.5*(p1 + p2) + OptionValue[BendFactor]*Norm[d]*perp;
-                        pAt  = Function[t, (1-t)^2*p1 + 2*(1-t)*t*ctrl + t^2*p2];
-                        Join[
-                            Table[
-                                With[{t0 = k/nSeg, t1 = (k + 1)/nSeg},
-                                    {color, thick, Opacity[op], Line[{pAt[t0], pAt[t1]}]}],
-                                {k, 0, nSeg - 1}],
-                            {{GrayLevel[0.3], Opacity[op], Arrowheads[{{0.02, 1}}],
-                              Arrow[{pAt[0.45], pAt[0.55]}]}}
-                        ]
-                    ]
-                ]
-            ],
-            EdgeLabels   -> Normal[edgeLabels],
-            GraphLayout  -> OptionValue[GraphLayout],
-            PlotLabel    -> plotLabelValue[OptionValue[PlotLabel], "Augmented graph with boundary data"],
-            ImageSize    -> OptionValue[ImageSize]
-        ]
+        If[legend === None || !showLegend, graph, Legended[graph, legend]]
     ];
 
 End[];


### PR DESCRIPTION
## Summary

This PR resurrects the graphics consolidation that was prepared but never landed in PR #195, and extends it with a 3D helix visualization for the Tawaf scenario.

### Two commits

1. **`feat(graphics): consolidate plot surface to rawNetworkPlot + richNetworkPlot`** (cherry-pick of `438e956`, originally prepared on the now-deleted `chore/ship-20260507-104254` branch). Replaces the 8-plotter public surface with two:
   - `rawNetworkPlot` — physical network. Real vertices stay gray; aux vertices and labels are opt-in. Solution overlay via `sol` arg.
   - `richNetworkPlot` — augmented state-space. Quadratic Bezier arcs separate anti-parallel edges; only label-position aux nodes get boundary colors (fixes prior over-matching).
   - `augmentAuxiliaryGraph` retained.
   - Old behaviors covered via options: `ShowAuxiliaryVertices`, `ShowBoundaryData`, `ShowFlowLabels`, `ShowValueLabels`, `ShowDensityLabels` (raw); `ShowFlowEdges`, `ShowBoundaryData`, `ShowBoundaryValues` (rich); shared `ColorFunction`, `ShowLegend`, `BendFactor`.
   - Updates `Getting started.wl`, `Jamarat.wl`, and `Tests/graphicsTools.mt` to the new API.

2. **`feat(tawaf): helix 3D visualization + migrate workbook`**
   - Adds `tawafHelixPlot[s, sys, sol, opts]` to `TawafWorkbook.wl`: 3D `Graph3D` layout where each round is one angular turn rising vertically, so equivalent (same-position) nodes across rounds sit directly above each other. Layers → concentric helices. Optional dashed equivalence links; edge thickness by `|j[a,b]|`.
   - Migrates all `mfgAugmentedPlot` / `mfgFlowPlot` / `scenarioTopologyPlot` calls in the workbook to `richNetworkPlot` / `rawNetworkPlot`.
   - Demos in each of the 2×3×1, 3×4×1, 2×3×2, and 7×8×1 sections.

## Test plan

- [x] `Scripts/RunTests.wls fast` — 202 / 202 passing
- [x] Smoke test of `rawNetworkPlot` / `richNetworkPlot` (no-sol, with-sol, with-aux) on 2×3×1 — all return `Graph` / `Legended`
- [x] Helix renders correctly for 2×3×1 (structure + solved), 2×3×2, 7×8×1 (PNG export verified)
- [ ] Visual review of workbook in Mathematica front-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)