### PR TITLE
Add utilities/cache unit tests and wire in orphaned oracle suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,11 +107,13 @@ Active `.mt` files under `MFGraphs/Tests/`:
 | `scenario-consistency.mt` | cross-stage invariants (scenario ↔ unknowns ↔ system) |
 | `dnf-reducer.mt` | DNF reducer correctness and edge cases |
 | `boolean-minimize.mt` | `booleanMinimizeSystem` / `booleanMinimizeReduceSystem` |
-| `orchestration.mt` | `solveScenario` and full pipeline |
+| `orchestration.mt` | `solveScenario` / `SolveMFG`, full pipeline, and `clearSolveCache` memoization |
+| `utilities.mt` | typed-object infra (`mfgTypedQ`/`mfgData`), rule management, boundary exactification, critical-congestion guard |
 | `graphicsTools.mt` | `rawNetworkPlot`, `richNetworkPlot` |
 | `tawaf.mt` | unrolled-circumambulation scenario builder (opt-in `Tawaf`` context) |
 | `example-coverage.mt` | per-example smoke + cached-solution regression check across every key in `$ExampleScenarios` |
 | `numeric-oracle.mt` | opt-in `numericOracle`` classifier and `solveScenarioWithOracle` wrapper |
+| `fictitiousPlay.mt` | opt-in K-fold consensus classifier `numericFictitiousPlayClassify` (in the `oracle`/`full` suites, not `fast`) |
 
 ## Conventions
 

--- a/MFGraphs/Tests/fictitiousPlay.mt
+++ b/MFGraphs/Tests/fictitiousPlay.mt
@@ -1,7 +1,7 @@
 (* Tests for the K-fold consensus oracle in numericOracle.wl.
    OPT-IN: invokes Needs["numericOracle`"] which loads the float-isolated
-   subpackage. Not run by RunTests fast; invoke explicitly via
-   RunSingleTest.wls or a future "oracle" tag. *)
+   subpackage. Not in the "fast" suite; run it via the "oracle" or "full"
+   tag (Scripts/RunTests.wls oracle) or directly via RunSingleTest.wls. *)
 
 Needs["numericOracle`"];
 

--- a/MFGraphs/Tests/orchestration.mt
+++ b/MFGraphs/Tests/orchestration.mt
@@ -88,3 +88,48 @@ Test[
     True,
     TestID -> "SolveMFG: legacy association input still works after scenario dispatch added"
 ]
+
+(* ------------------------------------------------------------------ *)
+(* solveScenario memoization cache: clearSolveCache / cache hits        *)
+(* ------------------------------------------------------------------ *)
+
+Test[
+    NameQ["orchestrationTools`clearSolveCache"],
+    True,
+    TestID -> "Orchestration: clearSolveCache exists"
+]
+
+Test[
+    clearSolveCache[] === Null && clearSolveCache[] === Null,
+    True,
+    TestID -> "clearSolveCache: returns Null and is idempotent"
+]
+
+Test[
+    Module[{s, r1, r2},
+        clearSolveCache[];
+        s  = gridScenario[{2}, {{1, 100}}, {{2, 0}}];
+        r1 = TimeConstrained[solveScenario[s], 5, $TimedOut];
+        (* Second call on the same (scenario, solver) must hit the cache and
+           return the very same stored expression. *)
+        r2 = TimeConstrained[solveScenario[s], 5, $TimedOut];
+        r1 =!= $TimedOut && r1 === r2
+    ],
+    True,
+    TestID -> "solveScenario: repeated call returns the cached result (SameQ)"
+]
+
+Test[
+    Module[{s, cold},
+        s = gridScenario[{2}, {{1, 100}}, {{2, 0}}];
+        (* Warm the cache, then wipe it and confirm the cold path still
+           recomputes a valid solution. *)
+        TimeConstrained[solveScenario[s], 5, $TimedOut];
+        clearSolveCache[];
+        cold = TimeConstrained[solveScenario[s], 5, $TimedOut];
+        (ListQ[cold] || AssociationQ[cold]) &&
+        isValidSystemSolution[makeSystem[s], cold]
+    ],
+    True,
+    TestID -> "clearSolveCache: cold re-solve after wipe still produces a valid solution"
+]

