### PR TITLE
test(solvers): pin optimizedDNF parity with dnf + fix Grid0303 test args

### DIFF
--- a/MFGraphs/Tests/reduce-system.mt
+++ b/MFGraphs/Tests/reduce-system.mt
@@ -442,6 +442,53 @@ Test[
     TestID -> "solutionResultKind: example-12 dnf result is specific residual kind"
 ]
 
+(* Solver-parity regression: optimizedDNFReduceSystem used to diverge from
+   dnfReduceSystem on chain-3v-2exit and chain-3-midentry, reporting an extra
+   residual transition flow when $optimizedDNFVarThreshold routed these cases
+   through the branch-state path. The 2026-05-10 retune to threshold=0 plus
+   the branchStateFinalizeResult fix closed the gap; pin it so a future
+   threshold change cannot silently reintroduce the divergence. *)
+Test[
+    Module[{s, sys, dnfResult, optResult},
+        s = gridScenario[{3}, {{1, 120.0}}, {{2, 0.0}, {3, 10.0}}];
+        sys = makeSystem[s];
+        dnfResult = dnfReduceSystem[sys];
+        optResult = optimizedDNFReduceSystem[sys];
+        solversTools`Private`solutionResultKind[dnfResult] ===
+            solversTools`Private`solutionResultKind[optResult]
+    ],
+    True,
+    TestID -> "solver parity: optimizedDNFReduceSystem matches dnf kind on chain-3v-2exit"
+]
+
+Test[
+    Module[{s, sys, dnfResult, optResult},
+        s = gridScenario[{3}, {{2, 100.0}}, {{1, 0.0}, {3, 10.0}}];
+        sys = makeSystem[s];
+        dnfResult = dnfReduceSystem[sys];
+        optResult = optimizedDNFReduceSystem[sys];
+        solversTools`Private`solutionResultKind[dnfResult] ===
+            solversTools`Private`solutionResultKind[optResult]
+    ],
+    True,
+    TestID -> "solver parity: optimizedDNFReduceSystem matches dnf kind on chain-3-midentry"
+]
+
+Test[
+    Module[{s, sys, dnfResult, optResult, dnfDiag, optDiag},
+        s = gridScenario[{3}, {{1, 120.0}}, {{2, 0.0}, {3, 10.0}}];
+        sys = makeSystem[s];
+        dnfResult = dnfReduceSystem[sys];
+        optResult = optimizedDNFReduceSystem[sys];
+        dnfDiag = solversTools`Private`dnfResidualDiagnostics[dnfResult];
+        optDiag = solversTools`Private`dnfResidualDiagnostics[optResult];
+        Length[Lookup[dnfDiag, "TransitionFlowVariables", {}]] ===
+            Length[Lookup[optDiag, "TransitionFlowVariables", {}]]
+    ],
+    True,
+    TestID -> "solver parity: optimizedDNFReduceSystem matches dnf residual transition flows on chain-3v-2exit"
+]
+
 Test[
     Module[{s, sys, result},
         s = gridScenario[{3}, {{1, 120.0}}, {{2, 0.0}, {3, 10.0}}];

--- a/MFGraphs/Tests/scenario-consistency.mt
+++ b/MFGraphs/Tests/scenario-consistency.mt
@@ -251,7 +251,7 @@ Module[{sys, base},
 ];
 
 Module[{sys, base},
-    sys  = makeSystem[getExampleScenario["Grid0303", Automatic, Automatic]];
+    sys  = makeSystem[getExampleScenario["Grid0303", {{1, 100}}, {{9, 0}}]];
     base = sortedRules[activeSetReduceSystem[sys]];
     Test[
         sortedRules[activeSetReduceSystem[sys, "DisjunctOrdering" -> "Block-Vertex"]],


### PR DESCRIPTION
## Summary

- Add solver-parity regression tests pinning `optimizedDNFReduceSystem` to `dnfReduceSystem` on `chain-3v-2exit` and `chain-3-midentry` (matching `solutionResultKind` + residual transition-flow count). Historically these cases reported an extra residual transition flow when `\$optimizedDNFVarThreshold` routed them through the branch-state path; the 2026-05-10 retune to `threshold = 0` closed the gap. Pin it so a future threshold change cannot silently reintroduce the divergence.
- Fix DisjunctOrdering Grid0303 tests, which passed `Automatic` for entry/exit values. `getExampleScenario[\"Grid0303\", ...]` requires numeric boundary values, so those three tests have been failing since PR 3 (`4f9f739`). Use the canonical `{{1, 100}}, {{9, 0}}` from `SolutionCacheHelpers.wls`.

## Test plan

- [x] `wolframscript -file Scripts/RunTests.wls fast` → 318 passed, 0 failed (was 315/3 before fix)
- [x] `wolframscript -file Scripts/RunSingleTest.wls MFGraphs/Tests/reduce-system.mt` → 100/100
- [x] `wolframscript -file Scripts/RunSingleTest.wls MFGraphs/Tests/scenario-consistency.mt` → 31/31

🤖 Generated with [Claude Code](https://claude.com/claude-code)