### PR TITLE
fix(solvers): oracle over-prune probe reads nested records; booleanMinimizeReduceSystem surfaces infeasibility

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -144,6 +144,46 @@ as `dnfReduceSystem`.
 DNF-first benchmark entries from `Scripts/BenchmarkSystemSolver.wls` are appended
 here when the script is run with `--tag`.
 
+### 2026-07-12 - post-oracle-boolmin-fix
+
+**Commit:** `2a251bd`  
+**Environment:** local `wolframscript`, `$MFGraphsVerbose=False`  
+**Solver:** `dnf`  
+**Timeout per case:** 60s  
+**Solutions file:** `Results/system_solver_dnf_solutions_20260712-230757.wl`
+
+| Case | Solver | Build (ms) | Warmup (ms) | Repeat (ms) | Status | Kind | Transition flows | Residual Jts | Valid |
+|------|--------|-----------|------------|--------------|--------|------|------------------|--------------|-------|
+| chain-2v | dnf | 24.65 | 3.01 | 1.64 | OK | Rules | Unique | 0 | True |
+| chain-3v-1exit | dnf | 7.38 | 2.68 | 2.34 | OK | Rules | Unique | 0 | True |
+| chain-3v-2exit | dnf | 7.3 | 86.1 | 7.26 | OK | Underdetermined | Unique | 0 | True |
+| chain-3-midentry | dnf | 9.2 | 10.81 | 8.42 | OK | Rules | Unique | 0 | True |
+| chain-5v-1exit | dnf | 12.1 | 4.24 | 3.78 | OK | Rules | Unique | 0 | True |
+| grid-2x3 | dnf | 33.22 | 19.44 | 20.61 | OK | Rules | Unique | 0 | True |
+| grid-3x2 | dnf | 30.78 | 19.31 | 19.68 | OK | Rules | Unique | 0 | True |
+| example-12 | dnf | 20.76 | 21.63 | 21.73 | OK | Rules | Unique | 0 | True |
+---
+
+### 2026-07-12 - pre-oracle-boolmin-fix
+
+**Commit:** `2a251bd`  
+**Environment:** local `wolframscript`, `$MFGraphsVerbose=False`  
+**Solver:** `dnf`  
+**Timeout per case:** 60s  
+**Solutions file:** `Results/system_solver_dnf_solutions_20260712-230203.wl`
+
+| Case | Solver | Build (ms) | Warmup (ms) | Repeat (ms) | Status | Kind | Transition flows | Residual Jts | Valid |
+|------|--------|-----------|------------|--------------|--------|------|------------------|--------------|-------|
+| chain-2v | dnf | 35.72 | 4.07 | 1.69 | OK | Rules | Unique | 0 | True |
+| chain-3v-1exit | dnf | 9.31 | 3.1 | 3.46 | OK | Rules | Unique | 0 | True |
+| chain-3v-2exit | dnf | 7.22 | 99.25 | 7.45 | OK | Underdetermined | Unique | 0 | True |
+| chain-3-midentry | dnf | 9.85 | 10.68 | 10.84 | OK | Rules | Unique | 0 | True |
+| chain-5v-1exit | dnf | 10.66 | 4.04 | 3.8 | OK | Rules | Unique | 0 | True |
+| grid-2x3 | dnf | 36.71 | 22.73 | 20.62 | OK | Rules | Unique | 0 | True |
+| grid-3x2 | dnf | 32.06 | 20.25 | 22.33 | OK | Rules | Unique | 0 | True |
+| example-12 | dnf | 21.36 | 23.04 | 22.51 | OK | Rules | Unique | 0 | True |
+---
+
 ### 2026-05-10 - post-threshold-0
 
 **Commit:** `91ef016`  

--- a/MFGraphs/Tests/boolean-minimize.mt
+++ b/MFGraphs/Tests/boolean-minimize.mt
@@ -97,3 +97,31 @@ Module[{sys, inputs, constraints, allVars, atoms, linAtoms, disjAtoms,
         TestID -> "BooleanConvert raw disjunct count > 1 on grid-3x2 (sanity)"
     ]
 ]
+
+
+(* --------------------------------------------------------------- *)
+(* Infeasible systems must surface Residual -> False               *)
+(* --------------------------------------------------------------- *)
+
+(* An entry with no exits makes the linear part contradict itself; the
+   contradiction surfaces as a literal (variable-free) False atom, which
+   must short-circuit to the infeasible result shape instead of being
+   dropped by the component decomposition and reported as solved. *)
+Module[{s, sys, ref, bmr},
+    s = makeScenario[<|"Model" -> <|
+        "Vertices" -> {1, 2},
+        "Adjacency" -> {{0, 1}, {0, 0}},
+        "Entries" -> {{1, 1}}, "Exits" -> {},
+        "Switching" -> {}|>|>];
+    sys = makeSystem[s];
+    ref = dnfReduceSystem[sys];
+    bmr = booleanMinimizeReduceSystem[sys];
+    Test[
+        AssociationQ[bmr] && bmr["Residual"] === False &&
+        AssociationQ[ref] && ref["Residual"] === False
+        ,
+        True
+        ,
+        TestID -> "booleanMinimizeReduceSystem: entry with no exits is Residual False, matching dnfReduceSystem"
+    ]
+]