--- a/MFGraphs/Tests/utilities.mt
+++ b/MFGraphs/Tests/utilities.mt
@@ -1,0 +1,187 @@
+(* Unit tests for utilities.wl — typed-object infrastructure, rule management,
+   numeric exactification, and the critical-congestion solver guard.
+
+   These are pure functions feeding the whole solver, so they are tested
+   directly here rather than only indirectly through the pipeline. *)
+
+(* ------------------------------------------------------------------ *)
+(* Typed-object infrastructure: mfgTypedQ / mfgData                    *)
+(* ------------------------------------------------------------------ *)
+
+Test[
+    NameQ["utilities`mfgTypedQ"] && NameQ["utilities`mfgData"],
+    True,
+    TestID -> "utilities: mfgTypedQ / mfgData public symbols exist"
+]
+
+Test[
+    Module[{head},
+        mfgTypedQ[head[<|"a" -> 1|>], head] &&
+        !mfgTypedQ[head[1], head] &&
+        !mfgTypedQ[5, head]
+    ],
+    True,
+    TestID -> "mfgTypedQ: true only for head[Association]"
+]
+
+Test[
+    Module[{head},
+        mfgData[head[<|"a" -> 1, "b" -> 2|>]] === <|"a" -> 1, "b" -> 2|> &&
+        mfgData[head[<|"a" -> 1|>], "a"] === 1
+    ],
+    True,
+    TestID -> "mfgData: returns full association and per-key value"
+]
+
+Test[
+    Module[{head},
+        mfgData[head[<|"a" -> 1|>], "missing"] === Missing["KeyAbsent", "missing"]
+    ],
+    True,
+    TestID -> "mfgData: absent key returns Missing[KeyAbsent, key]"
+]
+
+(* ------------------------------------------------------------------ *)
+(* Rule management: mergeRules / normalizeRules / extractRules         *)
+(* ------------------------------------------------------------------ *)
+
+Test[
+    Module[{p, q, r},
+        mergeRules[{p -> 1, q -> 2}, {q -> 9, r -> 3}] === {p -> 1, q -> 9, r -> 3}
+    ],
+    True,
+    TestID -> "mergeRules: newRules wins per LHS, order preserved"
+]
+
+Test[
+    Module[{p, q},
+        (* a -> b chases b -> 3 to ground via ReplaceRepeated *)
+        normalizeRules[{p -> q, q -> 3}] === {p -> 3, q -> 3}
+    ],
+    True,
+    TestID -> "normalizeRules: rewrites RHS through the full rule set"
+]
+
+Test[
+    Module[{p, q},
+        extractRules[{p -> 1, 5, q -> 2, "noise"}] === {p -> 1, q -> 2}
+    ],
+    True,
+    TestID -> "extractRules: selects only rules from a mixed list"
+]
+
+Test[
+    Module[{p},
+        extractRules[<|"Rules" -> {p -> 1}|>] === {p -> 1} &&
+        extractRules[<|"NoRulesKey" -> 1|>] === {} &&
+        extractRules[42] === {}
+    ],
+    True,
+    TestID -> "extractRules: association and non-list inputs"
+]
+
+(* ------------------------------------------------------------------ *)
+(* Numerics: roundValues                                               *)
+(* ------------------------------------------------------------------ *)
+
+Test[
+    roundValues[2.0] == 2 &&
+    roundValues["passthrough"] === "passthrough",
+    True,
+    TestID -> "roundValues: rounds numbers, leaves non-numerics untouched"
+]
+
+Test[
+    Module[{x},
+        Head[roundValues[x -> 2.0]] === Rule &&
+        Head[roundValues[{1.0, 2.0}]] === List &&
+        Length[roundValues[{1.0, 2.0}]] === 2 &&
+        AssociationQ[roundValues[<|"a" -> 2.0|>]]
+    ],
+    True,
+    TestID -> "roundValues: recurses through rules, lists, and associations"
+]
+
+(* ------------------------------------------------------------------ *)
+(* Boundary exactification: exactBoundaryValue / exactBoundaryValues   *)
+(* ------------------------------------------------------------------ *)
+
+Test[
+    exactBoundaryValue[3] === 3 &&
+    exactBoundaryValue[1/2] === 1/2,
+    True,
+    TestID -> "exactBoundaryValue: exact numbers pass through unchanged"
+]
+
+Test[
+    exactBoundaryValue[0.5] === 1/2 &&
+    exactBoundaryValue[2.0] === 2,
+    True,
+    TestID -> "exactBoundaryValue: real machine numbers are rationalized exactly"
+]
+
+Test[
+    FailureQ[exactBoundaryValue[1.0 + 2.0 I]],
+    True,
+    TestID -> "exactBoundaryValue: inexact complex value is a Failure"
+]
+
+Test[
+    Module[{sym},
+        FailureQ[exactBoundaryValue[sym]]
+    ],
+    True,
+    TestID -> "exactBoundaryValue: non-numeric value is a Failure"
+]
+
+Test[
+    exactBoundaryValues[{1, 0.5, 2.0}] === {1, 1/2, 2},
+    True,
+    TestID -> "exactBoundaryValues: maps over a list of valid values"
+]
+
+Test[
+    Module[{sym},
+        FailureQ[exactBoundaryValues[{1, sym, 0.5}]]
+    ],
+    True,
+    TestID -> "exactBoundaryValues: returns the first Failure in the list"
+]
+
+(* ------------------------------------------------------------------ *)
+(* Critical-congestion guard: criticalCongestionSystemQ /              *)
+(* withCriticalCongestionGuard                                         *)
+(* ------------------------------------------------------------------ *)
+
+Test[
+    Module[{s, sys},
+        s   = gridScenario[{2}, {{1, 100}}, {{2, 0}}];
+        sys = makeSystem[s];
+        criticalCongestionSystemQ[sys]
+    ],
+    True,
+    TestID -> "criticalCongestionSystemQ: default (Alpha == 1) system is critical"
+]
+
+Test[
+    criticalCongestionSystemQ[mfgSystem[<||>]] === False,
+    True,
+    TestID -> "criticalCongestionSystemQ: system without HalfPairs is not critical"
+]
+
+Test[
+    Module[{s, sys},
+        s   = gridScenario[{2}, {{1, 100}}, {{2, 0}}];
+        sys = makeSystem[s];
+        (* HoldRest: the body is only evaluated on a critical system. *)
+        withCriticalCongestionGuard[sys, "probe", 42] === 42
+    ],
+    True,
+    TestID -> "withCriticalCongestionGuard: evaluates body on a critical system"
+]
+
+Test[
+    FailureQ[Quiet[withCriticalCongestionGuard[mfgSystem[<||>], "probe", 42]]],
+    True,
+    TestID -> "withCriticalCongestionGuard: returns a Failure on a non-critical system"
+]

