### PR TITLE
docs(tour): add TOUR.md and tighten onboarding workbooks

### DIFF
--- a/MFGraphs/Getting started.wl
+++ b/MFGraphs/Getting started.wl
@@ -22,7 +22,7 @@
 (*	6. Structural systems (makeSystem, mfgSystem, systemData)*)
 (*	7. Switching costs vs HJ/complementarity blocks*)
 (*	8. Topology visualisation (rawNetworkPlot)*)
-(*	9. Symbolic solving (solveScenario \[Rule] dnfReduceSystem)*)
+(*	9. Symbolic solving (solveScenario -> dnfReduceSystem)*)
 (*	10. Solution visualisation with flows / value function*)
 (*	11. Augmented state-space graph (richNetworkPlot, augmentAuxiliaryGraph)*)
 (*	12. Paper-style network construction (graphScenario)*)
@@ -167,8 +167,11 @@ EdgeModelPlot[s_?scenarioQ, sys_?mfgSystemQ, opts : OptionsPattern[]] :=
 (* Use the global flag from primitives context *)
 $MFGraphsVerbose = False;
 
+
+
 (* ::Section:: *)
 (*1. Build scenarios with ExampleScenarios constructors*)
+
 
 sGrid = gridScenario[
     {3},
@@ -220,6 +223,7 @@ Column[{
 (* ::Section:: *)
 (*2. Use named factory examples from ExampleScenarios.wl*)
 
+
 exY = gridScenario[{3}, {{2, 100.0}}, {{1, 0.0}, {3, 10.0}}];
 
 exGrid = getExampleScenario[
@@ -245,6 +249,7 @@ Column[{
 (* ::Section:: *)
 (*3. Inspect scenario structure from Scenario.wl*)
 
+
 scenarioChecks = <|
     "scenarioQ[exY]" -> scenarioQ[exY],
     "Identity" -> scenarioData[exY, "Identity"],
@@ -263,6 +268,7 @@ DescribeOutput[
 
 (* ::Section:: *)
 (*4. Show the Hamiltonian model stored on each edge*)
+
 
 edgeModelScenario = makeScenario[
     <|
@@ -322,6 +328,7 @@ Column[{
 (* ::Section:: *)
 (*5. Build exact symbolic unknown bundles from unknownsTools.wl*)
 
+
 exampleUnknowns = makeSymbolicUnknowns[exY];
 
 unknownSummary = <|
@@ -344,18 +351,19 @@ DescribeOutput[
 (* ::Section:: *)
 (*6. Build structural systems from System.wl*)
 
+
 exampleSystem = makeSystem[exY, exampleUnknowns];
 
 systemSummary = <|
     "mfgSystemQ" -> mfgSystemQ[exampleSystem],
     "System keys" -> Keys @ systemData[exampleSystem],
-    "# EqEntryIn" -> Length @ systemData[exampleSystem, "EqEntryIn"],
-    "# EqGeneral" -> Length @ systemData[exampleSystem, "EqGeneral"],
-    "# AltTransitionFlows" -> Length @ systemData[exampleSystem, "AltTransitionFlows"],
-    "# IneqSwitchingByVertex" -> Length @ systemData[exampleSystem, "IneqSwitchingByVertex"],
-    "# js" -> Length @ systemData[exampleSystem, "Js"],
-    "# jts" -> Length @ systemData[exampleSystem, "Jts"],
-    "# us" -> Length @ systemData[exampleSystem, "Us"],
+    "EqEntryIn" -> Length @ systemData[exampleSystem, "EqEntryIn"],
+    "EqGeneral" -> Length @ systemData[exampleSystem, "EqGeneral"],
+    "AltTransitionFlows" -> Length @ systemData[exampleSystem, "AltTransitionFlows"],
+    "IneqSwitchingByVertex" -> Length @ systemData[exampleSystem, "IneqSwitchingByVertex"],
+    "js" -> Length @ systemData[exampleSystem, "Js"],
+    "jts" -> Length @ systemData[exampleSystem, "Jts"],
+    "us" -> Length @ systemData[exampleSystem, "Us"],
     "Switching-cost consistency" -> systemData[exampleSystem, "ConsistentCosts"]
 |>;
 
@@ -368,6 +376,7 @@ DescribeOutput[
 
 (* ::Section:: *)
 (*7. Chain with two exits: equations without and with switching costs*)
+
 
 chain2ExNoSC = gridScenario[
     {3},
@@ -418,6 +427,7 @@ Column[{
 (* ::Section:: *)
 (*8. Topology visualization (from MFGraphs`graphicsTools`)*)
 
+
 Column[{
     DescribeOutput[
         "Chain topology \[LongDash] no switching costs",
@@ -428,7 +438,9 @@ Column[{
     DescribeOutput[
         "Chain topology \[LongDash] with switching cost {1,2,3}=2.0",
         "Same topology; SC at vertex 2 penalises continuing from edge 1\[Rule]2 to 2\[Rule]3.",
-        rawNetworkPlot[chain2ExWithSC, sysWithSC,
+        (*TODO: include swithing cost label on the relevant augmented graph. 
+        Maybe find a way to include extra arrows with the SC on the raw plots.*)
+        richNetworkPlot[chain2ExWithSC, sysWithSC,
             PlotLabel -> "Chain 1\[Rule]2\[Rule]3 (SC at 2)"]
     ]
 }]
@@ -436,6 +448,7 @@ Column[{
 
 (* ::Section:: *)
 (*9. Solve with solveScenario (DNF-first default)*)
+
 
 (* Chain 1->2->3, single exit at 3 (cost=0), entry flow=10.
    All variables are uniquely determined. *)
@@ -465,8 +478,10 @@ Column[{
 (* ::Section:: *)
 (*10. Visualize solveScenario solutions (from MFGraphs`graphicsTools`)*)
 
+
 (* ::Subsubsection:: *)
 (*Apply to chain with one exit (sol1Ex from section 9)*)
+
 
 Column[{
     DescribeOutput[
@@ -483,7 +498,7 @@ Column[{
     ],
     DescribeOutput[
         "Flow-only plot \[LongDash] chain 1\[Rule]2\[Rule]3, single exit",
-        "Same call without ShowValueLabels/ShowDensityLabels — only j-flow values appear on edges.",
+        "Same call without ShowValueLabels/ShowDensityLabels \[LongDash] only j-flow values appear on edges.",
         rawNetworkPlot[chain1Ex, sys1Ex, sol1Ex,
             PlotLabel -> "Chain 1\[Rule]2\[Rule]3: flow values only"]
     ]
@@ -492,6 +507,7 @@ Column[{
 
 (* ::Subsubsection:: *)
 (*Apply to chain with two exits (solNoSC from section 9)*)
+
 
 Column[{
     DescribeOutput[
@@ -514,6 +530,7 @@ Column[{
 (* ::Section:: *)
 (*11. Advanced Solution Visualization (Paper Scheme)*)
 
+
 augChain1 = augmentAuxiliaryGraph[sys1Ex];
 
 Column[{
@@ -532,7 +549,7 @@ Column[{
         "richNetworkPlot with ShowFlowEdges -> False suppresses j[a,b] flow arcs, leaving the transition graph (j[r,i,w]). Nodes are colored on a Blue\[Rule]Red u-value gradient when a solution is provided. A color bar legend is shown by default.",
         richNetworkPlot[chain1Ex, sys1Ex, sol1Ex,
             PlotLabel -> "Chain 1\[Rule]2\[Rule]3: transition graph",
-            ShowFlowEdges -> False]
+            ShowFlowEdges -> True]
     ],
     DescribeOutput[
         "Transition graph \[LongDash] BendFactor comparison",
@@ -540,15 +557,15 @@ Column[{
         Row[{
             richNetworkPlot[chain1Ex, sys1Ex, sol1Ex,
                 PlotLabel -> "BendFactor \[Rule] 0 (straight)",
-                ShowFlowEdges -> False, ShowLegend -> False,
+                ShowFlowEdges -> True, ShowLegend -> False,
                 BendFactor -> 0, ImageSize -> 300],
             richNetworkPlot[chain1Ex, sys1Ex, sol1Ex,
                 PlotLabel -> "BendFactor \[Rule] 0.15 (default)",
-                ShowFlowEdges -> False, ShowLegend -> False,
+                ShowFlowEdges -> True, ShowLegend -> False,
                 BendFactor -> 0.15, ImageSize -> 300],
             richNetworkPlot[chain1Ex, sys1Ex, sol1Ex,
                 PlotLabel -> "BendFactor \[Rule] 0.35",
-                ShowFlowEdges -> False, ShowLegend -> False,
+                ShowFlowEdges -> True, ShowLegend -> False,
                 BendFactor -> 0.35, ImageSize -> 300]
         }, Spacer[12]]
     ],
@@ -569,7 +586,8 @@ Column[{
 
 
 (* ::Section:: *)
-(*12. Paper-style network: Figure 3 \[Rule] Figure 4 transformation*)
+(*12. Paper-style network: Figure 3 -> Figure 4 transformation*)
+
 
 paperFig3Scenario = graphScenario[
     Graph[{1 \[UndirectedEdge] 2, 2 \[UndirectedEdge] 3, 3 \[UndirectedEdge] 4}],
@@ -623,6 +641,7 @@ Column[{
 (* ::Section:: *)
 (*13. Jamaratv9 example from the named scenario registry*)
 
+
 jamaratScenario = getExampleScenario[
     "Jamaratv9",
     {{1, 100}, {2, 50}},
@@ -671,3 +690,6 @@ Column[{
         |>
     ]
 }]
+
+
+(*TODO: include a plot with the solution, it is taking less than a minute!*)

--- a/MFGraphs/Getting started.wl
+++ b/MFGraphs/Getting started.wl
@@ -1,43 +1,40 @@
 (* ::Package:: *)
 
+(* ::Title:: *)
+(*MFGraphs Getting Started*)
+
+
+(* ::Subsection:: *)
+(*Overview*)
+
+
+(* ::Text:: *)
+(*A notebook tour of the MFGraphs scenario kernel and the solversTools solver. Evaluate cells one at a time or section by section \[LongDash] do not evaluate the entire file at once. To force a clean reload, restart the kernel with Quit[] and re-evaluate from the top.*)
+
+
+(* ::Text:: *)
+(*Capabilities demonstrated, in order:*)
+(*	1. Direct scenario constructors (gridScenario, cycleScenario, amScenario)*)
+(*	2. Named example registry (getExampleScenario, listExampleScenarios)*)
+(*	3. Typed scenarios and scenarioData accessor*)
+(*	4. Per-edge Hamiltonian model (Alpha, V, G overrides)*)
+(*	5. Symbolic unknown bundles (makeSymbolicUnknowns)*)
+(*	6. Structural systems (makeSystem, mfgSystem, systemData)*)
+(*	7. Switching costs vs HJ/complementarity blocks*)
+(*	8. Topology visualisation (rawNetworkPlot)*)
+(*	9. Symbolic solving (solveScenario \[Rule] dnfReduceSystem)*)
+(*	10. Solution visualisation with flows / value function*)
+(*	11. Augmented state-space graph (richNetworkPlot, augmentAuxiliaryGraph)*)
+(*	12. Paper-style network construction (graphScenario)*)
+(*	13. Multi-entrance/multi-exit scenario (Jamaratv9)*)
+
+
+(* ::Subsection:: *)
+(*Initialization*)
+
+
 (*Quit[]*)
 
-
-(* Notebook-friendly MFGraphs workbook covering the typed scenario kernels
-   and the solversTools solver. *)
-
-(* Evaluate cells one at a time or section by section \[LongDash] do not evaluate the entire file at once. *)
-
-(* Force clean reload \[LongDash] safe to re-evaluate without restarting the kernel. *)
-Quiet[
-    With[
-        {
-            reloadContexts = {
-                "MFGraphs`",
-                "primitives`",
-                "scenarioTools`",
-                "examples`",
-                "unknownsTools`",
-                "systemTools`",
-                "solversTools`",
-                "graphicsTools`"
-            }
-        },
-        Remove["Global`*"];
-        Scan[
-            Remove[# <> "*", # <> "Private`*"]&,
-            reloadContexts
-        ];
-        $Packages = DeleteCases[
-            $Packages,
-            Alternatives @@ Join[reloadContexts, (# <> "Private`") /@ reloadContexts]
-        ];
-        $ContextPath = DeleteCases[
-            $ContextPath,
-            Alternatives @@ Join[reloadContexts, (# <> "Private`") /@ reloadContexts]
-        ];
-    ];
-];
 
 (* This file lives alongside MFGraphs.wl in the same directory. *)
 mfgDir = If[$InputFileName === "", 
@@ -170,7 +167,8 @@ EdgeModelPlot[s_?scenarioQ, sys_?mfgSystemQ, opts : OptionsPattern[]] :=
 (* Use the global flag from primitives context *)
 $MFGraphsVerbose = False;
 
-(* --- 1. Build scenarios with ExampleScenarios constructors --- *)
+(* ::Section:: *)
+(*1. Build scenarios with ExampleScenarios constructors*)
 
 sGrid = gridScenario[
     {3},
@@ -219,7 +217,8 @@ Column[{
 }]
 
 
-(* --- 2. Use named factory examples from ExampleScenarios.wl --- *)
+(* ::Section:: *)
+(*2. Use named factory examples from ExampleScenarios.wl*)
 
 exY = gridScenario[{3}, {{2, 100.0}}, {{1, 0.0}, {3, 10.0}}];
 
@@ -243,7 +242,8 @@ Column[{
 }]
 
 
-(* --- 3. Inspect scenario structure from Scenario.wl --- *)
+(* ::Section:: *)
+(*3. Inspect scenario structure from Scenario.wl*)
 
 scenarioChecks = <|
     "scenarioQ[exY]" -> scenarioQ[exY],
@@ -261,7 +261,8 @@ DescribeOutput[
 ]
 
 
-(* --- 4. Show the Hamiltonian model stored on each edge --- *)
+(* ::Section:: *)
+(*4. Show the Hamiltonian model stored on each edge*)
 
 edgeModelScenario = makeScenario[
     <|
@@ -318,7 +319,8 @@ Column[{
 }]
 
 
-(* --- 5. Build exact symbolic unknown bundles from unknownsTools.wl --- *)
+(* ::Section:: *)
+(*5. Build exact symbolic unknown bundles from unknownsTools.wl*)
 
 exampleUnknowns = makeSymbolicUnknowns[exY];
 
@@ -339,7 +341,8 @@ DescribeOutput[
 ]
 
 
-(* --- 6. Build structural systems from System.wl --- *)
+(* ::Section:: *)
+(*6. Build structural systems from System.wl*)
 
 exampleSystem = makeSystem[exY, exampleUnknowns];
 
@@ -363,7 +366,8 @@ DescribeOutput[
 ]
 
 
-(* --- 7. Chain with two exits: equations without and with switching costs --- *)
+(* ::Section:: *)
+(*7. Chain with two exits: equations without and with switching costs*)
 
 chain2ExNoSC = gridScenario[
     {3},
@@ -411,7 +415,8 @@ Column[{
 }]
 
 
-(* --- 8. Topology visualization (from MFGraphs`graphicsTools`) --- *)
+(* ::Section:: *)
+(*8. Topology visualization (from MFGraphs`graphicsTools`)*)
 
 Column[{
     DescribeOutput[
@@ -429,7 +434,8 @@ Column[{
 }]
 
 
-(* --- 9. Solve with solveScenario (DNF-first default) --- *)
+(* ::Section:: *)
+(*9. Solve with solveScenario (DNF-first default)*)
 
 (* Chain 1->2->3, single exit at 3 (cost=0), entry flow=10.
    All variables are uniquely determined. *)
@@ -456,9 +462,11 @@ Column[{
 }]
 
 
-(* --- 10. Visualize solveScenario solutions (from MFGraphs`graphicsTools`) --- *)
+(* ::Section:: *)
+(*10. Visualize solveScenario solutions (from MFGraphs`graphicsTools`)*)
 
-(* --- Apply to chain with one exit (sol1Ex from section 9) --- *)
+(* ::Subsubsection:: *)
+(*Apply to chain with one exit (sol1Ex from section 9)*)
 
 Column[{
     DescribeOutput[
@@ -482,7 +490,8 @@ Column[{
 }]
 
 
-(* --- Apply to chain with two exits (solNoSC from section 9) --- *)
+(* ::Subsubsection:: *)
+(*Apply to chain with two exits (solNoSC from section 9)*)
 
 Column[{
     DescribeOutput[
@@ -502,7 +511,8 @@ Column[{
 }]
 
 
-(* --- 11. Advanced Solution Visualization (Paper Scheme) --- *)
+(* ::Section:: *)
+(*11. Advanced Solution Visualization (Paper Scheme)*)
 
 augChain1 = augmentAuxiliaryGraph[sys1Ex];
 
@@ -519,7 +529,7 @@ Column[{
     ],
     DescribeOutput[
         "Transition graph \[LongDash] richNetworkPlot[..., ShowFlowEdges -> False]",
-        "richNetworkPlot with ShowFlowEdges -> False suppresses j[a,b] flow arcs, leaving the transition graph (j[r,i,w]). Nodes are colored on a Red\[Rule]Blue u-value gradient when a solution is provided. A color bar legend is shown by default.",
+        "richNetworkPlot with ShowFlowEdges -> False suppresses j[a,b] flow arcs, leaving the transition graph (j[r,i,w]). Nodes are colored on a Blue\[Rule]Red u-value gradient when a solution is provided. A color bar legend is shown by default.",
         richNetworkPlot[chain1Ex, sys1Ex, sol1Ex,
             PlotLabel -> "Chain 1\[Rule]2\[Rule]3: transition graph",
             ShowFlowEdges -> False]
@@ -558,7 +568,8 @@ Column[{
 }]
 
 
-(* --- 12. Paper-style network: Figure 3 \[Rule] Figure 4 transformation --- *)
+(* ::Section:: *)
+(*12. Paper-style network: Figure 3 \[Rule] Figure 4 transformation*)
 
 paperFig3Scenario = graphScenario[
     Graph[{1 \[UndirectedEdge] 2, 2 \[UndirectedEdge] 3, 3 \[UndirectedEdge] 4}],
@@ -609,7 +620,8 @@ Column[{
 }]
 
 
-(* --- 13. Jamaratv9 example from the named scenario registry --- *)
+(* ::Section:: *)
+(*13. Jamaratv9 example from the named scenario registry*)
 
 jamaratScenario = getExampleScenario[
     "Jamaratv9",

--- a/MFGraphs/Jamarat.wl
+++ b/MFGraphs/Jamarat.wl
@@ -3,61 +3,53 @@
 Quit[]
 
 
+(* ::Title:: *)
+(*MFGraphs Jamarat workbook*)
+
+
+(* ::Subsection:: *)
+(*Overview*)
+
+
+(* ::Text:: *)
+(*A guided tour of MFGraphs on the Jamarat scenario family \[LongDash] multi-entrance / multi-exit infrastructure problems. Each section names the package capability it demonstrates. Evaluate cells one at a time or section by section; the Quit[] at the top is a safety device.*)
+
+
+(* ::Text:: *)
+(*Capabilities demonstrated, in order:*)
+(*	1. Direct cycle scenario construction (cycleScenario) and a simple multi-exit case*)
+(*	2. Named registry retrieval (getExampleScenario["Jamaratv9", ...])*)
+(*	3. Augmented state-space graph (richNetworkPlot, augmentAuxiliaryGraph)*)
+(*	4. Symbolic solving (solveScenario, dnf-first default)*)
+(*	5. Two-mode solution visualisation \[LongDash] flow-coloured edges and value-function-coloured nodes (UseColorFunction -> True)*)
+(*	6. Congestion behaviour when entry flow exceeds exit budget (Section 3, optional, expensive)*)
+
+
 (* ::Subsection:: *)
 (*Initialization*)
 
 
-(* Notebook-friendly MFGraphs workbook for the Jamaratv9 scenario only. *)
-(* Evaluate cells one at a time or section by section \[LongDash] do not evaluate the entire file at once. *)
-(* Force clean reload \[LongDash] safe to re-evaluate without restarting the kernel. *)
-(*Quiet[
-    With[
-        {
-            reloadContexts = {
-                "MFGraphs`",
-                "primitives`",
-                "scenarioTools`",
-                "examples`",
-                "unknownsTools`",
-                "systemTools`",
-                "solversTools`",
-                "graphicsTools`"
-            }
-        },
-        Remove["Global`*"];
-        Scan[
-            Remove[# <> "*", # <> "Private`*"]&,
-            reloadContexts
-        ];
-        $Packages = DeleteCases[
-            $Packages,
-            Alternatives @@ Join[reloadContexts, (# <> "Private`") /@ reloadContexts]
-        ];
-        $ContextPath = DeleteCases[
-            $ContextPath,
-            Alternatives @@ Join[reloadContexts, (# <> "Private`") /@ reloadContexts]
-        ];
-    ];
-];*)
-
 (* This file lives alongside MFGraphs.wl in the same directory. *)
-mfgDir = If[$InputFileName === "", 
-    NotebookDirectory[], 
+mfgDir = If[$InputFileName === "",
+    NotebookDirectory[],
     DirectoryName[$InputFileName]
 ];
 
-(* Robustness: ensure mfgDir is a string for ParentDirectory *)
-If[!StringQ[mfgDir] || mfgDir === "", 
-    mfgDir = ExpandFileName["."];
+If[!StringQ[mfgDir] || mfgDir === "",
+    mfgDir = ExpandFileName["."]
 ];
 
 mfgParentDir = ParentDirectory[mfgDir];
-If[!MemberQ[$Path, mfgParentDir],
-    PrependTo[$Path, mfgParentDir]
-];
+If[!MemberQ[$Path, mfgParentDir], PrependTo[$Path, mfgParentDir]];
 Needs["MFGraphs`"];
 
-ClearAll[DescribeOutput];
+
+(* ::Subsection:: *)
+(*Presentation helpers*)
+
+
+ClearAll[DescribeOutput, JamaratScenarioSummary];
+
 DescribeOutput[title_String, description_String, expr_] :=
     Column[
         {
@@ -67,136 +59,6 @@ DescribeOutput[title_String, description_String, expr_] :=
         },
         Alignment -> Left,
         Spacings -> {0.2, 0.7}
-    ];
-
-ClearAll[
-    WorkbookFilePath,
-    CapturedSolutionFromWorkbook,
-    DNFBranches,
-    EntryCostData,
-    BranchVariables,
-    BranchEntryCostSummary,
-    RankSolutionBranches,
-    JamaratScenarioSummary
-];
-
-WorkbookFilePath[] :=
-    FileNameJoin[{mfgDir, "Jamarat.wl"}];
-
-CapturedSolutionFromWorkbook[symbolName_String] :=
-    Module[{path, text, start, stop, snippet},
-        path = WorkbookFilePath[];
-        text = Import[path, "Text"];
-        start = StringPosition[text, "(*" <> symbolName <> "="];
-        If[start === {}, Return[$Failed, Module]];
-        stop = StringPosition[text, "|>;*)"];
-        stop = Select[stop, #[[1]] > start[[1, 1]] &];
-        If[stop === {}, Return[$Failed, Module]];
-        snippet = StringTake[
-            text,
-            {start[[1, 1]] + StringLength["(*" <> symbolName <> "="], stop[[1, 1]] + 2}
-        ];
-        snippet = StringTrim[snippet];
-        If[StringEndsQ[snippet, ";"], snippet = StringDrop[snippet, -1]];
-        ToExpression[snippet]
-    ];
-
-DNFBranches[expr_, timeout_:60] :=
-    Module[{dnf},
-        dnf = TimeConstrained[
-            Quiet @ Check[BooleanConvert[expr, "DNF"], $Failed],
-            timeout,
-            $TimedOut
-        ];
-        Which[
-            dnf === $TimedOut || dnf === $Failed, dnf,
-            dnf === False, {},
-            Head[dnf] === Or, List @@ dnf,
-            True, {dnf}
-        ]
-    ];
-
-EntryCostData[s_?scenarioQ, sys_?mfgSystemQ] :=
-    Module[{pairs, vars, flows},
-        pairs = systemData[sys, "InAuxEntryPairs"];
-        vars = u @@@ pairs;
-        flows = Last /@ scenarioData[s, "Model"]["Entries"];
-        <|"Pairs" -> pairs, "Variables" -> vars, "Flows" -> flows|>
-    ];
-
-BranchVariables[expr_] :=
-    Select[
-        Variables[
-            expr /. {Equal -> List, Unequal -> List, LessEqual -> List,
-                GreaterEqual -> List, Less -> List, Greater -> List, And -> List, Or -> List}
-        ],
-        MatchQ[#, j[__] | u[__] | z[__]] &
-    ];
-
-BranchEntryCostSummary[branch_, rules_List, entry_Association, minimizeTimeout_:10] :=
-    Module[{entryVars, entryFlows, entryValues, objective, constraints, vars, min},
-        entryVars = entry["Variables"];
-        entryFlows = entry["Flows"];
-        constraints = branch /. rules;
-        entryValues = Simplify[entryVars /. rules];
-        objective = Simplify[Total[entryFlows * entryValues]];
-        vars = DeleteDuplicates @ BranchVariables[{constraints, objective}];
-        min = If[vars === {},
-            If[TrueQ[constraints], {objective, {}}, $Failed],
-            TimeConstrained[
-                Quiet @ Check[Minimize[{objective, constraints}, vars, Reals], $Failed],
-                minimizeTimeout,
-                $TimedOut
-            ]
-        ];
-        <|
-            "EntryValues" -> entryValues,
-            "WeightedEntryCost" -> objective,
-            "MinimizeResult" -> min,
-            "ResidualVariableCount" -> Length[vars],
-            "ResidualVariables" -> vars
-        |>
-    ];
-
-RankSolutionBranches[s_?scenarioQ, sys_?mfgSystemQ, sol_Association,
-        maxBranches_:Infinity, dnfTimeout_:60, minimizeTimeout_:10] :=
-    Module[{rules, residual, entry, branches, summaries, rows},
-        rules = Lookup[sol, "Rules", {}];
-        residual = Simplify[Lookup[sol, "Residual", True] /. rules];
-        entry = EntryCostData[s, sys];
-        branches = DNFBranches[residual, dnfTimeout];
-        If[branches === $TimedOut || branches === $Failed,
-            Return[
-                <|
-                    "Status" -> branches,
-                    "EntryVariables" -> entry["Variables"],
-                    "EntryFlows" -> entry["Flows"],
-                    "ResidualLeafCount" -> LeafCount[residual]
-                |>,
-                Module
-            ]
-        ];
-        summaries = BranchEntryCostSummary[#, rules, entry, minimizeTimeout] & /@
-            Take[branches, UpTo[maxBranches]];
-        rows = MapIndexed[
-            Join[<|"Branch" -> First[#2]|>, #1] &,
-            summaries
-        ];
-        <|
-            "Status" -> "OK",
-            "EntryVariables" -> entry["Variables"],
-            "EntryFlows" -> entry["Flows"],
-            "BranchCount" -> Length[branches],
-            "AnalyzedBranchCount" -> Length[rows],
-            "ResidualLeafCount" -> LeafCount[residual],
-            "RankedBranches" -> SortBy[
-                rows,
-                Replace[#["MinimizeResult"], {
-                    {val_, ___} :> {0, N[val]},
-                    _ :> {1, Infinity}
-                }] &
-            ]
-        |>
     ];
 
 JamaratScenarioSummary[s_?scenarioQ, sys_?mfgSystemQ] :=
@@ -210,7 +72,7 @@ JamaratScenarioSummary[s_?scenarioQ, sys_?mfgSystemQ] :=
             "EntryFlowTotal" -> Total[Last /@ entries],
             "Exits" -> exits,
             "ExitCostTotal" -> Total[Last /@ exits],
-            "EntryFlowTotalGreaterThanExitCostTotal" -> (Total[Last /@ entries] > Total[Last /@ exits]),
+            "EntryFlowExceedsExitBudget" -> (Total[Last /@ entries] > Total[Last /@ exits]),
             "NetworkEdges" -> Length[systemData[sys, "Edges"]],
             "FlowVariables" -> Length[systemData[sys, "Js"]],
             "TransitionFlowVariables" -> Length[systemData[sys, "Jts"]],
@@ -220,341 +82,193 @@ JamaratScenarioSummary[s_?scenarioQ, sys_?mfgSystemQ] :=
         |>
     ];
 
-(* Use the global flag from primitives context *)
 $MFGraphsVerbose = False;
 
 
-(* ::Subsection:: *)
-(*Simplified Jamarat cycle*)
-
-
-(* ::Subsubsection:: *)
-(*Simplified Jamarat end*)
+(* ::Section:: *)
+(*Section 1 \[LongDash] Simplified Jamarat (5-cycle)*)
 
 
 (* ::Text:: *)
-(*This is a shorter version of the Jamarat example for when the flows are at the last pillar. *)
+(*A 5-vertex cycle with two entrances (vertices 1 and 5) and three exits (vertex 3 cost 0, vertex 4 cost 40, vertex 2 cost 30). The smallest case where multiple entries compete for shared downstream capacity. Capability: cycleScenario direct constructor + the standard makeSystem / solveScenario pipeline.*)
 
 
-jamaratEnd=cycleScenario[5, {{1,100},{5,100}},{{3,0},{4,40},{2,30}}];
-jamaratEndSystem=makeSystem[jamaratEnd];
-AbsoluteTiming[jamaratEndSol=solveScenario[jamaratEnd];]
-Column[{
-    DescribeOutput[
-        "Simplified Jamarat augmented infrastructure",
-        "Augmented graph before solving \[LongDash] structure only.",
-        rawNetworkPlot[jamaratEnd, jamaratEndSystem,
-            PlotLabel -> "Simplified Jamarat infrastructure",
-            ImageSize -> Large,
-            ShowBoundaryData->True]
-    ],
-    DescribeOutput[
-        "Simplified Jamarat augmented infrastructure",
-        "Augmented graph before solving \[LongDash] structure only.",
-        richNetworkPlot[jamaratEnd, jamaratEndSystem,
-            PlotLabel -> "Simplified Jamarat infrastructure",
-            ImageSize -> Large,
-            ShowBoundaryValues -> False]
-    ],
-    DescribeOutput[
-        "Simplified Jamarat augmented infrastructure",
-        "Augmented graph before solving \[LongDash] structure only.",
-        richNetworkPlot[jamaratEnd, jamaratEndSystem,
-            PlotLabel -> "Simplified Jamarat infrastructure",
-            ImageSize -> Large,
-            ShowBoundaryData->True]
-    ],
-    DescribeOutput[
-        "Simplified Jamarat augmented solution",
-        "Augmented graph with solved flow, transition, and u values.",
-        richNetworkPlot[jamaratEnd, jamaratEndSystem, jamaratEndSol,
-            PlotLabel -> "Simplified Jamarat solution",
-            ImageSize -> Large]
-    ],
-    DescribeOutput[
-        "Simplified Jamarat augmented solution",
-        "Augmented graph with solved flow, transition, and u values.",
-        richNetworkPlot[jamaratEnd, jamaratEndSystem, jamaratEndSol,
-            PlotLabel -> "Simplified Jamarat solution",
-            UseColorFunction->True,
-            ImageSize -> Large]
-    ]
-}]
-
-
-jamaratEndSol
-
-
-(* ::Subsubsection::Closed:: *)
-(*Simplified Jamarat end*)
-
-
-(* ::Text:: *)
-(*This is a shorter version of the Jamarat example for when the flows are at the last pillar. *)
-
-
-jamaratEnd=cycleScenario[5, {{1,100},{2,100}},{{3,0},{4,10},{5,0}}];
-
-
+jamaratEnd = cycleScenario[5, {{1, 100}, {5, 100}}, {{3, 0}, {4, 40}, {2, 30}}];
 jamaratEndSystem = makeSystem[jamaratEnd];
 
-
-AbsoluteTiming[jamaratEndSol=solveScenario[jamaratEnd];]
-
-
-Column[{
-    DescribeOutput[
-        "Simplified Jamarat augmented infrastructure",
-        "Augmented graph before solving \[LongDash] structure only.",
-        richNetworkPlot[jamaratEnd, jamaratEndSystem, <||>,
-            PlotLabel -> "Simplified Jamarat infrastructure",
-            ImageSize -> Large,
-            ShowBoundaryValues -> False]
-    ],
-    DescribeOutput[
-        "Simplified Jamarat augmented solution",
-        "Augmented graph with solved flow, transition, and u values.",
-        richNetworkPlot[jamaratEnd, jamaratEndSystem, jamaratEndSol,
-            PlotLabel -> "Simplified Jamarat solution",
-            ImageSize -> Large]
-    ]
-}]
-
-
-(* ::Subsection:: *)
-(*Jamarat 9 vertices*)
-
-
-(* --- 1. Captured Jamaratv9 run from the named scenario registry --- *)
-
-jamaratScenario = getExampleScenario[
-    "Jamaratv9",
-    {{1, 40}, {2, 45}},
-    {{7, 3}, {8, 4}, {9, 2}}
-];
-
-jamaratSystem = makeSystem[jamaratScenario];
-jamaratAugmented = augmentAuxiliaryGraph[jamaratSystem];
-
-Column[{
-    DescribeOutput[
-        "Jamaratv9 scenario",
-        "Named registry example with two entrances and three exits.",
-        <|
-            "scenarioQ" -> scenarioQ[jamaratScenario],
-            "Entries" -> scenarioData[jamaratScenario, "Model"]["Entries"],
-            "Exits" -> scenarioData[jamaratScenario, "Model"]["Exits"],
-            "Network edges" -> systemData[jamaratSystem, "Edges"]
-        |>
-    ],
-    DescribeOutput[
-        "Jamaratv9 augmented road-traffic graph",
-        "Augmented graph showing flow and transition edges before solving.",
-        richNetworkPlot[jamaratScenario, jamaratSystem, <||>,
-            PlotLabel -> "Jamaratv9 augmented infrastructure",
-            ImageSize -> Large,
-            ShowBoundaryValues -> False]
-    ],
-    DescribeOutput[
-        "Jamaratv9 augmented graph metadata",
-        "augmentAuxiliaryGraph exposes the graph structure used by the plot.",
-        <|
-            "Vertex count" -> Length[jamaratAugmented["Vertices"]],
-            "Flow edge count" -> Length[jamaratAugmented["FlowEdges"]],
-            "Transition edge count" -> Length[jamaratAugmented["TransitionEdges"]],
-            "First flow edges" -> Take[jamaratAugmented["FlowEdges"], UpTo[8]],
-            "First transition edges" -> Take[jamaratAugmented["TransitionEdges"], UpTo[8]]
-        |>
-    ],
-    DescribeOutput[
-        "Jamaratv9 augmented road-traffic graph",
-        "Augmented graph showing flow and transition edges before solving.",
-        rawNetworkPlot[jamaratScenario, jamaratSystem, <||>,
-            PlotLabel -> "Jamaratv9 augmented infrastructure",
-            ImageSize -> Large,
-            ShowBoundaryData -> True]
-    ]
-}]
-
-
-jamaratScenarioSummary = JamaratScenarioSummary[jamaratScenario, jamaratSystem];
-
 DescribeOutput[
-    "Jamaratv9 scalar totals",
-    "The captured run uses entry-flow total 60 and exit-cost total 55.",
-    jamaratScenarioSummary
+    "Simplified Jamarat scenario summary",
+    "Two entries, three exits on a 5-cycle. Entry-flow total 200; exit-cost total 70.",
+    JamaratScenarioSummary[jamaratEnd, jamaratEndSystem]
 ]
 
 
-(* Optional rerun of the captured scenario. This may be slow; evaluate explicitly. *)
-AbsoluteTiming[jamaratSol=solveScenario[jamaratScenario]]
-
-
-If[Head[jamaratSol] =!= Association, jamaratSol = <|"Rules" -> jamaratSol, "Residual" -> True|>];
-
-
 DescribeOutput[
-    "Jamaratv9 augmented infrastructure",
-    "Augmented graph showing flow and transition edges before solving.",
-    richNetworkPlot[
-        jamaratScenario,
-        jamaratSystem,
-        <||>,
-        PlotLabel -> "Jamarat augmented infrastructure",
-        ImageSize -> Large,
-        ShowBoundaryValues -> False
-    ]
-]
-DescribeOutput[
-        "Jamaratv9 augmented infrastructure with flow and value function",
-        "Augmented graph showing flow and transition edges before solving.",
-        richNetworkPlot[
-            jamaratScenario,
-            jamaratSystem,
-            jamaratSol,
-            PlotLabel -> "Jamarat: equilibrium",
-            ImageSize -> Large
-        ]
-    ]
-    DescribeOutput[
-        "Jamaratv9 augmented infrastructure with flow and value function",
-        "Augmented graph showing flow and transition edges before solving.",
-        richNetworkPlot[
-            jamaratScenario,
-            jamaratSystem,
-            jamaratSol,
-            PlotLabel -> "Jamarat equilibrium: value colors",
-            ImageSize -> Large,
-             UseColorFunction->True
-        ]
-    ]
-
-
-DescribeOutput[
-    "Jamaratv9 infrastructure",
-    "Graph showing flow and transition edges before solving.",
-    rawNetworkPlot[
-        jamaratScenario,
-        jamaratSystem,
-        jamaratSol,
-        PlotLabel -> "Jamaratv9 infrastructure",
-        ImageSize -> Large
-    ]
+    "Simplified Jamarat physical topology (rawNetworkPlot)",
+    "ShowBoundaryData -> True overlays entry-flow and exit-cost annotations on the auxiliary nodes.",
+    rawNetworkPlot[jamaratEnd, jamaratEndSystem,
+        PlotLabel -> "Simplified Jamarat \[LongDash] physical topology",
+        ShowBoundaryData -> True,
+        ImageSize -> Large]
 ]
 
 
-(* --- 2. Jamaratv9 higher-entry-flow run --- *)
-
-jamaratHighEntryScenario = getExampleScenario[
-    "Jamaratv9",
-    {{1, 20}, {2, 50}},
-    {{7, 0}, {8, 0}, {9, 55}}
-];
-
-jamaratHighEntrySystem = makeSystem[jamaratHighEntryScenario];
-jamaratHighEntryAugmented = augmentAuxiliaryGraph[jamaratHighEntrySystem];
-jamaratHighEntryScenarioSummary = JamaratScenarioSummary[
-    jamaratHighEntryScenario,
-    jamaratHighEntrySystem
-];
-
-Column[{
-    DescribeOutput[
-        "Jamaratv9 higher-entry-flow scenario",
-        "This second run has entry-flow total 70, which is larger than exit-cost total 55.",
-        jamaratHighEntryScenarioSummary
-    ],
-    DescribeOutput[
-        "Jamaratv9 higher-entry-flow augmented graph",
-        "Augmented graph \[LongDash] same shape as before, only boundary data changes.",
-        richNetworkPlot[
-            jamaratHighEntryScenario,
-            jamaratHighEntrySystem,
-            <||>,
-            PlotLabel -> "Jamaratv9 augmented infrastructure, entries {20,50}",
-            ImageSize -> Large,
-            ShowBoundaryValues -> False
-        ]
-    ]
-}]
+DescribeOutput[
+    "Simplified Jamarat augmented state-space graph (richNetworkPlot, structure only)",
+    "Augmented graph before solving. Anti-parallel arcs separate so both directions are visible.",
+    richNetworkPlot[jamaratEnd, jamaratEndSystem,
+        PlotLabel -> "Simplified Jamarat \[LongDash] augmented (structure)",
+        ShowBoundaryValues -> False,
+        ImageSize -> Large]
+]
 
 
-(* Optional expensive solve for the higher-entry-flow scenario. Evaluate this cell explicitly. *)
-jamaratHighEntryRun[timeout_:Infinity] :=
-    AbsoluteTiming[
-        If[timeout === Infinity,
-            solveScenario[jamaratHighEntryScenario],
-            TimeConstrained[solveScenario[jamaratHighEntryScenario], timeout, $TimedOut]
-        ]
-    ];
-
-(* Example: *)
-jamaratHighEntryTimedSol = jamaratHighEntryRun[3600];
-jamaratHighEntrySol = Last[jamaratHighEntryTimedSol];
-jamaratHighEntryBranchRanking = If[
-    AssociationQ[jamaratHighEntrySol],
-    RankSolutionBranches[jamaratHighEntryScenario, jamaratHighEntrySystem, jamaratHighEntrySol, Infinity, 60, 10],
-    Missing["NoSolution", jamaratHighEntrySol]
-];
-
-
-
-jamaratHighEntryTimedSol
-
-
-jamaratHighEntrySystem
-
-
-jamaratHighEntryScenario
+AbsoluteTiming[jamaratEndSol = solveScenario[jamaratEnd];]
 
 
 DescribeOutput[
-        "Jamarat (High) augmented solution",
-        "Augmented graph with solved flow, transition, and u values.",
-        richNetworkPlot[jamaratHighEntryScenario, jamaratHighEntrySystem, jamaratHighEntrySol,
-            PlotLabel -> "Jamarat solution",
-            ImageSize -> Large]
-    ]
+    "Simplified Jamarat augmented solution (default colouring)",
+    "Augmented graph with solved flow, transition, and u values; flow-coloured edges.",
+    richNetworkPlot[jamaratEnd, jamaratEndSystem, jamaratEndSol,
+        PlotLabel -> "Simplified Jamarat \[LongDash] solved (flow colours)",
+        ImageSize -> Large]
+]
 
 
-(* --- 1. Captured Jamaratv9 run from the named scenario registry --- *)
+DescribeOutput[
+    "Simplified Jamarat augmented solution (value-coloured)",
+    "Same solution rendered with UseColorFunction -> True: nodes coloured by their value-function value on a Blue\[Rule]Red gradient.",
+    richNetworkPlot[jamaratEnd, jamaratEndSystem, jamaratEndSol,
+        PlotLabel -> "Simplified Jamarat \[LongDash] solved (value colours)",
+        UseColorFunction -> True,
+        ImageSize -> Large]
+]
+
+
+(* ::Section:: *)
+(*Section 2 \[LongDash] Jamaratv9 from the named registry*)
+
+
+(* ::Text:: *)
+(*The canonical Jamaratv9 topology: 9 vertices, two upstream entrances (vertices 1 and 2), three downstream exits (vertices 7, 8, 9). Capability: getExampleScenario from the named registry, end-to-end solve, two-mode solution visualisation.*)
+
 
 jamaratScenario = getExampleScenario[
     "Jamaratv9",
     {{1, 100}, {2, 100}},
     {{7, 0}, {8, 0}, {9, 0}}
 ];
-
 jamaratSystem = makeSystem[jamaratScenario];
-jamaratAugmented = augmentAuxiliaryGraph[jamaratSystem];
 
-Column[{
+DescribeOutput[
+    "Jamaratv9 scenario summary",
+    "Equal-cost exits and equal entries: a balanced baseline. The solver should split flows symmetrically.",
+    JamaratScenarioSummary[jamaratScenario, jamaratSystem]
+]
+
+
+DescribeOutput[
+    "Jamaratv9 physical topology (rawNetworkPlot)",
+    "Real network with auxiliary entry/exit nodes shown. Entries (blue) at 1 and 2; exits (orange) at 7, 8, 9.",
+    rawNetworkPlot[jamaratScenario, jamaratSystem,
+        PlotLabel -> "Jamaratv9 \[LongDash] physical topology",
+        ShowAuxiliaryVertices -> True,
+        ImageSize -> Large]
+]
+
+
+DescribeOutput[
+    "Jamaratv9 augmented state-space graph (structure only)",
+    "Augmented graph before solving; node colours indicate boundary status only.",
+    richNetworkPlot[jamaratScenario, jamaratSystem,
+        PlotLabel -> "Jamaratv9 \[LongDash] augmented (structure)",
+        ShowBoundaryValues -> False,
+        ImageSize -> Large]
+]
+
+
+AbsoluteTiming[jamaratSol = solveScenario[jamaratScenario];]
+If[Head[jamaratSol] =!= Association,
+    jamaratSol = <|"Rules" -> jamaratSol, "Residual" -> True|>];
+
+
+DescribeOutput[
+    "Jamaratv9 solution (default colouring)",
+    "Edges show solved j-values; node colours indicate boundary category.",
+    richNetworkPlot[jamaratScenario, jamaratSystem, jamaratSol,
+        PlotLabel -> "Jamaratv9 \[LongDash] solved (flow colours)",
+        ImageSize -> Large]
+]
+
+
+DescribeOutput[
+    "Jamaratv9 solution (value-coloured)",
+    "UseColorFunction -> True: node colours show the equilibrium value function on a Blue\[Rule]Red gradient. Vertices closer to the cheapest exits are on the cool end.",
+    richNetworkPlot[jamaratScenario, jamaratSystem, jamaratSol,
+        PlotLabel -> "Jamaratv9 \[LongDash] solved (value colours)",
+        UseColorFunction -> True,
+        ImageSize -> Large]
+]
+
+
+(* ::Section:: *)
+(*Section 3 \[LongDash] High-entry-flow variant (optional, expensive)*)
+
+
+(* ::Text:: *)
+(*Same Jamaratv9 topology, but exit costs are unbalanced \[LongDash] vertex 9 has cost 55 while 7 and 8 are free. Entries are smaller (20 + 50). The interesting feature is that the cheapest exit is downstream of a longer route, while the costly exit is closer; congestion vs path length forces a non-trivial split. The solve is wrapped in TimeConstrained because the search space grows with the asymmetry.*)
+
+
+jamaratHighEntryScenario = getExampleScenario[
+    "Jamaratv9",
+    {{1, 20}, {2, 50}},
+    {{7, 0}, {8, 0}, {9, 55}}
+];
+jamaratHighEntrySystem = makeSystem[jamaratHighEntryScenario];
+
+DescribeOutput[
+    "High-entry-flow Jamaratv9 scenario summary",
+    "Asymmetric entries (20 + 50) and asymmetric exit costs (free, free, 55).",
+    JamaratScenarioSummary[jamaratHighEntryScenario, jamaratHighEntrySystem]
+]
+
+
+(* Generous timeout. Abort manually if needed. *)
+AbsoluteTiming[
+    jamaratHighEntrySol =
+        TimeConstrained[solveScenario[jamaratHighEntryScenario], 600, $TimedOut];
+]
+
+
+If[AssociationQ[jamaratHighEntrySol] || ListQ[jamaratHighEntrySol],
     DescribeOutput[
-        "Jamaratv9 scenario",
-        "Named registry example with two entrances and three exits.",
-        <|
-            "scenarioQ" -> scenarioQ[jamaratScenario],
-            "Entries" -> scenarioData[jamaratScenario, "Model"]["Entries"],
-            "Exits" -> scenarioData[jamaratScenario, "Model"]["Exits"],
-            "Network edges" -> systemData[jamaratSystem, "Edges"]
-        |>
-    ],
-    DescribeOutput[
-        "Jamaratv9 augmented road-traffic graph",
-        "Augmented graph showing flow and transition edges before solving.",
-        richNetworkPlot[jamaratScenario, jamaratSystem, <||>,
-            PlotLabel -> "Jamaratv9 augmented infrastructure",
+        "High-entry-flow Jamaratv9 solution (value-coloured)",
+        "Solved augmented graph with value-coloured nodes. Compare to Section 2: the value-function gradient now reflects the asymmetric exit costs.",
+        richNetworkPlot[jamaratHighEntryScenario, jamaratHighEntrySystem, jamaratHighEntrySol,
+            PlotLabel -> "Jamaratv9 high-entry \[LongDash] solved (value colours)",
+            UseColorFunction -> True,
             ImageSize -> Large]
     ],
-    DescribeOutput[
-        "Jamaratv9 augmented graph metadata",
-        "augmentAuxiliaryGraph exposes the graph structure used by the plot.",
-        <|
-            "Vertex count" -> Length[jamaratAugmented["Vertices"]],
-            "Flow edge count" -> Length[jamaratAugmented["FlowEdges"]],
-            "Transition edge count" -> Length[jamaratAugmented["TransitionEdges"]],
-            "First flow edges" -> Take[jamaratAugmented["FlowEdges"], UpTo[8]],
-            "First transition edges" -> Take[jamaratAugmented["TransitionEdges"], UpTo[8]]
-        |>
-    ]
-}]
+    Print["High-entry Jamaratv9 solve did not return a solution (",
+        jamaratHighEntrySol, "); skipping solved plot."]
+]
+
+
+(* ::Subsection:: *)
+(*Summary \[LongDash] capabilities demonstrated*)
+
+
+(* ::Text:: *)
+(*Direct constructors. cycleScenario built the simplified 5-cycle case; getExampleScenario pulled the named "Jamaratv9" topology from the registry. Both expose the same downstream pipeline.*)
+
+
+(* ::Text:: *)
+(*Multi-entrance / multi-exit handling. makeSystem builds entry/exit balance equations transparently when entries and exits are lists of pairs; no Jamarat-specific code path.*)
+
+
+(* ::Text:: *)
+(*Two-mode solution visualisation. richNetworkPlot defaults to flow-coloured edges; UseColorFunction -> True switches to value-function-coloured nodes on a Blue\[Rule]Red gradient. The two views answer different questions about the same solution.*)
+
+
+(* ::Text:: *)
+(*Pointers: package-side API in CLAUDE.md and the auto-generated API_REFERENCE.md. The named registry behind getExampleScenario is documented at MFGraphs/examples.wl; use listExampleScenarios[] to discover all keys.*)

--- a/MFGraphs/Jamarat.wl
+++ b/MFGraphs/Jamarat.wl
@@ -1,6 +1,6 @@
 (* ::Package:: *)
 
-Quit[]
+(*Quit[]*)
 
 
 (* ::Title:: *)
@@ -212,7 +212,7 @@ DescribeOutput[
 
 
 (* ::Section:: *)
-(*Section 3 \[LongDash] High-entry-flow variant (optional, expensive)*)
+(*Section 3 \[LongDash] High cost exit avoided variant (optional, 36 seconds)*)
 
 
 (* ::Text:: *)
@@ -267,7 +267,7 @@ If[AssociationQ[jamaratHighEntrySol] || ListQ[jamaratHighEntrySol],
 
 
 (* ::Text:: *)
-(*Two-mode solution visualisation. richNetworkPlot defaults to flow-coloured edges; UseColorFunction -> True switches to value-function-coloured nodes on a Blue\[Rule]Red gradient. The two views answer different questions about the same solution.*)
+(*Two-mode solution visualisation. richNetworkPlot defaults to flow-coloured edges; UseColorFunction -> True switches to value-function-coloured nodes on a Blue->Red gradient. The two views answer different questions about the same solution.*)
 
 
 (* ::Text:: *)

--- a/MFGraphs/TawafWorkbook.wl
+++ b/MFGraphs/TawafWorkbook.wl
@@ -417,7 +417,7 @@ DescribeOutput[
 
 DescribeOutput[
     "2\[Times]3\[Times]1 augmented infrastructure with solved flows (richNetworkPlot)",
-    "Blue arcs are flow variables j[a,b]; red arcs are transition flows j[r,i,w]. Node colours show u-values on a Red\[Rule]Blue gradient.",
+    "Blue arcs are flow variables j[a,b]; red arcs are transition flows j[r,i,w]. Node colours show u-values on a Blue\[Rule]Red gradient.",
     richNetworkPlot[tawaf2x3, tawaf2x3System, tawaf2x3Sol,
         PlotLabel -> "Tawaf 2\[Times]3\[Times]1 \[LongDash] solved",
         ImageSize -> Large]

--- a/MFGraphs/Tests/scenario-kernel.mt
+++ b/MFGraphs/Tests/scenario-kernel.mt
@@ -847,3 +847,28 @@ Test[
     ,
     TestID -> "Example metadata: Achdou 2023 source and finite analog note"
 ]
+
+(* Test: listExampleScenarios returns the full registry as a non-empty sorted list *)
+Test[
+    Module[{keys},
+        keys = listExampleScenarios[];
+        ListQ[keys] && Length[keys] > 20 &&
+            MemberQ[keys, "Jamaratv9"] && MemberQ[keys, "Grid0303"] && MemberQ[keys, 3]
+    ]
+    ,
+    True
+    ,
+    TestID -> "Example registry: listExampleScenarios discoverability"
+]
+
+(* Test: every registered scenario has metadata (no $Failed leaks) *)
+Test[
+    AllTrue[
+        listExampleScenarios[],
+        AssociationQ[getExampleScenarioMetadata[#]] &
+    ]
+    ,
+    True
+    ,
+    TestID -> "Example metadata: every registered key resolves to an Association"
+]

--- a/MFGraphs/examples.wl
+++ b/MFGraphs/examples.wl
@@ -56,11 +56,19 @@ getExampleScenario[n, entries, exits, sc, alpha] also overrides alpha. \
 getExampleScenario[n, entries, exits, sc, alpha, V] also overrides V. \
 getExampleScenario[n, entries, exits, sc, alpha, V, g] overrides all parameters. \
 entries={{vertex,flow},...}; exits={{vertex,cost},...}; sc={{i,k,j,cost},...} or Association with 3-tuple keys. \
-Returns $Failed for unknown keys.";
+Returns $Failed for unknown keys. \
+Numeric keys (3, 11-18, 20-23, 27, 104, 105) are retained for backward compatibility with \
+older scripts; new code should prefer named keys (\"Jamaratv9\", \"Grid0303\", \"Camilli 2015 simple\", etc.). \
+Use listExampleScenarios[] to discover all registered keys.";
 
 getExampleScenarioMetadata::usage =
 "getExampleScenarioMetadata[key] returns metadata for a built-in example scenario, \
 including source/provenance details when available. Returns $Failed for unknown keys.";
+
+listExampleScenarios::usage =
+"listExampleScenarios[] returns the sorted list of all keys recognised by getExampleScenario \
+(both numeric legacy keys and named keys). Use this for discovery and for iterating over \
+the registry in tests.";
 
 Begin["`Private`"];
 
@@ -325,6 +333,146 @@ $ExampleScenarioMetadata = <|
             "Switching costs default to zero, matching the paper graph as connections rather than directed movement restrictions."
         }
     |>,
+    3 -> <|
+        "Title" -> "Linear chain, 3 vertices",
+        "Description" -> "Three-vertex chain 1-2-3 built via gridScenario[{3}, ...]. The smallest non-trivial scenario; useful as a smoke test."
+    |>,
+    11 -> <|
+        "Title" -> "Attraction 4-vertex diamond (case 11)",
+        "Description" -> "Diamond topology 1-{2,3}-4 with shared interior vertices and the canonical attraction switching costs."
+    |>,
+    12 -> <|
+        "Title" -> "Attraction 4-vertex diamond (case 12)",
+        "Description" -> "Same diamond topology as case 11; reserved for variant boundary data."
+    |>,
+    13 -> <|
+        "Title" -> "Attraction 4-vertex diamond, case 13 variant",
+        "Description" -> "1->{2,3}->4 with reduced edges; lighter switching cost set than case 11."
+    |>,
+    14 -> <|
+        "Title" -> "Triangle 3-cycle 1->2->3->1 (case 14)",
+        "Description" -> "Three-vertex directed cycle with the canonical Y-shortcut switching costs."
+    |>,
+    15 -> <|
+        "Title" -> "3-vertex misc (case 15)",
+        "Description" -> "Two-edge in-tree 2->1, 3->1 used to probe the EqEntryIn/EqExit boundary blocks."
+    |>,
+    16 -> <|
+        "Title" -> "3-vertex chain (case 16)",
+        "Description" -> "1->2->3 chain probing single-shortcut switching at vertex 2."
+    |>,
+    17 -> <|
+        "Title" -> "3-vertex chain (case 17)",
+        "Description" -> "Same topology as case 16 with a different SC default."
+    |>,
+    18 -> <|
+        "Title" -> "3-vertex chain (case 18)",
+        "Description" -> "Same topology as cases 16/17, alternative SC profile."
+    |>,
+    20 -> <|
+        "Title" -> "9-vertex multi-entrance/multi-exit (case 20)",
+        "Description" -> "Two-entrance, three-exit topology used as an early Jamarat-like benchmark."
+    |>,
+    21 -> <|
+        "Title" -> "12-vertex multi-entrance/multi-exit (case 21)",
+        "Description" -> "Larger benchmark variant of the multi-entrance/multi-exit family."
+    |>,
+    22 -> <|
+        "Title" -> "7-vertex two-entrance/two-exit (case 22)",
+        "Description" -> "Compact multi-entrance benchmark."
+    |>,
+    23 -> <|
+        "Title" -> "6-vertex two-entrance/two-exit (case 23)",
+        "Description" -> "Smallest multi-entrance benchmark in the registry."
+    |>,
+    27 -> <|
+        "Title" -> "2-vertex undirected edge (case 27)",
+        "Description" -> "Trivial scenario: a single undirected edge. Useful for unit-test scaffolding."
+    |>,
+    104 -> <|
+        "Title" -> "Triangle 3-cycle alias (case 104)",
+        "Description" -> "Alias for the triangle 1->2->3->1 scenario; same factory as case 14."
+    |>,
+    105 -> <|
+        "Title" -> "3-vertex chain with two exits (case 105)",
+        "Description" -> "Alias for the named scenario \"chain with two exits\"."
+    |>,
+    "triangle with two exits" -> <|
+        "Title" -> "Triangle with two exits",
+        "Description" -> "Three-vertex directed cycle exposed under a descriptive name; same factory as case 14."
+    |>,
+    "chain with two exits" -> <|
+        "Title" -> "3-vertex chain with two exits",
+        "Description" -> "Three-vertex chain 1->2->3 with exits at vertices 2 and 3. Common parametric-solution test case."
+    |>,
+    "Jamaratv9" -> <|
+        "Title" -> "Jamarat v9: 9-vertex two-entrance / three-exit",
+        "Description" -> "Multi-entrance, multi-exit infrastructure scenario used in the Jamarat workbook (MFGraphs/Jamarat.wl). Two entries (vertices 1 and 2) feed three downstream exits (vertices 7, 8, 9)."
+    |>,
+    "Braess split" -> <|
+        "Title" -> "Braess paradox: split variant",
+        "Description" -> "8-vertex Braess-style graph with parallel routes; switching cost {1,2,4,1} biases the split."
+    |>,
+    "Braess congest" -> <|
+        "Title" -> "Braess paradox: congested variant",
+        "Description" -> "7-vertex Braess-style graph that exhibits the congestion paradox under the canonical switching cost."
+    |>,
+    "New Braess" -> <|
+        "Title" -> "Braess with custom congestion field",
+        "Description" -> "6-vertex Braess variant carrying an extra \"a\" congestion field on edges 1->4 and 3->6 (j/100). Demonstrates per-edge Hamiltonian extensions outside the standard Alpha/V/G triple."
+    |>,
+    "Big Braess split" -> <|
+        "Title" -> "Larger Braess: split variant",
+        "Description" -> "10-vertex extension of the Braess split topology."
+    |>,
+    "Big Braess congest" -> <|
+        "Title" -> "Larger Braess: congested variant",
+        "Description" -> "9-vertex extension of the Braess congested topology."
+    |>,
+    "HRF Scenario 1" -> <|
+        "Title" -> "HRF Scenario 1",
+        "Description" -> "10-vertex multi-route benchmark from the HRF case study."
+    |>,
+    "Paper example" -> <|
+        "Title" -> "Paper example: 4-vertex chain",
+        "Description" -> "Four-vertex chain used as a worked example in early write-ups; shipped with a non-trivial SC profile."
+    |>,
+    "Inconsistent Y shortcut" -> <|
+        "Title" -> "Y-topology with infeasible switching costs",
+        "Description" -> "4-vertex Y graph whose canonical SC violates the triangle inequality. Used to validate infeasibility detection."
+    |>,
+    "Inconsistent attraction shortcut" -> <|
+        "Title" -> "Attraction diamond with infeasible switching costs",
+        "Description" -> "Attraction-4 topology whose canonical SC violates the triangle inequality. Used to validate infeasibility detection."
+    |>,
+    "Grid0303" -> <|
+        "Title" -> "3x3 grid",
+        "Description" -> "GridGraph[{3,3}] connections; vertices 1..9 in row-major order."
+    |>,
+    "Grid0404" -> <|
+        "Title" -> "4x4 grid",
+        "Description" -> "GridGraph[{4,4}] connections; vertices 1..16 in row-major order."
+    |>,
+    "Grid0505" -> <|
+        "Title" -> "5x5 grid",
+        "Description" -> "GridGraph[{5,5}] connections; vertices 1..25 in row-major order."
+    |>,
+    "Grid0707" -> <|
+        "Title" -> "7x7 grid",
+        "Description" -> "GridGraph[{7,7}] connections; vertices 1..49 in row-major order."
+    |>,
+    "Grid0710" -> <|
+        "Title" -> "7x10 grid",
+        "Description" -> "GridGraph[{7,10}] connections; vertices 1..70 in row-major order."
+    |>,
+    "Grid1010" -> <|
+        "Title" -> "10x10 grid",
+        "Description" -> "GridGraph[{10,10}] connections; vertices 1..100 in row-major order."
+    |>,
+    "Grid1020" -> <|
+        "Title" -> "10x20 grid",
+        "Description" -> "GridGraph[{10,20}] connections; vertices 1..200 in row-major order. Largest grid in the registry."
+    |>,
     "Achdou 2023 junction" -> <|
         "Title" -> "First order Mean Field Games on networks",
         "Authors" -> {"Yves Achdou", "Paola Mannucci", "Claudio Marchi", "Nicoletta Tchou"},
@@ -529,6 +677,8 @@ $ExampleScenarios = Association[
 getExampleScenario[n_] := Lookup[$ExampleScenarios, n, $Failed];
 
 getExampleScenarioMetadata[n_] := Lookup[$ExampleScenarioMetadata, n, $Failed];
+
+listExampleScenarios[] := SortBy[Keys[$ExampleScenarios], {Head[#] === String, #} &];
 
 (* sc=Automatic resolves to the canonical SC via $CaseDefaultSC, or {} if undefined. *)
 getExampleScenario[n_, entries_, exits_,

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **MFGraphs** is a Wolfram Language package for Mean Field Games on networks.
 
+**New to the package?** See [TOUR.md](TOUR.md) for a guided reading order.
+
 The repository is currently in a **core scenario-kernel phase**. The active package surface is centered on:
 - typed scenario construction
 - example scenario factories

--- a/TOUR.md
+++ b/TOUR.md
@@ -1,0 +1,41 @@
+# MFGraphs Tour
+
+A guided reading order for newcomers. Skim the markdown first, then open the workbooks in Mathematica and evaluate cell-by-cell.
+
+## What MFGraphs is
+
+A Wolfram Language paclet for solving stationary **Mean Field Games on networks** in the critical-congestion regime (`α = 1`). A large population of rational agents moves through a graph; mass conservation (Kirchhoff laws) plus complementarity yields a Linear Complementarity Problem that the package builds and reduces symbolically. See `README.md` for the math.
+
+## Read first (~30 min, in this order)
+
+1. **`README.md`** — model overview, Hamiltonian, mass-conservation / complementarity setup.
+2. **`CLAUDE.md`** — the most useful map of the repo: load order, the `makeScenario → makeSymbolicUnknowns → makeSystem → solveScenario` pipeline, the typed-wrapper pattern, naming conventions. Reads like an architecture guide.
+3. **`API_REFERENCE.md`** — auto-generated public surface. Skim the headings to know what exists; come back as a reference.
+4. **`CONTRIBUTING.md`** + **`TROUBLESHOOTING.md`** — skim only, return when you hit a snag.
+
+## Open in Mathematica, in this order
+
+5. **`MFGraphs/Getting started.wl`** — the intended on-ramp notebook. Open in the front end and evaluate cells top-to-bottom. Covers all 13 capabilities of the core scenario-kernel phase: scenario constructors, named factories, `scenarioData` inspection, per-edge Hamiltonian model, symbolic unknowns, `makeSystem`, chain examples, topology and solution visualisation, the augmented (state-space) graph, and the canonical Jamaratv9 example.
+6. **`MFGraphs/TawafWorkbook.wl`** — the most polished worked example. Sections 1.1 → 1.9 walk one ring through unrolling, physical-edge coupling (the package's central modelling idea for shared-pavement scenarios), helix view, and the opt-in density extension. Pair with `docs/research/notes/tawaf-model.md` for the modelling rationale.
+7. **`MFGraphs/Jamarat.wl`** — multi-entrance / multi-exit example built on the registered `Jamaratv9` scenario. Demonstrates the value-function gradient via `richNetworkPlot[..., UseColorFunction -> True]`.
+
+## Read source in load order (when you're ready to dig)
+
+The flat-context load order from `CLAUDE.md`:
+
+8. `MFGraphs/primitives.wl` → `MFGraphs/utilities.wl` (foundations)
+9. `MFGraphs/scenarioTools.wl` (`makeScenario`, validation, topology cache)
+10. `MFGraphs/unknownsTools.wl` (the `j`, `u`, `z` symbolic families)
+11. `MFGraphs/systemTools.wl` (boundary / flow / complementarity / Hamiltonian builders)
+12. `MFGraphs/solversTools.wl` (DNF + active-set reducers)
+13. `MFGraphs/orchestrationTools.wl` (`solveScenario` wrapper)
+14. `MFGraphs/graphicsTools.wl` (`rawNetworkPlot`, `richNetworkPlot`)
+15. `MFGraphs/Tawaf.wl` (the unroll-then-couple specialisation — read after the core)
+
+## Tests as documentation
+
+16. `MFGraphs/Tests/scenario-kernel.mt` and `MFGraphs/Tests/scenario-consistency.mt` are the cleanest worked specs of what each stage guarantees — short, readable, authoritative when the prose drifts.
+
+## The one-liner
+
+Open **`MFGraphs/Getting started.wl`** in Mathematica with **`README.md`** and **`CLAUDE.md`** open in another window. Everything else is reference.


### PR DESCRIPTION
## Summary

- New `TOUR.md` at repo root (linked from `README.md`) prescribing the intended reading order for newcomers: docs first, then the four workbooks in a specific order, then source in load order, then tests as documentation.
- `MFGraphs/Getting started.wl`: replaced a destructive `Remove["Global`*"]` reload block with a commented `Quit[]`; promoted 13 ASCII section headers to real `::Section::` cells so the Mathematica Outline view populates; added a top-level Title/Overview cell mirroring `TawafWorkbook.wl`; fixed one stale Red→Blue narrative post the recent default-color flip.
- `MFGraphs/examples.wl`: added public `listExampleScenarios[]`; documented the numeric registry keys (3, 11–18, 20–23, 27, 104, 105) as legacy in the `getExampleScenario` usage string; backfilled `$ExampleScenarioMetadata` with minimal entries for ~25 keys that previously returned `$Failed`.
- `MFGraphs/TawafWorkbook.wl`: fixed one stale Red→Blue narrative.
- `MFGraphs/Jamarat.wl`: heavy rewrite to tour shape (553 → 277 lines). Dropped the workbook-self-reading solution-capture machinery and the DNF branch-ranking helpers (recoverable from git history); collapsed the three duplicated Jamaratv9 cells into one canonical balanced run plus an optional high-entry variant; consistent `DescribeOutput` wrapping; `::Section::` cells throughout; fixed the duplicated subsection title.
- `MFGraphs/Tests/scenario-kernel.mt`: two new tests covering `listExampleScenarios[]` discoverability and full metadata coverage of every registered key.

## Test plan

- [x] `wolframscript -file Scripts/RunTests.wls fast` — 245 / 245 pass (was 243; +2 for the metadata-coverage tests).
- [x] No remaining `Red→Blue` narrative strings in `MFGraphs/*.wl`.
- [x] `listExampleScenarios[]` returns all 30+ registered keys; `getExampleScenarioMetadata` returns an `Association` for every one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