--- a/MFGraphs/Tests/scenario-consistency.mt
+++ b/MFGraphs/Tests/scenario-consistency.mt
@@ -182,6 +182,47 @@ Module[{s, sys},
     ]
 ];
 
+(* The probe reads EqEntryIn/EqBalance*/IneqJs/IneqJts through the nested
+   typed records. Pinning the sole entry flow contradicts EqEntryIn
+   (j == entry value), so the pruning must be rejected. *)
+Module[{s, sys, entryVar},
+    s = makeScenario[<|"Model" -> <|
+        "Vertices" -> {1, 2, 3},
+        "Adjacency" -> {{0, 1, 0}, {0, 0, 1}, {0, 0, 0}},
+        "Entries" -> {{1, 1}}, "Exits" -> {{3, 0}},
+        "Switching" -> {}|>|>];
+    sys = makeSystem[s];
+    entryVar = First[First[systemData[sys, "EqEntryIn"]]];
+    Test[
+        addOracleEqualities[sys, <|"Converged" -> True, "Inactive" -> {entryVar}|>] === sys
+        ,
+        True
+        ,
+        TestID -> "Oracle: over-pruning the entry flow is rejected by the feasibility probe"
+    ]
+];
+
+(* A genuinely inactive variable (the backward flow on a forward chain)
+   must still be pinned: the probe accepts it and the j == 0 equality
+   lands in EqGeneral. *)
+Module[{s, sys, pruned},
+    s = makeScenario[<|"Model" -> <|
+        "Vertices" -> {1, 2, 3},
+        "Adjacency" -> {{0, 1, 0}, {0, 0, 1}, {0, 0, 0}},
+        "Entries" -> {{1, 1}}, "Exits" -> {{3, 0}},
+        "Switching" -> {}|>|>];
+    sys = makeSystem[s];
+    pruned = addOracleEqualities[sys, <|"Converged" -> True, "Inactive" -> {j[2, 1]}|>];
+    Test[
+        mfgSystemQ[pruned] && pruned =!= sys &&
+        MemberQ[systemData[pruned, "EqGeneral"], j[2, 1] == 0]
+        ,
+        True
+        ,
+        TestID -> "Oracle: feasible pruning is accepted and appends the pin to EqGeneral"
+    ]
+];
+
 (* Note: addOracleEqualities runs a FindInstance probe on the linear part
    only -- it can detect over-pruning that violates mass balance, but
    complementarity-level over-pruning (oracle's pinned vars conflict with

--- a/MFGraphs/solversTools.wl
+++ b/MFGraphs/solversTools.wl
@@ -526,6 +526,12 @@ booleanMinimizeSystem[sys_?mfgSystemQ, opts : OptionsPattern[]] :=
 pruneDisjunctiveArms[linearAtoms_List, disjAtoms_List, allVars_List, armTimeout_] :=
     Module[{lin = linearAtoms, disj = disjAtoms, changed = True, status = "Unchanged",
             newDisj, atom, arms, kept, fi, infeasibleAll = False},
+        (* A literal False in the linear part (a contradiction surfaced during
+           rule accumulation) carries no variables, so the variable-sharing
+           decomposition downstream would silently drop it. It must short-
+           circuit here as infeasibility. *)
+        If[MemberQ[lin, False],
+            Return[{lin, disj, "Infeasible"}, Module]];
         While[changed && !infeasibleAll,
             changed = False;
             newDisj = {};

--- a/MFGraphs/systemTools.wl
+++ b/MFGraphs/systemTools.wl
@@ -565,7 +565,8 @@ boundaryPreservingAutomorphisms[s_?scenarioQ] :=
    pruned system fails its FindInstance safety check -> no-op. *)
 addOracleEqualities[sys_?mfgSystemQ, oracle_Association] :=
     Module[{inactive, eqs, sysAssoc, hamRecord, hamAssoc, newEqGeneral, newHam,
-            newSys, allVars, feasibilityProbe},
+            newSys, allVars, eqEntryIn, eqBalanceSplit, eqBalanceGather,
+            ineqJs, ineqJts, feasibilityProbe},
         If[! TrueQ[Lookup[oracle, "Converged", False]], Return[sys, Module]];
         inactive = Lookup[oracle, "Inactive", {}];
         If[inactive === {}, Return[sys, Module]];
@@ -579,23 +580,30 @@ addOracleEqualities[sys_?mfgSystemQ, oracle_Association] :=
         newSys = mfgSystem[<|sysAssoc, "HamiltonianData" -> newHam|>];
         (* Safety check: does the pruned linear part still admit a feasible
            point? If FindInstance returns {} the oracle over-pruned -- bail
-           out and return the original system. Skip the check if the system
-           lacks the expected linear-program buckets. *)
+           out and return the original system. The probe buckets live inside
+           the nested BoundaryData/FlowData records, so they must be read via
+           systemData (a top-level Lookup returns its default and voids the
+           probe). Skip the check if the system lacks the expected buckets. *)
         allVars = Join[
             Lookup[sysAssoc, "Js",  {}],
             Lookup[sysAssoc, "Jts", {}],
             Lookup[sysAssoc, "Us",  {}]
         ];
+        eqEntryIn       = systemData[sys, "EqEntryIn"];
+        eqBalanceSplit  = systemData[sys, "EqBalanceSplittingFlows"];
+        eqBalanceGather = systemData[sys, "EqBalanceGatheringFlows"];
+        ineqJs          = systemData[sys, "IneqJs"];
+        ineqJts         = systemData[sys, "IneqJts"];
+        If[AnyTrue[{eqEntryIn, eqBalanceSplit, eqBalanceGather, ineqJs, ineqJts}, MissingQ],
+            Return[newSys, Module]];
         feasibilityProbe = TimeConstrained[
             Quiet @ FindInstance[
                 And @@ Join[
-                    Lookup[sysAssoc, "EqEntryIn", {}],
-                    {Lookup[sysAssoc, "EqBalanceSplittingFlows", True],
-                     Lookup[sysAssoc, "EqBalanceGatheringFlows", True]},
-                    Lookup[sysAssoc, "EqGeneral", {}],
+                    eqEntryIn,
+                    {eqBalanceSplit, eqBalanceGather},
                     newEqGeneral,
-                    Lookup[sysAssoc, "IneqJs",  {}],
-                    Lookup[sysAssoc, "IneqJts", {}]
+                    ineqJs,
+                    ineqJts
                 ],
                 allVars, Reals, 1
             ],

--- a/Results/system_solver_dnf_solutions_latest.wl
+++ b/Results/system_solver_dnf_solutions_latest.wl
@@ -1,5 +1,5 @@
 (* Created with the Wolfram Language : www.wolfram.com *)
-<|"Timestamp" -> "Sun 10 May 2026 16:22:03", "Commit" -> "91ef016", 
+<|"Timestamp" -> "Sun 12 Jul 2026 23:08:09", "Commit" -> "2a251bd", 
  "Solver" -> "dnf", "Cases" -> 
   <|"chain-2v" -> <|"Status" -> "OK", "Kind" -> "Rules", 
      "TransitionFlowStatus" -> "Unique", "TransitionFlowResidualCount" -> 0, 


### PR DESCRIPTION
## Summary

Fixes the two silent-wrong-answer solver bugs found by the full repo sweep (both empirically verified before and after the fix).

### 1. `addOracleEqualities` feasibility probe was vacuous (`systemTools.wl`)

The FindInstance safety probe assembled its input via `Lookup[sysAssoc, "EqEntryIn", {}]`, `Lookup[sysAssoc, "IneqJs", {}]`, etc. — but those buckets live inside the nested `BoundaryData`/`FlowData` typed records, not at the top level of the system association, so every lookup returned its default. The probe degenerated to `EqGeneral + j==0 pins`, which the all-zeros point always satisfies, so the documented "over-pruned → return `sys` unchanged" contract could never fire: a pin directly contradicting `EqEntryIn` (`j[auxEntry1,1] == 1` pinned to `0`) was accepted.

The probe now reads the buckets through `systemData` (which searches the nested records) and skips the check only when they are genuinely absent.

### 2. `booleanMinimizeReduceSystem` reported infeasible systems as solved (`solversTools.wl`)

Variable-free atoms have empty `varsOf`, get `compIndex === Missing[]`, and are dropped from every component in `decomposeByVariableSharing`. The literal `False` produced for a contradictory linear part therefore vanished: on a scenario with an entry and no exits, `dnfReduceSystem` correctly returned `Residual -> False`, while `booleanMinimizeReduceSystem` returned a bare rule list containing `j[auxEntry1,1] -> 0` — contradicting the system's own `j[auxEntry1,1] == 1`.

`pruneDisjunctiveArms` now short-circuits to `"Infeasible"` when the linear part contains a literal `False`; the existing infeasibility branch in `booleanMinimizeReduceSystem` then yields the same `Residual -> False` shape as `dnfReduceSystem`.

## Tests

- 3 new regression tests:
  - `scenario-consistency.mt` — over-pruning the entry flow is rejected; a genuinely feasible pin is still accepted and lands in `EqGeneral`.
  - `boolean-minimize.mt` — entry-with-no-exits yields `Residual -> False`, matching `dnfReduceSystem`.
- Fast suite: **345 passed, 0 failed** (342 baseline + 3 new).

## Benchmarks

Before/after appended to `BENCHMARKS.md` (tags `pre-oracle-boolmin-fix` / `post-oracle-boolmin-fix`, `--timeout 60`). Timings are within noise, as expected — the changed paths only execute on infeasible systems or missing-bucket lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)