### PR TITLE
refactor(solvers): systemTools cleanup + restore cachedSolve memo

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -155,10 +155,6 @@ flowSplitting[AT][UndirectedEdge[a, b]] returns the splitting that start with {a
 
 getKirchhoffLinearSystem[sys] returns the entry current vector, Kirchhoff matrix, and the variables in the order corresponding to the Kirchhoff matrix.
 
-## getKirchhoffMatrix
-
-getKirchhoffMatrix[sys] returns the entry current vector, Kirchhoff matrix, (critical congestion) cost function placeholder, and the variables in the order corresponding to the Kirchhoff matrix. The third slot is retained for backward compatibility.
-
 ## ineqSwitch
 
 ineqSwitch[u, switchingCosts][r, i, w] returns the optimality condition at junction i for the transition from r to w. Namely,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Active `.mt` files under `MFGraphs/Tests/`:
 | `reduce-system.mt` | system reduction end-to-end |
 | `scenario-consistency.mt` | cross-stage invariants (scenario ↔ unknowns ↔ system) |
 | `dnf-reducer.mt` | DNF reducer correctness and edge cases |
+| `boolean-minimize.mt` | `booleanMinimizeSystem` / `booleanMinimizeReduceSystem` |
 | `orchestration.mt` | `solveScenario` and full pipeline |
 | `graphicsTools.mt` | `rawNetworkPlot`, `richNetworkPlot` |
 | `tawaf.mt` | unrolled-circumambulation scenario builder |

--- a/MFGraphs/Tests/boolean-minimize.mt
+++ b/MFGraphs/Tests/boolean-minimize.mt
@@ -57,11 +57,14 @@ Do[
         sys    = makeSystem[scen];
         refSol = dnfReduceSystem[sys];
         bmrSol = booleanMinimizeReduceSystem[sys];
-        Test[
-            ListQ[bmrSol] && ListQ[refSol] && (Sort[bmrSol] === Sort[refSol]),
-            True,
-            TestID -> "booleanMinimizeReduceSystem matches dnfReduceSystem on " <> label
-        ]
+        (* Split assertions so mutual $Failed cannot satisfy the equivalence
+           check by short-circuiting both ListQ guards to False. *)
+        Test[ListQ[refSol], True,
+             TestID -> "dnfReduceSystem returns a List on " <> label];
+        Test[ListQ[bmrSol], True,
+             TestID -> "booleanMinimizeReduceSystem returns a List on " <> label];
+        Test[Sort[bmrSol] === Sort[refSol], True,
+             TestID -> "booleanMinimizeReduceSystem matches dnfReduceSystem on " <> label]
     ],
     {pair, $smallCases}
 ];

--- a/MFGraphs/Tests/boolean-minimize.mt
+++ b/MFGraphs/Tests/boolean-minimize.mt
@@ -45,6 +45,27 @@ Do[
     {pair, $smallCases}
 ];
 
+(* --------------------------------------------------------------------- *)
+(* booleanMinimizeReduceSystem matches dnfReduceSystem on small cases    *)
+(* (cross-check that the levered solver lands on the same rules as the   *)
+(* reference DNF reducer when both fully determine the system).          *)
+(* --------------------------------------------------------------------- *)
+
+Do[
+    Module[{label, scen, sys, refSol, bmrSol},
+        {label, scen} = pair;
+        sys    = makeSystem[scen];
+        refSol = dnfReduceSystem[sys];
+        bmrSol = booleanMinimizeReduceSystem[sys];
+        Test[
+            ListQ[bmrSol] && ListQ[refSol] && (Sort[bmrSol] === Sort[refSol]),
+            True,
+            TestID -> "booleanMinimizeReduceSystem matches dnfReduceSystem on " <> label
+        ]
+    ],
+    {pair, $smallCases}
+];
+
 (* --------------------------------------------------------------- *)
 (* Lever 1 (arm-pruning) actually fires: surviving disjAtom count   *)
 (* is strictly less than raw BooleanConvert disjunct count.         *)

--- a/MFGraphs/Tests/scenario-consistency.mt
+++ b/MFGraphs/Tests/scenario-consistency.mt
@@ -70,3 +70,26 @@ Test[
     ,
     TestID -> "Scenario consistency: HRF Scenario 1 paper case migrated"
 ] *)
+
+(* Structural invariants relied on by getKirchhoffLinearSystem and makeSystem
+   after the dead defensive guards were removed. If a future scenario builder
+   ever fails to populate one of these keys, these tests will catch it before
+   downstream Join / lookups blow up. Runs against two scenario shapes so
+   builder-specific regressions are more likely to surface. *)
+
+Do[
+    Module[{label, s, sys},
+        {label, s} = pair;
+        sys = makeSystem[s];
+        Test[ListQ[systemData[sys, "EqEntryIn"]],             True, TestID -> "System invariant: EqEntryIn is a List ("             <> label <> ")"];
+        Test[ListQ[systemData[sys, "BalanceGatheringFlows"]], True, TestID -> "System invariant: BalanceGatheringFlows is a List (" <> label <> ")"];
+        Test[ListQ[systemData[sys, "BalanceSplittingFlows"]], True, TestID -> "System invariant: BalanceSplittingFlows is a List (" <> label <> ")"];
+        Test[AssociationQ[systemData[sys, "RuleEntryIn"]],    True, TestID -> "System invariant: RuleEntryIn is an Association ("   <> label <> ")"];
+        Test[AssociationQ[systemData[sys, "RuleEntryOut"]],   True, TestID -> "System invariant: RuleEntryOut is an Association ("  <> label <> ")"];
+        Test[AssociationQ[scenarioData[s, "Topology"]],       True, TestID -> "Scenario invariant: Topology is Association ("       <> label <> ")"]
+    ],
+    {pair, {
+        {"case-12",         getExampleScenario[12, $entries12, $exits12, {}]},
+        {"chain-two-exits", getExampleScenario["chain with two exits", {{1, 100}}, {{2, 0}, {3, 20}}, {{1, 2, 3, 10}}]}
+    }}
+];

--- a/MFGraphs/archive/README.md
+++ b/MFGraphs/archive/README.md
@@ -5,6 +5,7 @@ This directory contains modules intentionally removed from the active core-only 
 ## Archived modules
 
 - Solver-era modules and backend helpers that are not loaded by the active package.
+- `getKirchhoffMatrix.wl` — public wrapper around `getKirchhoffLinearSystem` with a placeholder cost-function slot; archived after the active code path stopped consuming the 4-tuple shape.
 
 ## Notes
 

--- a/MFGraphs/archive/getKirchhoffMatrix.wl
+++ b/MFGraphs/archive/getKirchhoffMatrix.wl
@@ -1,0 +1,37 @@
+(* Wolfram Language package *)
+(*
+   getKirchhoffMatrix.wl — archived from systemTools.wl.
+
+   Wrapped getKirchhoffLinearSystem with a placeholder cost-function slot
+   intended for future congestion-cost injection. Zero in-tree callers at
+   the time of archival; the placeholder body returned a constant Function
+   producing {0&, 0&, ...} regardless of input mass.
+
+   Restoration: re-add the ::usage declaration and definition to
+   systemTools.wl alongside getKirchhoffLinearSystem.
+*)
+
+BeginPackage["getKirchhoffMatrixArchive`", {"systemTools`"}]
+
+getKirchhoffMatrix::usage =
+"getKirchhoffMatrix[sys] returns the entry current vector, Kirchhoff matrix, \
+(critical congestion) cost function placeholder, and the variables in the \
+order corresponding to the Kirchhoff matrix. The third slot is retained for \
+backward compatibility.";
+
+Begin["`Private`"]
+
+getKirchhoffMatrix[sys_] :=
+    Module[{b, km, vars, cost, cCost},
+        {b, km, vars} = getKirchhoffLinearSystem[sys];
+        If[Length[vars] === 0,
+            Return[{b, km, <||>, vars}, Module]
+        ];
+        cost  = AssociationThread[vars, (0&) /@ vars];
+        cCost = cost /@ vars /. MapThread[Rule, {vars, #}]&;
+        {b, km, cCost, vars}
+    ];
+
+End[]
+
+EndPackage[]

--- a/MFGraphs/solversTools.wl
+++ b/MFGraphs/solversTools.wl
@@ -239,6 +239,13 @@ buildSolverInputs::usage =
 exit-value rules, and runs accumulateEqualityRules. Returns \
 {constraints, allVars, rulesAcc} ready for the final solve step.";
 
+booleanDnfReducePipeline::usage =
+"booleanDnfReducePipeline[dnfFn, multisolEmit][constraints, allVars, timeout, returnAll] \
+is the shared body of booleanReduceSystem and booleanMinimizeSystem. dnfFn is the Boolean \
+DNF operation (BooleanConvert or BooleanMinimize); multisolEmit is a 1-arg callback that \
+emits the solver-specific ::multisol message when distinct disjuncts produce differing \
+rule sets.";
+
 checkBlock::usage =
 "checkBlock[expr, tol] evaluates a substituted constraint block using tolerance tol for numeric comparisons.";
 
@@ -288,12 +295,17 @@ reduceSystem[sys_?mfgSystemQ] :=
     ];
 
 dnfReduceSystem[sys_?mfgSystemQ] :=
-    withCriticalCongestionSolver[sys, "dnfReduceSystem",
-        Function[{constraints, allVars},
-            parseDNFReduceResult[dnfReduce[True, constraints], allVars]
-        ],
-        buildSolverInputs,
-        attachAccumulatedRules
+    Module[{result},
+        resetSolveCacheCounters[];
+        result = withCriticalCongestionSolver[sys, "dnfReduceSystem",
+            Function[{constraints, allVars},
+                parseDNFReduceResult[dnfReduce[True, constraints], allVars]
+            ],
+            buildSolverInputs,
+            attachAccumulatedRules
+        ];
+        If[TrueQ[$MFGraphsVerbose], printSolveCacheSummary["dnfReduceSystem"]];
+        result
     ];
 
 optimizedDNFReduceSystem[sys_?mfgSystemQ] :=
@@ -348,6 +360,28 @@ activeSetReduceSystem[sys_?mfgSystemQ] :=
     ]
     ];
 
