### PR TITLE
chore(scripts): regenerate paper figures + result plots

### DIFF
--- a/Scripts/RegenPaperFigures.wls
+++ b/Scripts/RegenPaperFigures.wls
@@ -12,6 +12,8 @@
      example22.pdf  -- road fork    (augmented with auxiliary exit edges)
      Triangle.pdf   -- triangular network (with aux entry/exit edges)
      Jama.pdf       -- Jamarat bridge network
+     corridor.pdf   -- §5.3 corridor (direct route vs bypass)
+     crossing.pdf   -- §5.5 non-uniqueness crossing (2-in/2-out at v5)
 
    Usage: wolframscript -file Scripts/RegenPaperFigures.wls
 *)
@@ -97,5 +99,33 @@ jama = Graph[{Labeled[1 \[UndirectedEdge] 2, Subscript["e", "12"]],
   VertexLabelStyle -> 14, EdgeLabelStyle -> 14];
 Export[FileNameJoin[{figDir, "Jama.pdf"}], jama];
 Print["Wrote Jama.pdf"];
+
+(* --- corridor: direct route e14 vs bypass v1-v2-v3-v4 (§5.3).  Explicit
+   coordinates: direct edge along the bottom, bypass arc over the top. *)
+corridor = Graph[{Labeled[1 \[UndirectedEdge] 4, Subscript["e", "14"]],
+  Labeled[1 \[UndirectedEdge] 2, Subscript["e", "12"]],
+  Labeled[2 \[UndirectedEdge] 3, Subscript["e", "23"]],
+  Labeled[3 \[UndirectedEdge] 4, Subscript["e", "34"]]},
+  VertexLabels -> {1 -> Subscript["v", 1], 2 -> Subscript["v", 2],
+    3 -> Subscript["v", 3], 4 -> Subscript["v", 4]},
+  VertexCoordinates -> {1 -> {0, 0}, 2 -> {1, 1}, 3 -> {2, 1}, 4 -> {3, 0}},
+  VertexLabelStyle -> 14, EdgeLabelStyle -> 14];
+Export[FileNameJoin[{figDir, "corridor.pdf"}], corridor];
+Print["Wrote corridor.pdf"];
+
+(* --- crossing: §5.5 non-uniqueness example.  Entries v1,v2 -> center v5 ->
+   exits v3,v4 (a 2-in/2-out vertex: edge currents determined, transition
+   currents free).  Left-center-right layout makes the crossing structure clear. *)
+crossing = Graph[{Labeled[1 \[UndirectedEdge] 5, Subscript["e", "15"]],
+  Labeled[2 \[UndirectedEdge] 5, Subscript["e", "25"]],
+  Labeled[5 \[UndirectedEdge] 3, Subscript["e", "53"]],
+  Labeled[5 \[UndirectedEdge] 4, Subscript["e", "54"]]},
+  VertexLabels -> {1 -> Subscript["v", 1], 2 -> Subscript["v", 2],
+    3 -> Subscript["v", 3], 4 -> Subscript["v", 4], 5 -> Subscript["v", 5]},
+  VertexCoordinates -> {1 -> {0, 1}, 2 -> {0, -1}, 5 -> {1.4, 0},
+    3 -> {2.8, 1}, 4 -> {2.8, -1}},
+  VertexLabelStyle -> 14, EdgeLabelStyle -> 14];
+Export[FileNameJoin[{figDir, "crossing.pdf"}], crossing];
+Print["Wrote crossing.pdf"];
 
 Print["Done."];

--- a/Scripts/RegenPaperResults.wls
+++ b/Scripts/RegenPaperResults.wls
@@ -1,0 +1,65 @@
+#!/usr/bin/env wolframscript
+(* RegenPaperResults.wls -- Regenerate the §5 result plots for the paper
+   "An Exact Solver for Stationary Mean-Field Games on Networks" by replaying
+   each EXE-block scenario through the current solver and exporting the
+   density/value-profile grids to PDF.
+
+   Companion to RegenPaperFigures.wls (which regenerates the network diagrams).
+   Each plot reproduces its EXE block's exact data (entries/exits/switching
+   costs/g/edges/PlotRange) via amScenario -> makeSystem -> solveScenario ->
+   edgeDensityProfile/edgeValueProfile.
+
+   Outputs (to the paper's executables/ directory):
+     merge1result.pdf       -- road merge, g(m)=m
+     merge3result.pdf       -- road merge, g(m)=log m
+     fork1result.pdf        -- road fork, cheap exit at v3
+     fork2result.pdf        -- road fork, cheap exit at v4
+     fork3result.pdf        -- road fork, equal exit costs
+     corridorresult.pdf     -- corridor, direct route vs bypass
+     corridorpsiresult.pdf  -- corridor with a turn penalty psi=40 at v2
+
+   Usage: wolframscript -file Scripts/RegenPaperResults.wls
+*)
+
+$RepoRoot = FileNameJoin[{DirectoryName[$InputFileName], ".."}];
+PrependTo[$Path, $RepoRoot];
+Needs["MFGraphs`"];
+$MFGraphsVerbose = False;
+
+exeDir = "/Users/ribeirrd/Dropbox/Apps/Overleaf/Stationary solutions of a congested MFG on Networks/executables";
+If[!DirectoryQ[exeDir],
+  Print["Executables directory not found: ", exeDir];
+  Exit[1]
+];
+
+V = Function[x, (1/2) Sin[2 Pi (x + 1/4)]^2];
+Id = (# &); Lg = (Log[#] &);
+mfAdj  = {{0,1,0,0},{0,0,1,1},{0,0,0,0},{0,0,0,0}};   (* merge & fork edge set *)
+corAdj = {{0,1,0,1},{0,0,1,0},{0,0,0,1},{0,0,0,0}};   (* corridor: direct + bypass *)
+
+res[label_, entries_, exits_, psi_, gfun_, adj_, edges_, densR_, valR_] :=
+  Module[{s, sys, sol, rules, grid},
+    s = amScenario[{1,2,3,4}, adj, entries, exits, psi, 1, V, gfun];
+    sys = makeSystem[s, makeSymbolicUnknowns[s]];
+    sol = solveScenario[s];
+    rules = If[AssociationQ[sol], sol["Rules"], sol];
+    grid = Grid[{
+      Plot[edgeDensityProfile[s, sys, #, rules, x], {x, 0, 1},
+        PlotLabel -> Row[{"density at ", #}], PlotRange -> densR] & /@ edges,
+      Plot[edgeValueProfile[s, sys, #, rules, x], {x, 0, 1},
+        PlotLabel -> Row[{"value function at ", #}], PlotRange -> valR] & /@ edges}];
+    Export[FileNameJoin[{exeDir, label <> "result.pdf"}], grid];
+    Print["Wrote ", label, "result.pdf  (solveScenario valid: ",
+      isValidSystemSolution[sys, sol], ")"];
+  ];
+
+res["merge1", {{1,2},{3,3}}, {{4,5}}, {}, Id, mfAdj, {{1,2},{3,2},{2,4}}, {1,4},  {5,13}];
+res["merge3", {{1,2},{3,3}}, {{4,5}}, {}, Lg, mfAdj, {{1,2},{3,2},{2,4}}, {0,25}, {5,13}];
+res["fork1",  {{1,2}}, {{3,2},{4,5}}, {}, Id, mfAdj, {{1,2},{2,3},{2,4}}, {-0.5,2}, {2,7}];
+res["fork2",  {{1,2}}, {{3,5},{4,2}}, {}, Id, mfAdj, {{1,2},{2,3},{2,4}}, {-0.5,2}, {2,7}];
+res["fork3",  {{1,2}}, {{3,5},{4,5}}, {}, Id, mfAdj, {{1,2},{2,3},{2,4}}, {-0.5,2}, {2,9}];
+res["corridor", {{1,100}}, {{4,0}}, {}, Id, corAdj, {{1,4},{1,2},{2,3},{3,4}}, {0,80}, {0,80}];
+res["corridorpsi", {{1,100}}, {{4,0}}, {{1,2,3,40},{3,2,1,40}}, Id, corAdj,
+    {{1,4},{1,2},{2,3},{3,4}}, {0,100}, {0,100}];
+
+Print["Done."];


### PR DESCRIPTION
## Summary

Adds reproducible scripts that regenerate the figures and result plots for the paper *"An Exact Solver for Stationary Mean-Field Games on Networks"* from the current solver.

- **`Scripts/RegenPaperResults.wls` (new)** — replays each §5 `EXE` block (road merge, road fork ×3, corridor, corridor + turn penalty) through `amScenario → makeSystem → solveScenario → edgeDensity/ValueProfile` and exports the density/value-profile grids to `executables/*result.pdf`. The merge/fork result plots had been stale since **May 2025** (old solver); all are now current and each reports `solveScenario valid: True`.
- **`Scripts/RegenPaperFigures.wls`** — added two network diagrams: **corridor** (§5.3, direct route vs bypass) and **crossing** (§5.5 non-uniqueness, a 2-in/2-out vertex).

Scripts only — no package code touched; neither file is loaded by `Needs["MFGraphs`"]`.

## Context

The crossing diagram supports a §5.5 correction: the previous fork-based non-uniqueness example is determinate in the critical case (verified against raw `Reduce`), so it was replaced by the 2-in/2-out crossing, where the edge currents are determined but the transition currents are a genuine one-parameter family.

## Testing

- `Scripts/RunTests.wls fast` → **342 passed, 0 failed**.
- Both scripts run clean on Wolfram 14.3; all 5 network diagrams + 7 result plots export successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
