### PR TITLE
fix(graphics): preserve real-network layout in rawNetworkPlot when aux vertices are added

### DIFF
--- a/MFGraphs/graphicsTools.wl
+++ b/MFGraphs/graphicsTools.wl
@@ -375,7 +375,7 @@ rawNetworkPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, title_String, opts : Options
 rawNetworkPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
     Module[{rules, model, realV, auxEntryV, auxExitV, auxV, showAux, showBoundary,
             showFlow, showValues, showDensity, showLegend, colorFn,
-            edges, vertices, edgeLabels, dispEdges,
+            edges, vertices, edgeLabels, dispEdges, vertexCoords,
             entryDataAssoc, inAuxEntryPairs, exitCosts, entryEdgeMap,
             uValues, numericU, uMin, uMax,
             baseStyleMap, gradientStyle, vertexStyle, vertexLabels,
@@ -406,6 +406,18 @@ rawNetworkPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
             edges = systemData[sys, "Edges"];
             auxV = {};
             vertices = realV
+        ];
+
+        (* Pin real-vertex coordinates to the layout the real-only subgraph
+           would have on its own, so adding aux vertices doesn't perturb the
+           embedding (which can introduce spurious edge crossings). Aux vertices
+           are left to the automatic layout. *)
+        vertexCoords = If[showAux,
+            With[{realGraph = Graph[realV, systemData[sys, "Edges"],
+                                    GraphLayout -> OptionValue[GraphLayout]]},
+                Thread[realV -> GraphEmbedding[realGraph]]
+            ],
+            Automatic
         ];
 
         (* Direct edges by net flow when flow info is being shown; else keep undirected. *)
@@ -497,6 +509,7 @@ rawNetworkPlot[s_?scenarioQ, sys_?mfgSystemQ, sol_, opts : OptionsPattern[]] :=
                 AssociationThread[realV, 0.38],
                 AssociationThread[auxV, 0.28]
             ],
+            VertexCoordinates -> vertexCoords,
             EdgeStyle    -> edgeStyle,
             EdgeLabels   -> Normal[edgeLabels],
             GraphLayout  -> OptionValue[GraphLayout],


### PR DESCRIPTION
## Summary

`rawNetworkPlot` with `ShowBoundaryData -> True` (or `ShowAuxiliaryVertices -> True`) was switching the input to the aux-augmented edge set and letting Mathematica auto-layout re-solve from scratch on the larger vertex set. This could reorder real edges — on Jamaratv9 it crossed `{1,3}` and `{2,4}`, even though those edges lay out cleanly without aux vertices.

Fix: pre-compute the real-only subgraph embedding once and pin real-vertex coordinates via `VertexCoordinates`. Aux vertices are left to the automatic layout and fall in around the fixed real vertices.

### Before / after on Jamaratv9 (`ShowBoundaryData -> True`)
- **Before:** real edges reordered, `{1,3}` crossed `{2,4}`.
- **After:** real-edge embedding identical to the no-aux view; only the `auxEntry1` and `auxExit4` nodes are added, near their respective real endpoints.

## Test plan

- [x] `Scripts/RunTests.wls fast` — 202/202
- [x] Smoke test on Jamaratv9: with and without `ShowBoundaryData -> True` produce matching real-network layouts (PNGs verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