+(* Shared body for booleanReduceSystem / booleanMinimizeSystem.
+   dnfFn is the Boolean DNF operation (BooleanConvert or BooleanMinimize);
+   multisolEmit is a 1-arg callback that emits the solver-specific
+   ::multisol message when distinct disjuncts produce differing rule sets. *)
+booleanDnfReducePipeline[dnfFn_, multisolEmit_][constraints_, allVars_, timeout_, returnAll_] :=
+    Module[{dnf, disjuncts, reducedList, nonFalse, parsed},
+        dnf         = dnfFn[constraints, "DNF"];
+        disjuncts   = If[Head[dnf] === Or, List @@ dnf, {dnf}];
+        reducedList = TimeConstrained[Reduce[#, allVars, Reals], timeout, $Aborted] & /@ disjuncts;
+        nonFalse    = Select[reducedList, # =!= False && # =!= $Aborted &];
+        If[nonFalse === {},
+            Return[<|"Rules" -> {}, "Residual" -> False|>, Module]
+        ];
+        parsed = parseReduceResult[#, allVars] & /@ nonFalse;
+        If[Length[parsed] > 1,
+            With[{ruleSets = (If[ListQ[#], #, Lookup[#, "Rules", {}]] & /@ parsed)},
+                If[!SameQ @@ (Sort /@ ruleSets), multisolEmit[Length[parsed]]]
+            ]
+        ];
+        If[returnAll, parsed, First[parsed]]
+    ];
+
 Options[booleanReduceSystem] = {
     "DisjunctTimeout" -> 30,
     "ReturnAll"       -> False
@@ -356,23 +390,13 @@ Options[booleanReduceSystem] = {
 booleanReduceSystem[sys_?mfgSystemQ, opts : OptionsPattern[]] :=
     withCriticalCongestionSolver[sys, "booleanReduceSystem",
         Function[{constraints, allVars},
-            Module[{dnf, disjuncts, reducedList, nonFalse, parsed, timeout, returnAll},
-                timeout   = OptionValue[booleanReduceSystem, {opts}, "DisjunctTimeout"];
-                returnAll = TrueQ[OptionValue[booleanReduceSystem, {opts}, "ReturnAll"]];
-                dnf       = BooleanConvert[constraints, "DNF"];
-                disjuncts = If[Head[dnf] === Or, List @@ dnf, {dnf}];
-                reducedList = TimeConstrained[Reduce[#, allVars, Reals], timeout, $Aborted] & /@ disjuncts;
-                nonFalse = Select[reducedList, # =!= False && # =!= $Aborted &];
-                If[nonFalse === {},
-                    Return[<|"Rules" -> {}, "Residual" -> False|>, Module]
-                ];
-                parsed = parseReduceResult[#, allVars] & /@ nonFalse;
-                If[Length[parsed] > 1,
-                    With[{ruleSets = (If[ListQ[#], #, Lookup[#, "Rules", {}]] & /@ parsed)},
-                        If[!SameQ @@ (Sort /@ ruleSets), Message[booleanReduceSystem::multisol, Length[parsed]]]
-                    ]
-                ];
-                If[returnAll, parsed, First[parsed]]
+            booleanDnfReducePipeline[
+                BooleanConvert,
+                Function[{n}, Message[booleanReduceSystem::multisol, n]]
+            ][
+                constraints, allVars,
+                OptionValue[booleanReduceSystem, {opts}, "DisjunctTimeout"],
+                TrueQ[OptionValue[booleanReduceSystem, {opts}, "ReturnAll"]]
             ]
         ],
         buildSolverInputs,
@@ -389,23 +413,13 @@ Options[booleanMinimizeSystem] = {
 booleanMinimizeSystem[sys_?mfgSystemQ, opts : OptionsPattern[]] :=
     withCriticalCongestionSolver[sys, "booleanMinimizeSystem",
         Function[{constraints, allVars},
-            Module[{dnf, disjuncts, reducedList, nonFalse, parsed, timeout, returnAll},
-                timeout   = OptionValue[booleanMinimizeSystem, {opts}, "DisjunctTimeout"];
-                returnAll = TrueQ[OptionValue[booleanMinimizeSystem, {opts}, "ReturnAll"]];
-                dnf       = BooleanMinimize[constraints, "DNF"];
-                disjuncts = If[Head[dnf] === Or, List @@ dnf, {dnf}];
-                reducedList = TimeConstrained[Reduce[#, allVars, Reals], timeout, $Aborted] & /@ disjuncts;
-                nonFalse = Select[reducedList, # =!= False && # =!= $Aborted &];
-                If[nonFalse === {},
-                    Return[<|"Rules" -> {}, "Residual" -> False|>, Module]
-                ];
-                parsed = parseReduceResult[#, allVars] & /@ nonFalse;
-                If[Length[parsed] > 1,
-                    With[{ruleSets = (If[ListQ[#], #, Lookup[#, "Rules", {}]] & /@ parsed)},
-                        If[!SameQ @@ (Sort /@ ruleSets), Message[booleanMinimizeSystem::multisol, Length[parsed]]]
-                    ]
-                ];
-                If[returnAll, parsed, First[parsed]]
+            booleanDnfReducePipeline[
+                BooleanMinimize,
+                Function[{n}, Message[booleanMinimizeSystem::multisol, n]]
+            ][
+                constraints, allVars,
+                OptionValue[booleanMinimizeSystem, {opts}, "DisjunctTimeout"],
+                TrueQ[OptionValue[booleanMinimizeSystem, {opts}, "ReturnAll"]]
             ]
         ],
         buildSolverInputs,
@@ -1310,6 +1324,50 @@ branchStateFinalizeResult[branches_List, allVars_List] :=
 branchStateReduceResult[constraints_, allVars_List] :=
     branchStateFinalizeResult[branchStateReduce[constraints, allVars], allVars];
 
+(* --- cachedSolve: memoized Quiet[Solve[expr], Solve::svars] ------------- *)
+(* Used inside dnfReduce / dnfReduceProcedural / dnfReduceInstrumented.
+   On a baseline measurement (2026-05-11) grid-4x4 made 71 051 non-trivial
+   Solve calls on only 114 distinct keys (99.8% hit rate). The cache is
+   keyed by Hash[expr] (32-bit, fast); collisions are negligible at our
+   scale. Reset before each dnfReduceSystem invocation. *)
+
+$dnfSolveCache    = <||>;
+$dnfSolveHits     = 0;
+$dnfSolveMiss     = 0;
+$dnfSolveMissTag  = Unique["dnfSolveMissTag$"];  (* sentinel — guaranteed not to collide with any Solve result *)
+
+resetSolveCacheCounters[] := (
+    $dnfSolveHits = 0;
+    $dnfSolveMiss = 0;
+);
+
+clearSolveCache[] := ($dnfSolveCache = <||>);
+
+cachedSolve[expr_] :=
+    Module[{h = Hash[expr], cached},
+        cached = Lookup[$dnfSolveCache, h, $dnfSolveMissTag];
+        If[cached === $dnfSolveMissTag,
+            $dnfSolveMiss++;
+            cached = Quiet[Solve[expr], Solve::svars];
+            $dnfSolveCache[h] = cached;
+            ,
+            $dnfSolveHits++;
+        ];
+        cached
+    ];
+
+printSolveCacheSummary[label_String] :=
+    Module[{total, hitRate},
+        total   = $dnfSolveHits + $dnfSolveMiss;
+        hitRate = If[total === 0, 0., N[$dnfSolveHits / total]];
+        Print["SOLVE_CACHE|", label,
+              "|total=", total,
+              "|hits=",  $dnfSolveHits,
+              "|miss=",  $dnfSolveMiss,
+              "|hit_rate=", hitRate,
+              "|cache_size=", Length[$dnfSolveCache]];
+    ];
+
 dnfReduce[_,    False] := False
 dnfReduce[False, _]    := False
 dnfReduce[xp_,  True]  := xp
@@ -1345,7 +1403,7 @@ dnfReduce[xp_, sys_And] :=
                         Module
                     ],
                 Head[elem] === Equal,
-                    sol  = Quiet[Solve[elem], Solve::svars];
+                    sol  = cachedSolve[elem];
                     fsol = If[MatchQ[sol, {{__Rule}, ___}], First[sol], {}];
                     newxp = substituteSolution[xpAcc, fsol];
                     If[newxp === False, Return[False, Module]];
@@ -1381,7 +1439,7 @@ dnfReduce[xp_, leq_] := xp && leq
 
 dnfReduce[xp_, rst_, fst_Equal] :=
     Module[{sol, fsol, newxp, newrst},
-        sol  = Quiet[Solve[fst], Solve::svars];
+        sol  = cachedSolve[fst];
         fsol = If[MatchQ[sol, {{__Rule}, ___}], First[sol], {}];
         newxp = substituteSolution[xp, fsol];
         If[newxp === False,
@@ -1437,7 +1495,7 @@ dnfReduceProcedural[xp0_, sys0_, allVars_List] :=
                                        {b, Reverse[List @@ elem]}];
                                     outcome = "branched",
                                 Head[elem] === Equal,
-                                    sol  = Quiet[Solve[elem], Solve::svars];
+                                    sol  = cachedSolve[elem];
                                     fsol = If[MatchQ[sol, {{__Rule}, ___}], First[sol], {}];
                                     newxp = substituteSolution[xpAcc, fsol];
                                     If[newxp === False,
@@ -1458,7 +1516,7 @@ dnfReduceProcedural[xp0_, sys0_, allVars_List] :=
                             AppendTo[results, xpAcc && rst]]
                     ],
                 Head[fst] === Equal,
-                    sol  = Quiet[Solve[fst], Solve::svars];
+                    sol  = cachedSolve[fst];
                     fsol = If[MatchQ[sol, {{__Rule}, ___}], First[sol], {}];
                     newxp = substituteSolution[xp, fsol];
                     If[newxp =!= False,
@@ -1623,7 +1681,7 @@ dnfReduceInstrumentedAnd[xp_, conjuncts_List, monitor_, order_String, sysObj_, d
                     ],
                 Head[elem] === Equal,
                     dnfCounterIncrement[monitor, "EqualityAttempts"];
-                    sol  = Quiet[Solve[elem], Solve::svars];
+                    sol  = cachedSolve[elem];
                     fsol = If[MatchQ[sol, {{__Rule}, ___}], First[sol], {}];
                     If[fsol =!= {},
                         dnfCounterIncrement[monitor, "EqualitySolves"];
@@ -1651,7 +1709,7 @@ dnfReduceInstrumented[xp_, rst_, fst_Equal, monitor_, order_String, sysObj_, dep
         dnfCounterIncrement[monitor, "ConjunctsProcessed"];
         dnfCounterIncrement[monitor, "EqualityAttempts"];
         dnfTraceEvent[monitor, <|"Phase" -> "DNF", "Action" -> "ProcessBranchEquality", "Depth" -> depth, "Expression" -> fst|>];
-        sol  = Quiet[Solve[fst], Solve::svars];
+        sol  = cachedSolve[fst];
         fsol = If[MatchQ[sol, {{__Rule}, ___}], First[sol], {}];
         If[fsol =!= {},
             dnfCounterIncrement[monitor, "EqualitySolves"];

--- a/MFGraphs/solversTools.wl
+++ b/MFGraphs/solversTools.wl
@@ -295,32 +295,32 @@ reduceSystem[sys_?mfgSystemQ] :=
     ];
 
 dnfReduceSystem[sys_?mfgSystemQ] :=
-    Module[{result},
-        resetSolveCacheCounters[];
-        result = withCriticalCongestionSolver[sys, "dnfReduceSystem",
+    withDnfSolveCache["dnfReduceSystem",
+        withCriticalCongestionSolver[sys, "dnfReduceSystem",
             Function[{constraints, allVars},
                 parseDNFReduceResult[dnfReduce[True, constraints], allVars]
             ],
             buildSolverInputs,
             attachAccumulatedRules
-        ];
-        If[TrueQ[$MFGraphsVerbose], printSolveCacheSummary["dnfReduceSystem"]];
-        result
+        ]
     ];
 
 optimizedDNFReduceSystem[sys_?mfgSystemQ] :=
-    withCriticalCongestionSolver[sys, "optimizedDNFReduceSystem",
-        Function[{constraints, allVars},
-            If[Length[allVars] <= $optimizedDNFVarThreshold,
-                branchStateReduceResult[constraints, allVars],
-                parseDNFReduceResult[dnfReduce[True, constraints], allVars]
-            ]
-        ],
-        buildSolverInputs,
-        attachAccumulatedRules
+    withDnfSolveCache["optimizedDNFReduceSystem",
+        withCriticalCongestionSolver[sys, "optimizedDNFReduceSystem",
+            Function[{constraints, allVars},
+                If[Length[allVars] <= $optimizedDNFVarThreshold,
+                    branchStateReduceResult[constraints, allVars],
+                    parseDNFReduceResult[dnfReduce[True, constraints], allVars]
+                ]
+            ],
+            buildSolverInputs,
+            attachAccumulatedRules
+        ]
     ];
 
 activeSetReduceSystem[sys_?mfgSystemQ] :=
+    withDnfSolveCache["activeSetReduceSystem",
     withCriticalCongestionGuard[sys, "activeSetReduceSystem",
     Module[{initRules, deterministicConstraints, activeConstraints, allVars,
             detReduced, rulesAcc, activeReduced, result, branches},
@@ -357,6 +357,7 @@ activeSetReduceSystem[sys_?mfgSystemQ] :=
             parseDNFReduceResult[dnfReduce[True, And[detReduced, activeReduced]], allVars]
         ];
         attachAccumulatedRules[result, rulesAcc]
+    ]
     ]
     ];
 
@@ -1326,30 +1327,26 @@ branchStateReduceResult[constraints_, allVars_List] :=
 
 (* --- cachedSolve: memoized Quiet[Solve[expr], Solve::svars] ------------- *)
 (* Used inside dnfReduce / dnfReduceProcedural / dnfReduceInstrumented.
-   On a baseline measurement (2026-05-11) grid-4x4 made 71 051 non-trivial
-   Solve calls on only 114 distinct keys (99.8% hit rate). The cache is
-   keyed by Hash[expr] (32-bit, fast); collisions are negligible at our
-   scale. Reset before each dnfReduceSystem invocation. *)
+   See BENCHMARKS.md for the grid-4x4 baseline (~99.8% hit rate) that
+   motivated the cache. Scope: $dnfSolveCache and its counters are
+   rebound per public entry point via withDnfSolveCache[...] so the
+   cache is empty at every invocation and cannot leak across scenarios.
+   Keyed by the full expression (no hash) to eliminate any chance of
+   returning a wrong solution under collision. *)
 
-$dnfSolveCache    = <||>;
-$dnfSolveHits     = 0;
-$dnfSolveMiss     = 0;
-$dnfSolveMissTag  = Unique["dnfSolveMissTag$"];  (* sentinel — guaranteed not to collide with any Solve result *)
+$dnfSolveCache = <||>;
+$dnfSolveHits  = 0;
+$dnfSolveMiss  = 0;
 
-resetSolveCacheCounters[] := (
-    $dnfSolveHits = 0;
-    $dnfSolveMiss = 0;
-);
-
-clearSolveCache[] := ($dnfSolveCache = <||>);
-
-cachedSolve[expr_] :=
-    Module[{h = Hash[expr], cached},
-        cached = Lookup[$dnfSolveCache, h, $dnfSolveMissTag];
-        If[cached === $dnfSolveMissTag,
+(* Typed Equal pattern self-documents the contract; expr is always an
+   Equal expression (not a List), so it is a safe direct Association key. *)
+cachedSolve[expr_Equal] :=
+    Module[{cached},
+        cached = Lookup[$dnfSolveCache, expr, Missing["NotCached"]];
+        If[MissingQ[cached],
             $dnfSolveMiss++;
             cached = Quiet[Solve[expr], Solve::svars];
-            $dnfSolveCache[h] = cached;
+            $dnfSolveCache[expr] = cached;
             ,
             $dnfSolveHits++;
         ];
@@ -1360,12 +1357,25 @@ printSolveCacheSummary[label_String] :=
     Module[{total, hitRate},
         total   = $dnfSolveHits + $dnfSolveMiss;
         hitRate = If[total === 0, 0., N[$dnfSolveHits / total]];
-        Print["SOLVE_CACHE|", label,
+        mfgPrint["SOLVE_CACHE|", label,
               "|total=", total,
               "|hits=",  $dnfSolveHits,
               "|miss=",  $dnfSolveMiss,
               "|hit_rate=", hitRate,
               "|cache_size=", Length[$dnfSolveCache]];
+    ];
+
+(* HoldRest defers body until the Block rebinds the cache vars, so
+   cachedSolve sees the per-invocation empty cache. Module captures the
+   body's return value in r before printSolveCacheSummary runs, so the
+   final cache stats reflect the completed work. *)
+SetAttributes[withDnfSolveCache, HoldRest];
+withDnfSolveCache[label_String, body_] :=
+    Block[{$dnfSolveCache = <||>, $dnfSolveHits = 0, $dnfSolveMiss = 0},
+        Module[{r = body},
+            printSolveCacheSummary[label];
+            r
+        ]
     ];
 
 dnfReduce[_,    False] := False
@@ -1460,6 +1470,7 @@ dnfReduce for well-formed inputs. Or-branches are pushed in original order \
 Not wired into dnfReduceSystem by default; call directly for deep Or-chains.";
 
 dnfReduceProcedural[xp0_, sys0_, allVars_List] :=
+    withDnfSolveCache["dnfReduceProcedural",
     Module[{stack = {<|"xp" -> xp0, "rst" -> True, "fst" -> sys0|>},
             results = {}, item, xp, rst, fst,
             conjuncts, xpAcc, i, elem, sol, fsol, newxp, rest, newRest},
@@ -1532,6 +1543,7 @@ dnfReduceProcedural[xp0_, sys0_, allVars_List] :=
             Length[results] === 1, First[results],
             True, Or @@ results
         ]
+    ]
     ]
 
 dnfTraceEvent::usage =
@@ -1740,6 +1752,7 @@ Options[dnfReduceDiagnosticReport] = {
 };
 
 dnfReduceDiagnosticReport[sys_?mfgSystemQ, OptionsPattern[]] :=
+    withDnfSolveCache["dnfReduceDiagnosticReport",
     Module[{order, timeout, traceLength, tInputs, inputs, constraints, allVars,
             rulesAcc, conjuncts, orderedConstraints, orderingSummary, monitor,
             tDNF, reduced, status, parsed, result, variableDiagnostics, summary},
@@ -1847,6 +1860,7 @@ dnfReduceDiagnosticReport[sys_?mfgSystemQ, OptionsPattern[]] :=
             "LastEvents" -> Lookup[monitor, "LastEvents", {}],
             "TimeoutLocation" -> Lookup[monitor, "TimeoutLocation", <||>]
         |>
+    ]
     ];
 
 (* reduceSystem only handles the critical-congestion structural system. The

--- a/MFGraphs/systemTools.wl
+++ b/MFGraphs/systemTools.wl
@@ -81,8 +81,6 @@ with legacy solvers.";
 
 getKirchhoffLinearSystem::usage = "getKirchhoffLinearSystem[sys] returns the entry current vector, Kirchhoff matrix, and the variables in the order corresponding to the Kirchhoff matrix.";
 
-getKirchhoffMatrix::usage = "getKirchhoffMatrix[sys] returns the entry current vector, Kirchhoff matrix, (critical congestion) cost function placeholder, and the variables in the order corresponding to the Kirchhoff matrix. The third slot is retained for backward compatibility.";
-
 altFlowOp::usage = "altFlowOp[j][list] returns the alternative: j@@list ==0 || j@@Reverse@list ==0.";
 
 flowSplitting::usage = "flowSplitting[AT][UndirectedEdge[a, b]] returns the splitting that start with {a,b}.";
@@ -393,14 +391,8 @@ getKirchhoffLinearSystem[sys_] :=
         ruleEntryIn          = systemData[sys, "RuleEntryIn"];
         ruleEntryOut         = systemData[sys, "RuleEntryOut"];
 
-        If[MissingQ[eqEntryIn],            eqEntryIn = True];
-        If[MissingQ[balanceGatheringFlows], balanceGatheringFlows = {}];
-        If[MissingQ[balanceSplittingFlows], balanceSplittingFlows = {}];
-        If[MissingQ[ruleEntryIn],          ruleEntryIn = <||>];
-        If[MissingQ[ruleEntryOut],         ruleEntryOut = <||>];
-
         kirchhoff = Join[
-            If[Head[eqEntryIn] === List, eqEntryIn, {eqEntryIn}],
+            eqEntryIn,
             (# == 0& /@ Join[balanceGatheringFlows, balanceSplittingFlows])
         ];
         kirchhoff = kirchhoff /. Join[Normal[ruleEntryIn], Normal[ruleEntryOut]];
@@ -416,22 +408,15 @@ getKirchhoffLinearSystem[sys_] :=
         ]
     ];
 
-getKirchhoffMatrix[sys_] :=
-    Module[{b, km, vars, cost, cCost},
-        {b, km, vars} = getKirchhoffLinearSystem[sys];
-        If[Length[vars] === 0,
-            Return[{b, km, <||>, vars}, Module]
-        ];
-        cost  = AssociationThread[vars, (0&) /@ vars];
-        cCost = cost /@ vars /. MapThread[Rule, {vars, #}]&;
-        {b, km, cCost, vars}
-    ];
-
 (* --- Constructors --- *)
 
-(* When Alpha == 1, the generated system consists of linear equations,
-   alternatives between linear equations, and linear inequalities; nothing is
-   non-linear. *)
+(* The generated system consists of linear equations, alternatives between
+   linear equations, and linear inequalities; nothing is non-linear. Linearity
+   is preserved by two conventions: (i) switching costs are scalars or affine
+   Function[x, a x + b], so cost[j[r,i,w]] stays linear in j; (ii) non-linear
+   Hamiltonian terms (e.g. m^alpha for Alpha != 1) are represented by cpf
+   placeholder symbols, with the non-linear relationship deferred to a
+   separate closure equation outside this kernel. *)
 makeSystem[s_?scenarioQ] := makeSystem[s, makeSymbolicUnknowns[s]];
 
 makeSystem[s_?scenarioQ, unk_?symbolicUnknownsQ] :=
@@ -441,11 +426,6 @@ makeSystem[s_?scenarioQ, unk_?symbolicUnknownsQ] :=
 
         model    = scenarioData[s, "Model"];
         topology = scenarioData[s, "Topology"];
-        If[!AssociationQ[topology], topology = buildAuxiliaryTopology[model]];
-
-        If[topology === $Failed,
-            Return[Failure["makeSystem", <|"Message" -> "Could not build topology from scenario."|>], Module]
-        ];
 
         graph          = topology["Graph"];
         auxiliaryGraph = topology["AuxiliaryGraph"];

--- a/Scripts/CompareSingleCase.wls
+++ b/Scripts/CompareSingleCase.wls
@@ -23,7 +23,7 @@ $HistoryLength = 0;
 $Timeout            = 300;
 $BoolConvertTimeout = 60;
 $BMTimeout          = 60;
-$BMRTimeout         = 60;
+$BMRTimeout         = 600;
 
 $KnownCases = <|
     "grid-2x2" -> Function[gridScenario[{2, 2}, {{1, 100}}, {{4, 0}}]],
@@ -106,6 +106,15 @@ match = Which[
 ];
 Print["  verdict: ", match];
 
+(* Free large intermediate results before the Boolean stage. On grid-4x4 / 4x5
+   the dnfReduce outputs (7200 / 27000 branches) plus their canonical sorted
+   forms hold enough memory that the kernel can be OOM-killed during the
+   subsequent BooleanConvert allocation. wolframscript reports an OOM kernel
+   loss as "license error", which is misleading. *)
+ClearAll[resRec, resProc, recCan, procCan];
+Share[];
+Print["  freed dnf results; mem now ", MemoryInUse[]];
+
 (* BooleanConvert (Stage 1 only) *)
 {tBool, resBool} = AbsoluteTiming[
     TimeConstrained[
@@ -138,21 +147,20 @@ bmVerdict = Which[
 ];
 Print["  BooleanMinimize: ", tBM, "s  verdict: ", bmVerdict];
 
-(* booleanMinimizeReduceSystem *)
-{tBMR, resBMR} = AbsoluteTiming[
-    TimeConstrained[
-        Quiet[booleanMinimizeReduceSystem[sys,
-              "ArmTimeout" -> 2, "DisjunctTimeout" -> 10],
-              {booleanMinimizeReduceSystem::multisol}],
-        $BMRTimeout, $Aborted
+(* booleanMinimizeReduceSystem — runs in a fresh kernel so that OOM during BMR
+   cannot kill the current kernel and lose the rows already computed. *)
+ClearAll[resBool]; Share[];
+bmrScript = FileNameJoin[{$RepoRoot, "Scripts", "CompareSingleCaseBMR.wls"}];
+bmrProc = RunProcess[{"wolframscript", "-file", bmrScript, caseName}];
+bmrOut  = Lookup[bmrProc, "StandardOutput", ""];
+bmrLine = SelectFirst[StringSplit[bmrOut, "\n"], StringStartsQ[#, "BMR_RESULT|"] &, ""];
+{bmrVerdict, tBMR} = If[bmrLine === "",
+    {"FAIL", 0.0},
+    Module[{parts = StringSplit[bmrLine, "|"]},
+        {parts[[2]], ToExpression[parts[[3]]]}
     ]
 ];
-bmrVerdict = Which[
-    resBMR === $Aborted,                   "TIMEOUT",
-    ListQ[resBMR] || AssociationQ[resBMR], "OK",
-    True,                                  "FAIL"
-];
-Print["  BooleanMinimizeReduce: ", tBMR, "s  verdict: ", bmrVerdict];
+Print["  BooleanMinimizeReduce: ", tBMR, "s  verdict: ", bmrVerdict, "  (subprocess)"];
 
 (* Single markdown row, same column shape as the multi-case report. *)
 row = StringJoin[

--- a/Scripts/CompareSingleCase.wls
+++ b/Scripts/CompareSingleCase.wls
@@ -115,37 +115,36 @@ ClearAll[resRec, resProc, recCan, procCan];
 Share[];
 Print["  freed dnf results; mem now ", MemoryInUse[]];
 
-(* BooleanConvert (Stage 1 only) *)
-{tBool, resBool} = AbsoluteTiming[
-    TimeConstrained[
-        BooleanConvert[constraints, "DNF"],
-        $BoolConvertTimeout, $Aborted
+(* BooleanConvert — runs in a fresh kernel with an OS-level wall-clock
+   watchdog so that the known C-level abort-deafness of BooleanConvert
+   cannot block the main pipeline. *)
+bcScript = FileNameJoin[{$RepoRoot, "Scripts", "CompareSingleCaseBC.wls"}];
+bcProc   = RunProcess[{"wolframscript", "-file", bcScript, caseName}];
+bcOut    = Lookup[bcProc, "StandardOutput", ""];
+bcLine   = SelectFirst[StringSplit[bcOut, "\n"], StringStartsQ[#, "BC_RESULT|"] &, ""];
+{boolVerdict, tBool, boolBranches} = If[bcLine === "",
+    {"FAIL", 0.0, "?"},
+    Module[{parts = StringSplit[bcLine, "|"]},
+        {parts[[2]], ToExpression[parts[[3]]], parts[[4]]}
     ]
-];
-boolVerdict = If[resBool === $Aborted, "TIMEOUT", "OK"];
-boolBranches = Which[
-    resBool === $Aborted, "?",
-    Head[resBool] === Or, ToString[Length[resBool]],
-    True,                 "1"
 ];
 Print["  BooleanConvert: ", tBool, "s",
-      If[resBool === $Aborted, " (TIMEOUT)", ""],
-      "  disjuncts: ", boolBranches];
+      If[boolVerdict === "TIMEOUT", " (TIMEOUT)", ""],
+      "  disjuncts: ", boolBranches, "  (subprocess)"];
 
-(* booleanMinimizeSystem *)
-{tBM, resBM} = AbsoluteTiming[
-    TimeConstrained[
-        Quiet[booleanMinimizeSystem[sys, "DisjunctTimeout" -> 10],
-              {booleanMinimizeSystem::multisol}],
-        $BMTimeout, $Aborted
+(* booleanMinimizeSystem — runs in a fresh kernel with an OS-level
+   wall-clock watchdog (same rationale as BooleanConvert). *)
+bmScript = FileNameJoin[{$RepoRoot, "Scripts", "CompareSingleCaseBM.wls"}];
+bmProc   = RunProcess[{"wolframscript", "-file", bmScript, caseName}];
+bmOut    = Lookup[bmProc, "StandardOutput", ""];
+bmLine   = SelectFirst[StringSplit[bmOut, "\n"], StringStartsQ[#, "BM_RESULT|"] &, ""];
+{bmVerdict, tBM} = If[bmLine === "",
+    {"FAIL", 0.0},
+    Module[{parts = StringSplit[bmLine, "|"]},
+        {parts[[2]], ToExpression[parts[[3]]]}
     ]
 ];
-bmVerdict = Which[
-    resBM === $Aborted,                  "TIMEOUT",
-    ListQ[resBM] || AssociationQ[resBM], "OK",
-    True,                                "FAIL"
-];
-Print["  BooleanMinimize: ", tBM, "s  verdict: ", bmVerdict];
+Print["  BooleanMinimize: ", tBM, "s  verdict: ", bmVerdict, "  (subprocess)"];
 
 (* booleanMinimizeReduceSystem — runs in a fresh kernel so that OOM during BMR
    cannot kill the current kernel and lose the rows already computed. *)

--- a/Scripts/CompareSingleCaseBC.wls
+++ b/Scripts/CompareSingleCaseBC.wls
@@ -1,0 +1,71 @@
+#!/usr/bin/env wolframscript
+(* CompareSingleCaseBC.wls — run only the BooleanConvert[..., "DNF"] stage
+   on ONE case in a fresh kernel. Invoked by CompareSingleCase.wls so that
+   BooleanConvert runs in its own process and its known-bad TimeConstrained
+   behavior (C-level Boolean kernel ignores aborts for many minutes past
+   the requested limit) cannot block the main pipeline.
+
+   A self-kill watchdog ensures hard wall-clock termination:
+       Run["( sleep <wallclock>; kill -9 <pid> ) >/dev/null 2>&1 &"]
+   so even if TimeConstrained never fires inside the kernel, the process
+   is SIGKILLed by the OS at $WallclockKill seconds.
+
+   Usage:
+     wolframscript -file Scripts/CompareSingleCaseBC.wls grid-4x5
+
+   Output: prints exactly one machine-parseable line to stdout:
+     BC_RESULT|<verdict>|<seconds>|<disjuncts>
+   where <verdict> is OK | TIMEOUT and <disjuncts> is an integer or "?". *)
+
+$RepoRoot = FileNameJoin[{DirectoryName[$InputFileName], ".."}];
+PrependTo[$Path, $RepoRoot];
+Needs["MFGraphs`"];
+$MFGraphsVerbose = False;
+$HistoryLength   = 0;
+
+$BoolConvertTimeout = 60;     (* WL-level (often ignored by C kernel) *)
+$WallclockKill      = 120;    (* OS-level hard ceiling *)
+
+$KnownCases = <|
+    "grid-2x2" -> Function[gridScenario[{2, 2}, {{1, 100}}, {{4, 0}}]],
+    "grid-3x2" -> Function[gridScenario[{3, 2}, {{1, 100}}, {{6, 0}}]],
+    "grid-2x3" -> Function[gridScenario[{2, 3}, {{1, 100}}, {{6, 0}}]],
+    "grid-2x4" -> Function[gridScenario[{2, 4}, {{1, 100}}, {{8, 0}}]],
+    "grid-3x3" -> Function[gridScenario[{3, 3}, {{1, 100}}, {{9, 0}}]],
+    "grid-3x4" -> Function[gridScenario[{3, 4}, {{1, 100}}, {{12, 0}}]],
+    "grid-4x4" -> Function[gridScenario[{4, 4}, {{1, 100}}, {{16, 0}}]],
+    "grid-4x5" -> Function[gridScenario[{4, 5}, {{1, 100}}, {{20, 0}}]]
+|>;
+
+args = Rest[$ScriptCommandLine];
+If[Length[args] < 1 || !KeyExistsQ[$KnownCases, First[args]],
+    Print["BC_RESULT|FAIL|0|?"];
+    Exit[1]
+];
+caseName = First[args];
+
+(* Spawn the OS-level watchdog. Detached shell sleeps then SIGKILLs us. *)
+Run["( sleep " <> ToString[$WallclockKill] <> "; kill -9 " <>
+    ToString[$ProcessID] <> " ) >/dev/null 2>&1 &"];
+
+scen        = $KnownCases[caseName][];
+sys         = makeSystem[scen];
+inputs      = solversTools`Private`buildSolverInputs[sys];
+constraints = inputs[[1]];
+
+{tBC, resBC} = AbsoluteTiming[
+    TimeConstrained[
+        BooleanConvert[constraints, "DNF"],
+        $BoolConvertTimeout, $Aborted
+    ]
+];
+
+bcVerdict = If[resBC === $Aborted, "TIMEOUT", "OK"];
+bcDj = Which[
+    resBC === $Aborted,   "?",
+    Head[resBC] === Or,   ToString[Length[resBC]],
+    True,                 "1"
+];
+
+Print["BC_RESULT|", bcVerdict, "|", tBC, "|", bcDj];
+Exit[0];

--- a/Scripts/CompareSingleCaseBM.wls
+++ b/Scripts/CompareSingleCaseBM.wls
@@ -1,0 +1,69 @@
+#!/usr/bin/env wolframscript
+(* CompareSingleCaseBM.wls — run only the booleanMinimizeSystem stage on
+   ONE case in a fresh kernel. Invoked by CompareSingleCase.wls so that
+   booleanMinimizeSystem's known-bad TimeConstrained behavior (the inner
+   per-disjunct loop, plus the C-level Boolean kernel's abort-deafness,
+   can push wall-clock to many times the requested 60s limit) cannot
+   block the main pipeline.
+
+   A self-kill watchdog ensures hard wall-clock termination at
+   $WallclockKill seconds even if TimeConstrained never fires inside
+   the kernel.
+
+   Usage:
+     wolframscript -file Scripts/CompareSingleCaseBM.wls grid-4x5
+
+   Output: prints exactly one machine-parseable line to stdout:
+     BM_RESULT|<verdict>|<seconds>
+   where <verdict> is OK | TIMEOUT | FAIL. *)
+
+$RepoRoot = FileNameJoin[{DirectoryName[$InputFileName], ".."}];
+PrependTo[$Path, $RepoRoot];
+Needs["MFGraphs`"];
+$MFGraphsVerbose = False;
+$HistoryLength   = 0;
+
+$BMTimeout     = 60;     (* WL-level (often ignored by C kernel) *)
+$WallclockKill = 120;    (* OS-level hard ceiling *)
+
+$KnownCases = <|
+    "grid-2x2" -> Function[gridScenario[{2, 2}, {{1, 100}}, {{4, 0}}]],
+    "grid-3x2" -> Function[gridScenario[{3, 2}, {{1, 100}}, {{6, 0}}]],
+    "grid-2x3" -> Function[gridScenario[{2, 3}, {{1, 100}}, {{6, 0}}]],
+    "grid-2x4" -> Function[gridScenario[{2, 4}, {{1, 100}}, {{8, 0}}]],
+    "grid-3x3" -> Function[gridScenario[{3, 3}, {{1, 100}}, {{9, 0}}]],
+    "grid-3x4" -> Function[gridScenario[{3, 4}, {{1, 100}}, {{12, 0}}]],
+    "grid-4x4" -> Function[gridScenario[{4, 4}, {{1, 100}}, {{16, 0}}]],
+    "grid-4x5" -> Function[gridScenario[{4, 5}, {{1, 100}}, {{20, 0}}]]
+|>;
+
+args = Rest[$ScriptCommandLine];
+If[Length[args] < 1 || !KeyExistsQ[$KnownCases, First[args]],
+    Print["BM_RESULT|FAIL|0"];
+    Exit[1]
+];
+caseName = First[args];
+
+(* Spawn the OS-level watchdog. *)
+Run["( sleep " <> ToString[$WallclockKill] <> "; kill -9 " <>
+    ToString[$ProcessID] <> " ) >/dev/null 2>&1 &"];
+
+scen = $KnownCases[caseName][];
+sys  = makeSystem[scen];
+
+{tBM, resBM} = AbsoluteTiming[
+    TimeConstrained[
+        Quiet[booleanMinimizeSystem[sys, "DisjunctTimeout" -> 10],
+              {booleanMinimizeSystem::multisol}],
+        $BMTimeout, $Aborted
+    ]
+];
+
+bmVerdict = Which[
+    resBM === $Aborted,                  "TIMEOUT",
+    ListQ[resBM] || AssociationQ[resBM], "OK",
+    True,                                "FAIL"
+];
+
+Print["BM_RESULT|", bmVerdict, "|", tBM];
+Exit[0];

--- a/Scripts/CompareSingleCaseBMR.wls
+++ b/Scripts/CompareSingleCaseBMR.wls
@@ -17,7 +17,8 @@ Needs["MFGraphs`"];
 $MFGraphsVerbose = False;
 $HistoryLength = 0;
 
-$BMRTimeout = 600;
+$BMRTimeout    = 600;    (* WL-level (often ignored by C kernel) *)
+$WallclockKill = 800;    (* OS-level hard ceiling *)
 
 $KnownCases = <|
     "grid-2x2" -> Function[gridScenario[{2, 2}, {{1, 100}}, {{4, 0}}]],
@@ -36,6 +37,10 @@ If[Length[args] < 1 || !KeyExistsQ[$KnownCases, First[args]],
     Exit[1]
 ];
 caseName = First[args];
+
+(* Spawn the OS-level watchdog. *)
+Run["( sleep " <> ToString[$WallclockKill] <> "; kill -9 " <>
+    ToString[$ProcessID] <> " ) >/dev/null 2>&1 &"];
 
 scen = $KnownCases[caseName][];
 sys  = makeSystem[scen];

--- a/Scripts/CompareSingleCaseBMR.wls
+++ b/Scripts/CompareSingleCaseBMR.wls
@@ -1,0 +1,58 @@
+#!/usr/bin/env wolframscript
+(* CompareSingleCaseBMR.wls — run only the booleanMinimizeReduceSystem stage
+   on ONE case in a fresh kernel. Invoked by CompareSingleCase.wls so that
+   BMR runs in its own process and cannot OOM-kill the kernel that holds the
+   recursive / procedural / BooleanConvert / BooleanMinimize timings.
+
+   Usage:
+     wolframscript -file Scripts/CompareSingleCaseBMR.wls grid-4x5
+
+   Output: prints exactly one machine-parseable line to stdout, prefixed
+     BMR_RESULT|<verdict>|<seconds>
+   where <verdict> is OK | TIMEOUT | FAIL and <seconds> is a Real. *)
+
+$RepoRoot = FileNameJoin[{DirectoryName[$InputFileName], ".."}];
+PrependTo[$Path, $RepoRoot];
+Needs["MFGraphs`"];
+$MFGraphsVerbose = False;
+$HistoryLength = 0;
+
+$BMRTimeout = 600;
+
+$KnownCases = <|
+    "grid-2x2" -> Function[gridScenario[{2, 2}, {{1, 100}}, {{4, 0}}]],
+    "grid-3x2" -> Function[gridScenario[{3, 2}, {{1, 100}}, {{6, 0}}]],
+    "grid-2x3" -> Function[gridScenario[{2, 3}, {{1, 100}}, {{6, 0}}]],
+    "grid-2x4" -> Function[gridScenario[{2, 4}, {{1, 100}}, {{8, 0}}]],
+    "grid-3x3" -> Function[gridScenario[{3, 3}, {{1, 100}}, {{9, 0}}]],
+    "grid-3x4" -> Function[gridScenario[{3, 4}, {{1, 100}}, {{12, 0}}]],
+    "grid-4x4" -> Function[gridScenario[{4, 4}, {{1, 100}}, {{16, 0}}]],
+    "grid-4x5" -> Function[gridScenario[{4, 5}, {{1, 100}}, {{20, 0}}]]
+|>;
+
+args = Rest[$ScriptCommandLine];
+If[Length[args] < 1 || !KeyExistsQ[$KnownCases, First[args]],
+    Print["BMR_RESULT|FAIL|0"];
+    Exit[1]
+];
+caseName = First[args];
+
+scen = $KnownCases[caseName][];
+sys  = makeSystem[scen];
+
+{tBMR, resBMR} = AbsoluteTiming[
+    TimeConstrained[
+        Quiet[booleanMinimizeReduceSystem[sys,
+              "ArmTimeout" -> 2, "DisjunctTimeout" -> 10],
+              {booleanMinimizeReduceSystem::multisol}],
+        $BMRTimeout, $Aborted
+    ]
+];
+bmrVerdict = Which[
+    resBMR === $Aborted,                   "TIMEOUT",
+    ListQ[resBMR] || AssociationQ[resBMR], "OK",
+    True,                                  "FAIL"
+];
+
+Print["BMR_RESULT|", bmrVerdict, "|", tBMR];
+Exit[0];

--- a/Scripts/ProfileDNFProcedural.wls
+++ b/Scripts/ProfileDNFProcedural.wls
@@ -1,0 +1,105 @@
+#!/usr/bin/env wolframscript
+(* ProfileDNFProcedural.wls — baseline profiler for dnfReduceProcedural.
+
+   The recursive engine has dnfReduceDiagnosticReport (via dnfReduceInstrumented);
+   the procedural engine has no equivalent. This script measures the procedural
+   reducer's wall-clock time, output branch count, output leaf count, and peak
+   worklist size on the same grid cases used by ProfileDNFReduce.wls and the
+   recursive/procedural comparison report.
+
+   Usage:
+     wolframscript -file Scripts/ProfileDNFProcedural.wls [--case name|all] [--timeout s]
+
+   Output: TSV rows on stdout, one per case.
+*)
+
+$RepoRoot = FileNameJoin[{DirectoryName[$InputFileName], ".."}];
+PrependTo[$Path, $RepoRoot];
+Needs["MFGraphs`"];
+$MFGraphsVerbose = False;
+$HistoryLength  = 0;
+
+$SelectedCase = "all";
+$TimeoutSecs  = 300;
+
+Module[{args = Rest[$ScriptCommandLine], i = 1, arg},
+    While[i <= Length[args],
+        arg = args[[i]];
+        Switch[arg,
+            "--case",    i++; If[i <= Length[args], $SelectedCase = ToLowerCase[args[[i]]]],
+            "--timeout", i++; If[i <= Length[args],
+                Module[{v = Quiet @ Check[ToExpression[args[[i]]], $Failed]},
+                    If[NumericQ[v] && v >= 0, $TimeoutSecs = v]]],
+            _, Null
+        ];
+        i++
+    ]
+];
+
+$Cases = {
+    {"grid-2x2", Function[gridScenario[{2, 2}, {{1, 100}}, {{4, 0}}]]},
+    {"grid-3x2", Function[gridScenario[{3, 2}, {{1, 100}}, {{6, 0}}]]},
+    {"grid-2x3", Function[gridScenario[{2, 3}, {{1, 100}}, {{6, 0}}]]},
+    {"grid-2x4", Function[gridScenario[{2, 4}, {{1, 100}}, {{8, 0}}]]},
+    {"grid-3x3", Function[gridScenario[{3, 3}, {{1, 100}}, {{9, 0}}]]},
+    {"grid-3x4", Function[gridScenario[{3, 4}, {{1, 100}}, {{12, 0}}]]},
+    {"grid-4x4", Function[gridScenario[{4, 4}, {{1, 100}}, {{16, 0}}]]},
+    {"grid-4x5", Function[gridScenario[{4, 5}, {{1, 100}}, {{20, 0}}]]}
+};
+
+If[$SelectedCase =!= "all",
+    $Cases = Select[$Cases, #[[1]] === $SelectedCase &];
+    If[$Cases === {},
+        Print["No case '", $SelectedCase, "'"]; Exit[2]
+    ]
+];
+
+Fmt[x_?NumericQ] := ToString[NumberForm[N[x], {Infinity, 3}]];
+Fmt[x_] := ToString[x];
+
+branchCount[expr_] :=
+    Which[
+        expr === True || expr === False, 0,
+        Head[expr] === Or, Length[expr],
+        True, 1
+    ];
+
+Print["MFGraphs dnfReduceProcedural baseline profile"];
+Print["Date\t", DateString[]];
+Print["TimeoutSeconds\t", $TimeoutSecs];
+Print["Case\tVars\tConj\tBuildMs\tProcMs\tStatus\tBranches\tLeaves"];
+
+Scan[
+    Function[{case},
+        Module[{name, builder, scen, sys, inputs, constraints, allVars,
+                tBuild, tProc, result, nVars, nConj, status, br, lv},
+            name    = case[[1]];
+            builder = case[[2]];
+            {tBuild, sys} = AbsoluteTiming[makeSystem[builder[]]];
+            inputs  = solversTools`Private`buildSolverInputs[sys];
+            {constraints, allVars} = inputs[[1 ;; 2]];
+            nVars = Length[allVars];
+            nConj = If[Head[constraints] === And, Length[constraints], 1];
+            {tProc, result} = AbsoluteTiming[
+                TimeConstrained[
+                    solversTools`Private`dnfReduceProcedural[True, constraints, allVars],
+                    $TimeoutSecs, $Aborted
+                ]
+            ];
+            status = If[result === $Aborted, "TIMEOUT", "OK"];
+            br = If[result === $Aborted, "?", ToString[branchCount[result]]];
+            lv = If[result === $Aborted, "?", ToString[LeafCount[result]]];
+            Print[StringRiffle[{
+                name,
+                ToString[nVars],
+                ToString[nConj],
+                Fmt[1000 tBuild],
+                Fmt[1000 tProc],
+                status,
+                br,
+                lv
+            }, "\t"]];
+        ]
+    ],
+    $Cases
+];

--- a/docs/history/DNF_PERFORMANCE_HISTORY.md
+++ b/docs/history/DNF_PERFORMANCE_HISTORY.md
@@ -582,6 +582,47 @@ All remaining cases should have consistent switching costs
 
 ---
 
+### 2026-05-11 — Restore `cachedSolve` (shared with procedural engine)
+
+**Commit:** _pending_
+**File:** `MFGraphs/solversTools.wl`
+
+#### Rationale
+
+The historical `CachedSolve` from v0.2 / v1.0 (`MFGraphs/ZAnd.m` /
+`MFGraphs/DNFReduce.m`) did not survive the move to `solversTools.wl`.
+A telemetry pass found 99.8% hit-rate on grid-4x4 (85 103 calls, 140
+distinct keys) — restoring the memo recovers ~13% of `dnfReduceSystem`
+wall-clock on that case.
+
+#### Changes
+
+Memoize all six `Quiet[Solve[expr], Solve::svars]` call sites inside
+`dnfReduce`, `dnfReduceProcedural`, and `dnfReduceInstrumented`. Keyed
+by `Hash[expr]`. Cache persists across calls within a session (small,
+content-hashed, correctness-safe). See `DNF_PROCEDURAL_PERFORMANCE_HISTORY.md`
+2026-05-11 entry for full instrumentation data and rationale for
+caching everything (no shape gate — trivial and non-trivial Equals
+are within noise of each other in mean per-call cost).
+
+#### Measured performance
+
+`dnfReduceSystem` wall-clock, same five-case sweep:
+
+| Case | Before (s) | After (s) | Speedup |
+|---|---|---|---|
+| grid-2x2 | 0.005 | 0.005 | 1.00× |
+| grid-3x2 | 0.008 | 0.008 | 1.00× |
+| grid-3x3 | 0.111 | 0.097 | 1.14× |
+| grid-3x4 | 0.184 | 0.164 | 1.12× |
+| grid-4x4 | 35.05 | 30.54 | 1.15× |
+
+#### Verification
+
+`Scripts/RunTests.wls fast` — 216/216 pass.
+
+---
+
 ## Future entries (template)
 
 When implementing a new optimization, copy this template:

--- a/docs/history/DNF_PROCEDURAL_PERFORMANCE_HISTORY.md
+++ b/docs/history/DNF_PROCEDURAL_PERFORMANCE_HISTORY.md
@@ -1,0 +1,232 @@
+# dnfReduceProcedural Performance History
+
+This document tracks optimization milestones applied to `dnfReduceProcedural`
+(the stack-based iterative DNF reducer in `solversTools`Private``). Its
+counterpart `dnfReduce` is logged in `DNF_PERFORMANCE_HISTORY.md`.
+
+`dnfReduceProcedural` exists to bypass `$RecursionLimit` on deeply nested
+Or-chains. It is structurally equivalent to `dnfReduce`: same output up to
+ordering, as verified by `Results/dnf_recursive_vs_procedural.md`.
+
+---
+
+## How to add a new entry
+
+Run the baseline profile and record the new TSV alongside the rationale:
+
+```bash
+caffeinate -dimsu wolframscript -file Scripts/ProfileDNFProcedural.wls \
+    --case all --timeout 300
+```
+
+Then append a new section below following the template at the bottom.
+
+---
+
+## Metrics glossary
+
+| Column | Meaning |
+|--------|---------|
+| **Vars** | Variables in `buildSolverInputs[sys]` |
+| **Conj** | Top-level conjuncts in the system constraint |
+| **BuildMs** | `makeSystem` wall-clock (ms) — context only, not part of the reducer |
+| **ProcMs** | `dnfReduceProcedural` wall-clock (ms) |
+| **Branches** | Or-disjunct count in the output (1 if a single And, 0 if `True`/`False`) |
+| **Leaves** | `LeafCount` of the output expression |
+
+---
+
+## Entries (oldest → newest)
+
+---
+
+### 2026-05-11 — Baseline (introduction)
+
+**Commit:** `4648fac` — *"docs(solversTools): annotate recursive functions and add iterative alternative"*
+**Hardware:** Apple Silicon, Mathematica 14.x
+
+#### What `dnfReduceProcedural` does
+
+Stack-based equivalent of `dnfReduce`. The recursive version recurses on
+`Or` and `Equal` heads; the procedural version maintains an explicit
+worklist of `<|xp, rst, fst|>` items. Or-branches are pushed with
+`Prepend + Reverse` so branch priority matches the recursive ordering.
+The `And`-case loop folds in `Equal`-induced substitutions in place
+without recursion, then queues remaining unsolved disjuncts.
+
+Not wired into `dnfReduceSystem` by default; called directly from
+`CompareSingleCase.wls` and a few diagnostic paths.
+
+#### Measured performance
+
+| Case | Vars | Conj | BuildMs | ProcMs | Status | Branches | Leaves |
+|---|---|---|---|---|---|---|---|
+| grid-2x2 | 4  | 36  | 13.66 | 2.63      | OK | 1     | 33         |
+| grid-3x2 | 9  | 63  | 10.79 | 1.92      | OK | 1     | 69         |
+| grid-2x3 | 9  | 63  | 8.59  | 2.34      | OK | 1     | 69         |
+| grid-2x4 | 14 | 90  | 9.23  | 3.79      | OK | 1     | 113        |
+| grid-3x3 | 21 | 114 | 16.44 | 12.57     | OK | 10    | 1 661      |
+| grid-3x4 | 33 | 165 | 17.17 | 50.92     | OK | 30    | 9 411      |
+| grid-4x4 | 52 | 240 | 48.17 | 11 306.31 | OK | 7 200 | 3 230 861  |
+| grid-4x5 | 71 | 315 | 28.96 | 89 304.62 | OK | 27 000 | 19 251 001 |
+
+#### Cross-reference vs recursive (`dnfReduce`)
+
+Both columns below are taken from a single same-run report
+(`Results/dnf_recursive_vs_procedural.md`) so the ratio is apples-to-apples.
+Canonicalized verdict was `OK` on every row — same branch sets, just
+ordering differs. The `ProcMs` column in the baseline table above is from
+a separate fresh run today and will differ on small cases by JIT/cache
+noise.
+
+| Case | Recursive (s) | Procedural (s) | Ratio P/R |
+|---|---|---|---|
+| grid-2x2 | 0.002 | 0.001 | 0.5 |
+| grid-3x2 | 0.002 | 0.002 | 1.0 |
+| grid-2x3 | 0.002 | 0.002 | 1.0 |
+| grid-2x4 | 0.004 | 0.003 | 0.75 |
+| grid-3x3 | 0.014 | 0.013 | 0.93 |
+| grid-3x4 | 0.054 | 0.049 | 0.91 |
+| grid-4x4 | 9.72  | 10.83 | 1.11 |
+| grid-4x5 | 57.39 | 79.89 | 1.39 |
+
+#### Interpretation
+
+- **Procedural matches recursive on disjunct count and structure** on every
+  case tested. No correctness gap.
+- **Procedural is at parity or slightly faster on small cases**
+  (grid-2x2 through grid-3x4) — likely because skipping the WL
+  function-call dispatch for shallow inputs offsets the worklist
+  bookkeeping cost.
+- **Wall-clock cost grows faster than the recursive version at scale.**
+  At grid-4x4 procedural is ~1.11× slower; at grid-4x5 ~1.39× slower.
+  The crossover is around grid-4x4 (52 vars, 7 200 output branches).
+- **Likely hot spot at scale**: the `AppendTo[results, ...]` and `stack =
+  Prepend[...]` / `stack = Rest[stack]` allocations are O(n) copies each.
+  At 27 000 leaf branches on grid-4x5 the worklist churn dominates.
+  The recursive engine avoids this by leaning on the WL function-call stack.
+- **Output leaf count** scales roughly linearly with branch count (~700
+  leaves/branch on grid-4x4 / 4x5). Suggests each branch carries the full
+  residual rather than being compacted.
+
+#### Open optimization candidates (not yet attempted)
+
+1. Replace `stack` (List with Prepend/Rest) with an internally mutable
+   `CreateDataStructure["Stack"]` or a packed array with an index cursor.
+2. Replace `AppendTo[results, ...]` with a `Sow`/`Reap` collector or a
+   pre-allocated buffer.
+3. Coalesce identical residuals before stacking (cheap branch-dedup —
+   recursive uses `RemoveDuplicates` after merge; procedural doesn't).
+4. Restore a `CachedSolve`-style memo around `Quiet[Solve[elem], ...]`.
+   Both recursive (`solversTools.wl:1348`, `1384`) and procedural
+   (`solversTools.wl:1440`, `1461`) currently call bare `Solve` per
+   `Equal`. The historical `$SolveCache` / `$ReduceCache` from
+   `DNF_PERFORMANCE_HISTORY.md` v0.2 / v1.0 lived in the old
+   `DNFReduce.m` and did not survive the move to `solversTools`. A memo
+   shared by both engines would help wherever Or-branches share equality
+   atoms.
+
+---
+
+### 2026-05-11 — Add `cachedSolve` memo (shared with recursive engine)
+
+**Commit:** _pending_
+**File:** `MFGraphs/solversTools.wl`
+
+#### Rationale
+
+The baseline entry (above) flagged "restore a `CachedSolve`-style memo"
+as a candidate. Instrumenting the six `Quiet[Solve[expr], Solve::svars]`
+call sites (L1348, L1384, L1440, L1461, L1626, L1654) and counting
+hashed-by-content keys per `dnfReduceSystem` invocation gave:
+
+| Case     | Solve calls | Distinct | Hit rate |
+|----------|-------------|----------|----------|
+| grid-2x2 | 6           | 6        | 0%       |
+| grid-3x2 | 16          | 16       | 0%       |
+| grid-3x3 | 117         | 49       | 58%      |
+| grid-3x4 | 434         | 80       | 80%      |
+| grid-4x4 | **85 103**  | **140**  | **99.8%** |
+
+The "post-substitution rewrites the Equal atoms" worry in the baseline
+turned out to be empirically wrong — Or-branches reconverge on the same
+constraints in massive volume on the harder cases. Original plan
+proposed a shape-gated cache (trivial vs non-trivial Equals); measurement
+showed trivial and non-trivial Solve costs are nearly identical at scale
+(~43 vs ~46 µs), so the gate was dropped — `cachedSolve` memoizes all
+Solve calls inside the DNF reducers.
+
+#### Changes
+
+- Added top-level state in `solversTools`Private``: `$dnfSolveCache`,
+  `$dnfSolveHits`, `$dnfSolveMiss`. Cache keyed by `Hash[expr]` (default
+  32-bit hash, much cheaper than the historical SHA-256).
+- Counters reset per `dnfReduceSystem` invocation; cache **persists
+  across calls** (content-hashing makes this correctness-safe and
+  long-session cache sizes stay small — 267 entries after running all
+  five grid sizes consecutively).
+- Internal `clearSolveCache[]` helper available in `solversTools`Private``
+  for forced eviction (not exposed publicly — cache stays small in
+  practice).
+- Six `Quiet[Solve[...], Solve::svars]` call sites replaced with
+  `cachedSolve[...]`.
+
+#### Measured performance
+
+`Scripts/ProfileDNFProcedural.wls --case all --timeout 300`, same hardware
+as the baseline:
+
+| Case | Vars | Conj | BuildMs | ProcMs | Δ vs baseline | Branches | Leaves |
+|---|---|---|---|---|---|---|---|
+| grid-2x2 | 4  | 36  | 12.79 | 2.02      | noise  | 1     | 33         |
+| grid-3x2 | 9  | 63  | 10.75 | 2.18      | noise  | 1     | 69         |
+| grid-2x3 | 9  | 63  | 8.39  | 2.00      | noise  | 1     | 69         |
+| grid-2x4 | 14 | 90  | 9.25  | 3.59      | noise  | 1     | 113        |
+| grid-3x3 | 21 | 114 | 15.70 | 10.60     | 1.19×  | 10    | 1 661      |
+| grid-3x4 | 33 | 165 | 16.79 | 36.59     | 1.39×  | 30    | 9 411      |
+| grid-4x4 | 52 | 240 | 45.31 | 7 987.88  | **1.42×** | 7 200 | 3 230 861 |
+| grid-4x5 | 71 | 315 | 27.49 | 68 563.01 | **1.30×** | 27 000 | 19 251 001 |
+
+#### Interpretation
+
+- Procedural benefits *more* than recursive in absolute terms because it
+  was the slower engine on these cases — the Solve fraction of total
+  time was larger there.
+- Cache only kicks in on cases where the Or-branch fan-out exceeds the
+  number of distinct equations; below grid-3x3 the noise floor swamps
+  the savings.
+- The new state lives in `solversTools`Private`` and is shared by
+  `dnfReduce`, `dnfReduceProcedural`, and `dnfReduceInstrumented`.
+  Other solvers (`booleanMinimizeSystem`, `findInstanceSystem`, etc.)
+  do not call Solve inside the DNF reducers, so they are unaffected.
+
+#### Verification
+
+- `Scripts/RunTests.wls fast` — 216/216 pass.
+- `Scripts/RunSingleTest.wls MFGraphs/Tests/reduce-system.mt` — 88/88
+  pass with cache active.
+
+---
+
+## Future entries (template)
+
+```markdown
+### YYYY-MM-DD — short name
+
+**Commit:** `<hash>` — *"subject"*
+
+#### Rationale
+_Bottleneck targeted._
+
+#### Changes
+_Diff or pseudocode._
+
+#### Measured performance
+
+| Case | Vars | Conj | BuildMs | ProcMs | Status | Branches | Leaves |
+|---|---|---|---|---|---|---|---|
+| ... |
+
+#### Interpretation
+_Which cases improved / regressed and why._
+```


### PR DESCRIPTION
## Summary

### Original scope — systemTools cleanup
- Remove unreachable `MissingQ` fallbacks and `!AssociationQ[topology]` rebuild in `getKirchhoffLinearSystem` / `makeSystem` — `makeScenario` and `buildBoundaryData` already establish those invariants.
- Archive `getKirchhoffMatrix` (zero in-tree callers, placeholder constant-zero cost slot) to `MFGraphs/archive/getKirchhoffMatrix.wl` with restoration note; regenerate `API_REFERENCE.md`.
- Rewrite the linearity comment in `makeSystem` to explain *why* the kernel stays linear (affine switching costs, `cpf` placeholders for `m^alpha`).
- `Scripts/CompareSingleCase.wls`: bump BMR timeout to 600s, free dnfReduce result tables before `BooleanConvert`, run BMR in a subprocess so a BMR OOM does not lose timings already computed. New `Scripts/CompareSingleCaseBMR.wls`.

### Added on this branch — restored `cachedSolve` memo
- New `cachedSolve` private wrapper around `Quiet[Solve[expr], Solve::svars]` shared by `dnfReduce` / `dnfReduceProcedural` / `dnfReduceInstrumented`. Keyed by `Hash[expr]`. Cache persists across calls in a session.
- Empirical justification: telemetry pass found 99.8% hit-rate on grid-4x4 (85 103 calls, 140 distinct keys). See `docs/history/DNF_PROCEDURAL_PERFORMANCE_HISTORY.md` 2026-05-11 entry for full data and rationale for skipping the shape gate.
- Refactor extending the cache to `optimizedDNFReduceSystem` / `activeSetReduceSystem` via a `withDnfSolveCache` wrapper.
- Shared `booleanDnfReducePipeline` body extracted between `booleanReduceSystem` and `booleanMinimizeSystem`.

### Documentation
- `docs/history/DNF_PERFORMANCE_HISTORY.md`: new entry for the recursive engine.
- `docs/history/DNF_PROCEDURAL_PERFORMANCE_HISTORY.md`: new history doc paralleling the recursive one. Baseline + cache-on entry.
- `Scripts/ProfileDNFProcedural.wls`: minimal TSV profiler used to produce the numbers in the procedural history.

### Measured impact
| Case | dnfReduceSystem | dnfReduceProcedural |
|---|---|---|
| grid-3x3 | 1.14× | 1.19× |
| grid-3x4 | 1.12× | 1.39× |
| grid-4x4 | 1.15× | **1.42×** |
| grid-4x5 | n/m | **1.30×** |

Cases below grid-3x3 are within noise.

## Follow-up
- #202 — `EqualitySolves` diagnostic counter now over-counts since it fires on cache hits too. Suggested fix: split into `EqualityResolutions` + `CachedSolveHits`.

## Test plan
- [x] `wolframscript -file Scripts/RunTests.wls fast` — 216 passed, 0 failed
- [x] `wolframscript -file Scripts/GenerateDocs.wls` — `API_REFERENCE.md` regenerated, `getKirchhoffMatrix` section removed
- [x] `wolframscript -file Scripts/RunSingleTest.wls MFGraphs/Tests/reduce-system.mt` — 88 passed
- [x] `wolframscript -file Scripts/ProfileDNFProcedural.wls --case all --timeout 300` — produced post-cache numbers in `DNF_PROCEDURAL_PERFORMANCE_HISTORY.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
