### PR TITLE
fix(diagnostics): EqualitySolves counts actual Solve calls, not cache hits (#202)

### DIFF
--- a/MFGraphs/solversTools.wl
+++ b/MFGraphs/solversTools.wl
@@ -2136,8 +2136,12 @@ dnfReduceInstrumentedAnd[xp_, conjuncts_List, monitor_, order_String, sysObj_, d
                     dnfCounterIncrement[monitor, "EqualityAttempts"];
                     sol  = cachedSolve[elem];
                     fsol = If[MatchQ[sol, {{__Rule}, ___}], First[sol], {}];
+                    (* EqualityResolutions counts every traversal that yields a
+                       non-empty rule list (cache hit or miss); the actual Solve
+                       CPU count is the cache-miss count, surfaced separately as
+                       EqualitySolves in the summary. See issue #202. *)
                     If[fsol =!= {},
-                        dnfCounterIncrement[monitor, "EqualitySolves"];
+                        dnfCounterIncrement[monitor, "EqualityResolutions"];
                         dnfCounterIncrement[monitor, "Substitutions", Length[fsol]]
                     ];
                     newxp = substituteSolution[xpAcc, fsol];
@@ -2165,7 +2169,7 @@ dnfReduceInstrumented[xp_, rst_, fst_Equal, monitor_, order_String, sysObj_, dep
         sol  = cachedSolve[fst];
         fsol = If[MatchQ[sol, {{__Rule}, ___}], First[sol], {}];
         If[fsol =!= {},
-            dnfCounterIncrement[monitor, "EqualitySolves"];
+            dnfCounterIncrement[monitor, "EqualityResolutions"];
             dnfCounterIncrement[monitor, "Substitutions", Length[fsol]]
         ];
         newxp = substituteSolution[xp, fsol];
@@ -2229,7 +2233,7 @@ dnfReduceDiagnosticReport[sys_?mfgSystemQ, OptionsPattern[]] :=
             "BranchesKeptByDisjunct" -> <||>,
             "BranchesDroppedByDisjunct" -> <||>,
             "EqualityAttempts" -> 0,
-            "EqualitySolves" -> 0,
+            "EqualityResolutions" -> 0,
             "Substitutions" -> 0,
             "MaxRecursionDepth" -> 0,
             "ExpressionLeafCount" -> LeafCount[constraints],
@@ -2288,7 +2292,9 @@ dnfReduceDiagnosticReport[sys_?mfgSystemQ, OptionsPattern[]] :=
             "BranchesKeptByDisjunct" -> Lookup[monitor, "BranchesKeptByDisjunct", <||>],
             "BranchesDroppedByDisjunct" -> Lookup[monitor, "BranchesDroppedByDisjunct", <||>],
             "EqualityAttempts" -> Lookup[monitor, "EqualityAttempts", 0],
-            "EqualitySolves" -> Lookup[monitor, "EqualitySolves", 0],
+            "EqualityResolutions" -> Lookup[monitor, "EqualityResolutions", 0],
+            "EqualitySolves" -> $dnfSolveMiss,
+            "CachedSolveHits" -> $dnfSolveHits,
             "Substitutions" -> Lookup[monitor, "Substitutions", 0],
             "MaxRecursionDepth" -> Lookup[monitor, "MaxRecursionDepth", 0],
             "ExpressionLeafCount" -> Lookup[monitor, "ExpressionLeafCount", Missing["Unavailable"]],

--- a/Scripts/ProfileDNFReduce.wls
+++ b/Scripts/ProfileDNFReduce.wls
@@ -100,7 +100,7 @@ If[$RecursionLimitOpt =!= Automatic, Print["RecursionLimit\t", $RecursionLimitOp
 If[$SelectedCase =!= "all", Print["CaseFilter\t", $SelectedCase]];
 Print[
   "Header\tCase\tOrder\tBuildMs\tStatus\tKind\tTransitionFlowStatus\tTransitionFlowRules\tTransitionFlowResiduals\tValid\tVertices\tEdges\tVars\tPreRules\tPreConjuncts\tOrs\tOrLeafCounts\t" <>
-  "SolverInputMs\tDNFMs\tProcessed\tBranchesStarted\tBranchesKept\tBranchesDropped\tMaxDepth\tEqualitySolves\tSubstitutions\t" <>
+  "SolverInputMs\tDNFMs\tProcessed\tBranchesStarted\tBranchesKept\tBranchesDropped\tMaxDepth\tEqualitySolves\tCachedSolveHits\tEqualityResolutions\tSubstitutions\t" <>
   "ExpressionLeaves\tResultLeaves\tTimeoutPhase\tLastHead\tLastLeaves\tLastConjunct"
 ];
 
@@ -152,6 +152,8 @@ RunOne[name_String, buildFn_, order_String] :=
         ToString[Lookup[summary, "BranchesDropped", Missing["Unavailable"]]],
         ToString[Lookup[summary, "MaxRecursionDepth", Missing["Unavailable"]]],
         ToString[Lookup[summary, "EqualitySolves", Missing["Unavailable"]]],
+        ToString[Lookup[summary, "CachedSolveHits", Missing["Unavailable"]]],
+        ToString[Lookup[summary, "EqualityResolutions", Missing["Unavailable"]]],
         ToString[Lookup[summary, "Substitutions", Missing["Unavailable"]]],
         ToString[Lookup[summary, "ExpressionLeafCount", Missing["Unavailable"]]],
         ToString[Lookup[summary, "ResultLeafCount", Missing["Unavailable"]]],


### PR DESCRIPTION
## Summary

Fixes #202. `dnfReduceInstrumented` incremented the `EqualitySolves` diagnostic counter on every traversal that produced a non-empty rule list. Once `cachedSolve` memoization was added, that fired on **cache hits too**, so `EqualitySolves` reported the structural traversal count rather than the number of `Solve` calls actually run (the issue cites tens of thousands reported where only ~140 distinct solves occurred).

Split the diagnostic into three coherent counters in the `dnfReduceDiagnosticReport` summary:

| Counter | Meaning | Source |
|---|---|---|
| `EqualitySolves` | actual `Solve` CPU calls | `$dnfSolveMiss` (cache misses) |
| `CachedSolveHits` | cache hits | `$dnfSolveHits` |
| `EqualityResolutions` | old behavior: non-empty resolutions across hits+misses (structural traversal view) | monitor counter (renamed from `EqualitySolves`) |

The set is self-consistent: **`EqualityAttempts == EqualitySolves + CachedSolveHits`** (every `cachedSolve` call is either a hit or a miss).

`Scripts/ProfileDNFReduce.wls` gains `CachedSolveHits` and `EqualityResolutions` TSV columns; its `EqualitySolves` column now reports actual solves.

## On `Substitutions`

The issue lumped `Substitutions` in with the over-count complaint, but it's **left as a per-traversal counter** — substitution work runs on every resolution regardless of whether the `Solve` was cached, so its count is already semantically correct. Flagging the decision in case the original intent was different.

## Verification

Direct `dnfReduceDiagnosticReport` run (the invariant is the decisive check the issue's mechanism predicts):

```
grid-3x3 : Attempts=117  Solves=49  CachedHits=68  Resolutions=117   ->  117 == 49 + 68  OK
grid-2x4 : Attempts=26   Solves=26  CachedHits=0   Resolutions=26    ->  26  == 26 + 0   OK  (control, no caching)
```

Before the fix, grid-3x3 would have reported `EqualitySolves = 117` (inflated by the 68 cache hits); it now reports the true **49**. The no-hit control confirms behavior is unchanged when there's nothing to over-count.

- `Scripts/RunTests.wls fast` -> **342 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
