### PR TITLE
fix(scenario): expand edgeEntryTolls for adjacency-only models; keep switching-cost metric closure exact

### DIFF
--- a/MFGraphs/Tests/scenario-kernel.mt
+++ b/MFGraphs/Tests/scenario-kernel.mt
@@ -872,3 +872,49 @@ Test[
     ,
     TestID -> "Example metadata: every registered key resolves to an Association"
 ]
+
+(* Test: edgeEntryTolls expand identically for Graph and adjacency-only models,
+   with no inadmissible U-turn key {nextV, targetV, nextV} *)
+Module[{mG, mA, sG, sA, swG, swA},
+    mG = <|"Graph" -> Graph[{1 -> 2, 2 -> 3, 3 -> 4}],
+           "Entries" -> {{1, 100}}, "Exits" -> {{4, 0}}, "Switching" -> {},
+           "edgeEntryTolls" -> <|{2, 3} -> 5|>|>;
+    mA = <|"Vertices" -> {1, 2, 3, 4},
+           "Adjacency" -> {{0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {0, 0, 0, 0}},
+           "Entries" -> {{1, 100}}, "Exits" -> {{4, 0}}, "Switching" -> {},
+           "edgeEntryTolls" -> <|{2, 3} -> 5|>|>;
+    sG = makeScenario[<|"Model" -> mG|>];
+    sA = makeScenario[<|"Model" -> mA|>];
+    swG = Select[scenarioData[sG, "Model"]["Switching"], # =!= 0 &];
+    swA = Select[scenarioData[sA, "Model"]["Switching"], # =!= 0 &];
+    Test[
+        scenarioQ[sG] && scenarioQ[sA] &&
+        Keys[swG] === {{1, 2, 3}} && Keys[swA] === {{1, 2, 3}} &&
+        swA[{1, 2, 3}][1] === 5
+        ,
+        True
+        ,
+        TestID -> "edgeEntryTolls: adjacency-only model expands like the Graph model, no U-turn keys"
+    ]
+]
+
+(* Test: metric closure of switching costs stays exact — rational costs are
+   stored as rationals and a cheaper two-hop route replaces a direct cost *)
+Module[{m, s, sw},
+    m = <|"Vertices" -> {1, 2, 3, 4},
+          "Adjacency" -> {{0, 1, 0, 0}, {0, 0, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+          "Entries" -> {{1, 100}}, "Exits" -> {{3, 0}, {4, 0}},
+          "Switching" -> {{1, 2, 3, 1/3}, {3, 2, 4, 1/3}, {1, 2, 4, 1}}|>;
+    s = makeScenario[<|"Model" -> m|>];
+    sw = scenarioData[s, "Model"]["Switching"];
+    Test[
+        scenarioQ[s] &&
+        sw[{1, 2, 3}] === 1/3 &&
+        sw[{1, 2, 4}] === 2/3 &&
+        FreeQ[Values[sw], _Real]
+        ,
+        True
+        ,
+        TestID -> "Switching metric closure: exact rationals in, exact rationals out"
+    ]
+]

--- a/MFGraphs/scenarioTools.wl
+++ b/MFGraphs/scenarioTools.wl
@@ -262,20 +262,32 @@ normalizeSwitchingCosts[sc_List] :=
     If[sc === {}, <||>, AssociationThread[Most /@ sc, Last /@ sc]];
 
 expandEdgeEntryTolls[model_Association] :=
-    Module[{tolls, g, expanded},
+    Module[{tolls, g, vertices, adjacency, sym, index, neighborsOf, expanded},
         tolls = Lookup[model, "edgeEntryTolls", <||>];
         If[tolls === <||>, Return[<||>, Module]];
 
+        (* normalizeScenarioModel stores a Graph only for Graph-specified
+           models; adjacency-only models carry just Vertices/Adjacency, so
+           the neighbor lookup must fall back to the undirected closure of
+           the adjacency matrix. *)
         g = Lookup[model, "Graph"];
-
-        (* If we don't have a graph yet, we can't expand tolls.
-           But makeScenario normalizes the model first, so we should have it. *)
-        If[!MatchQ[g, _Graph], Return[<||>, Module]];
+        If[MatchQ[g, _Graph],
+            neighborsOf = AdjacencyList[g, #] &,
+            vertices  = Lookup[model, "Vertices"];
+            adjacency = Lookup[model, "Adjacency"];
+            If[!ListQ[vertices] || !(ListQ[adjacency] || Head[adjacency] === SparseArray),
+                Return[<||>, Module]];
+            sym   = Unitize[Normal[adjacency] + Transpose[Normal[adjacency]]];
+            index = AssociationThread[vertices, Range[Length[vertices]]];
+            neighborsOf = Function[v, Pick[vertices, sym[[index[v]]], 1]]
+        ];
 
         expanded = KeyValueMap[
             Function[{edge, toll},
                 Module[{targetV = edge[[1]], nextV = edge[[2]], incoming},
-                    incoming = AdjacencyList[g, targetV];
+                    (* nextV itself would form the inadmissible U-turn triple
+                       {nextV, targetV, nextV}. *)
+                    incoming = DeleteCases[neighborsOf[targetV], nextV];
                     Association @ Table[
                         {r, targetV, nextV} -> If[MatchQ[toll, _Function], toll, toll &],
                         {r, incoming}
@@ -293,22 +305,38 @@ metricClosureSwitchingCosts[sc_Association] :=
         byVertex = GroupBy[Keys[sc], #[[2]] &];
         closedByVertex = KeyValueMap[
             Function[{v, triples},
-                Module[{numericTriples, nonNumericTriples, g},
+                Module[{numericTriples, nonNumericTriples, labels, index, n, dist},
                     numericTriples = Select[triples, NumericQ[sc[#]] &];
                     nonNumericTriples = Complement[triples, numericTriples];
 
                     If[numericTriples === {},
                         AssociationThread[triples, sc /@ triples],
-                        g = Graph[
-                            DirectedEdge[#[[1]], #[[3]], sc[#]] & /@ numericTriples,
-                            EdgeWeight -> (sc /@ numericTriples)
+                        (* Exact Floyd-Warshall over the edge labels around v.
+                           GraphDistance on a weighted Graph coerces exact
+                           rational costs to machine reals, which would leak
+                           floats into the symbolic pipeline. *)
+                        labels = DeleteDuplicates[
+                            Join[numericTriples[[All, 1]], numericTriples[[All, 3]]]];
+                        n = Length[labels];
+                        index = AssociationThread[labels, Range[n]];
+                        dist = ConstantArray[Infinity, {n, n}];
+                        Do[dist[[k, k]] = 0, {k, n}];
+                        Scan[
+                            Function[triple,
+                                With[{a = index[triple[[1]]], b = index[triple[[3]]]},
+                                    dist[[a, b]] = Min[dist[[a, b]], sc[triple]]
+                                ]
+                            ],
+                            numericTriples
+                        ];
+                        Do[
+                            dist[[a, b]] = Min[dist[[a, b]], dist[[a, k]] + dist[[k, b]]],
+                            {k, n}, {a, n}, {b, n}
                         ];
                         Join[
                             AssociationThread[nonNumericTriples, sc /@ nonNumericTriples],
                             Association @ Map[
-                                With[{dist = GraphDistance[g, #[[1]], #[[3]]]},
-                                    # -> If[IntegerQ[dist] || (NumericQ[dist] && dist == Round[dist]), Round[dist], dist]
-                                ] &,
+                                # -> dist[[index[#[[1]]], index[#[[3]]]]] &,
                                 numericTriples
                             ]
                         ]


### PR DESCRIPTION
## Summary

Fixes two verified bugs in `scenarioTools.wl` found by the full repo sweep.

### 1. `edgeEntryTolls` silently dropped for adjacency-only models

`expandEdgeEntryTolls` looked up the model's `"Graph"` key to enumerate incoming neighbors, but `normalizeScenarioModel` only stores a `Graph` for Graph-specified models — for `Vertices`+`Adjacency` input it early-returns without one. Result (empirically verified): the same scenario built from a `Graph` got its tolls (`{1,2,3} -> 5&`), built from an adjacency matrix got **zero** nonzero switching costs, with no message.

The neighbor lookup now falls back to the undirected closure of the adjacency matrix when no `Graph` is stored. The stored scenario shape is unchanged for all existing models.

Also excludes `nextV` from the incoming set, which previously produced the inadmissible U-turn key `{nextV, targetV, nextV}` polluting `Switching`.

### 2. `metricClosureSwitchingCosts` leaked machine floats into the exact pipeline

`GraphDistance` on a weighted `Graph` returns machine reals, and only integer-valued results were re-exactified via `Round`, so exact input costs like `1/2`, `7/10` were stored as `0.5`, `0.7` and flowed into `IneqSwitchingByVertex`/`AltOptCond` — violating the package invariant that `numericOracle.wl` is the only float-introducing file.

Replaced with an exact Floyd–Warshall over the per-vertex edge labels (these label sets are neighbor-sized, so the cubic loop is trivial). Semantics preserved: `NumericQ` costs only, `Infinity`/`Function` costs pass through untouched, unreachable pairs stay `Infinity`, and cheaper multi-hop routes still replace direct costs — now exactly (`1/3 + 1/3 = 2/3`).

## Tests

- 2 new regression tests in `scenario-kernel.mt`:
  - Graph vs adjacency-only toll-expansion parity, and no U-turn keys.
  - Metric closure keeps exact rationals exact (including the two-hop replacement) with `FreeQ[..., _Real]`.
- Fast suite: **344 passed, 0 failed**.

Not solver-sensitive (scenario construction only), so no benchmark run per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)