### PR TITLE
chore(docs): drop dead $* pass in GenerateDocs.wls, correct the comment

### DIFF
--- a/Scripts/GenerateDocs.wls
+++ b/Scripts/GenerateDocs.wls
@@ -21,11 +21,9 @@ $PublicContexts = {
   "graphicsTools`"
 };
 
-(* `Names[ctx<>"*"]` does NOT match `$`-prefix symbols by Wolfram convention,
-   so fold in a second pass with `ctx<>"$*"`. Both passes are then deduped. *)
-symbols = DeleteDuplicates @ Flatten[
-  {Names[# <> "*"], Names[# <> "$*"]} & /@ $PublicContexts
-];
+(* `Names[ctx<>"*"]` already matches `$`-prefixed symbols, so a single pass
+   suffices. ($-symbols are surfaced correctly by `readUsage` below, not here.) *)
+symbols = DeleteDuplicates @ Flatten[Names[# <> "*"] & /@ $PublicContexts];
 publicSymbols = Select[
   symbols,
   !StringContainsQ[#, "Private`"] && !StringEndsQ[#, "$"] &


### PR DESCRIPTION
## Summary

Small follow-up cleanup to the `GenerateDocs.wls` doc symbol-coverage fix (from #214). That fix added two things, but only one was load-bearing:

- **`readUsage` (kept)** — reads `name::usage` directly instead of `Information[Symbol[s],"Usage"]`, which evaluated assigned symbols (e.g. `$MFGraphsVerbose` → `False`) and produced "False is the symbol for…" junk that got filtered out. **This is the actual fix** for the previously-missing `$`-symbols. Unchanged here.
- **The `$*` second pass (removed)** — was dead code. `Names[ctx<>"*"]` *already* matches `$`-prefixed symbols. Verified: `Names["primitives`*"]` returns `$MFGraphsParallelReady/Threshold/Verbose`, and `Names["primitives`$*"]` adds **nothing** (`Complement` is empty). Its justifying comment ("`Names[ctx<>"*"]` does NOT match `$`-prefix symbols") was factually wrong and could mislead a future maintainer into thinking the pass is necessary.

## Verification

- **Output-neutral**: regenerated `API_REFERENCE.md` is **byte-identical** (sha unchanged) — the `$*` set was a strict subset of the `*` set.
- Reverts the symbol-collection line to the proven single-pass form.

(No test-suite run: `GenerateDocs.wls` is a standalone doc generator, not imported by the package or any `.mt` test; the relevant check is the unchanged generated output.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