--- a/Scripts/RunTests.wls
+++ b/Scripts/RunTests.wls
@@ -24,7 +24,15 @@ $TestSuites = <|
         "boolean-minimize.mt",
         "tawaf.mt",
         "example-coverage.mt",
-        "numeric-oracle.mt"
+        "numeric-oracle.mt",
+        "utilities.mt"
+    },
+    (* Opt-in oracle suite: the float-isolated numericOracle` classifiers.
+       numeric-oracle.mt also runs in fast; fictitiousPlay.mt (the K-fold
+       consensus classifier) runs here and in full until promoted to fast. *)
+    "oracle" -> {
+        "numeric-oracle.mt",
+        "fictitiousPlay.mt"
     },
     (* Archived tests are intentionally excluded from active CI.
        Use this suite only for explicit compatibility checks. *)
@@ -47,7 +55,8 @@ $TestSuites = <|
     }
 |>;
 $TestSuites["all"] = $TestSuites["fast"];
-$TestSuites["full"] = Join[$TestSuites["fast"], $TestSuites["archive"]];
+(* full = fast + the fictitiousPlay oracle extra + archived suites. *)
+$TestSuites["full"] = Join[$TestSuites["fast"], {"fictitiousPlay.mt"}, $TestSuites["archive"]];
 
 args = Select[
     Rest[$ScriptCommandLine],


### PR DESCRIPTION
Test-coverage improvements from the coverage analysis:

- utilities.mt: direct unit tests for utilities.wl — typed-object infra
  (mfgTypedQ/mfgData), rule management (mergeRules/normalizeRules/
  extractRules), boundary exactification (exactBoundaryValue[s] incl.
  Failure branches), roundValues recursion, and the critical-congestion
  guard (criticalCongestionSystemQ/withCriticalCongestionGuard). Added to
  the fast suite.

- orchestration.mt: cover solveScenario memoization — clearSolveCache
  returns Null/idempotent, repeated solves hit the cache (SameQ), and the
  cold re-solve after a wipe still yields a valid solution.

- RunTests.wls: fictitiousPlay.mt was orphaned (in no suite, never run).
  Add an opt-in "oracle" suite (numeric-oracle + fictitiousPlay) and include
  fictitiousPlay in "full"; promote to fast once confirmed green on a kernel.

- Sync CLAUDE.md test-suite table with the new/rewired files.

https://claude.ai/code/session_01XUE9JYJAAVbRNTWobt2Cgx