### PR TITLE
fix(tests): harness exits nonzero on failed/empty TestReport; de-vacuate two tests

### DIFF
--- a/MFGraphs/Tests/orchestration.mt
+++ b/MFGraphs/Tests/orchestration.mt
@@ -64,7 +64,8 @@ Test[
         solveScenarioResult = TimeConstrained[solveScenario[s], 5, $TimedOut];
         solveMFGResult = TimeConstrained[SolveMFG[s], 5, $TimedOut];
         (ListQ[solveMFGResult] || AssociationQ[solveMFGResult]) &&
-        solutionResultKind[solveMFGResult] === solutionResultKind[solveScenarioResult]
+        solversTools`Private`solutionResultKind[solveMFGResult] ===
+            solversTools`Private`solutionResultKind[solveScenarioResult]
     ],
     True,
     TestID -> "SolveMFG: accepts typed scenario and produces same result kind as solveScenario"
@@ -83,7 +84,8 @@ Test[
         solveScenarioResult = TimeConstrained[solveScenario[s], 5, $TimedOut];
         solveMFGResult = TimeConstrained[SolveMFG[rawAssoc], 5, $TimedOut];
         (ListQ[solveMFGResult] || AssociationQ[solveMFGResult]) &&
-        solutionResultKind[solveMFGResult] === solutionResultKind[solveScenarioResult]
+        solversTools`Private`solutionResultKind[solveMFGResult] ===
+            solversTools`Private`solutionResultKind[solveScenarioResult]
     ],
     True,
     TestID -> "SolveMFG: legacy association input still works after scenario dispatch added"

--- a/MFGraphs/Tests/scenario-kernel.mt
+++ b/MFGraphs/Tests/scenario-kernel.mt
@@ -145,7 +145,7 @@ Test[
 (* Test: getExampleScenario forwarding delegates omitted Hamiltonian defaults *)
 Test[
     Module[{s, h},
-        s = gridScenario[{2}, {{1, 10}}, {{2, 0}}];
+        s = getExampleScenario[3, {{1, 10}}, {{3, 0}}];
         h = scenarioData[s, "Hamiltonian"];
         scenarioQ[s] && h["Alpha"] === 1 && h["V"] === -1 && h["G"][2] === -1/2
     ],

--- a/Scripts/RunSingleTest.wls
+++ b/Scripts/RunSingleTest.wls
@@ -10,7 +10,7 @@ PrependTo[$Path, $RepoRoot];
 Needs["MFGraphs`"];
 $MFGraphsVerbose = False;
 
-args = Select[Rest[$ScriptCommandLine], !StringEndsQ[#, ".wls"] &];
+args = Select[Rest[$ScriptCommandLine], !StringStartsQ[#, "-"] && !StringEndsQ[#, ".wls"] &];
 If[args === {}, Print["Missing test file argument"]; Exit[1]];
 testFile = First[args];
 If[!FileExistsQ[testFile], Print["Test file not found: ", testFile]; Exit[1]];
@@ -18,9 +18,22 @@ If[!FileExistsQ[testFile], Print["Test file not found: ", testFile]; Exit[1]];
 Print["Running: ", testFile];
 report = TestReport[testFile];
 
-Print["Passed: ", report["TestsSucceededCount"]];
-Print["Failed: ", report["TestsFailedCount"]];
-If[report["TestsFailedCount"] > 0,
+(* A failed TestReport or a file that ran zero tests must exit nonzero — a
+   non-Boolean failure-count comparison would otherwise fall through to the
+   unconditional Exit[0]. *)
+If[!MatchQ[report, _TestReportObject],
+    Print["TestReport failed to run (load error or bad file)."];
+    Exit[1]
+];
+passed = report["TestsSucceededCount"];
+failed = report["TestsFailedCount"];
+If[!IntegerQ[passed] || !IntegerQ[failed] || passed + failed === 0,
+    Print["No test results produced (file aborted or contains no tests)."];
+    Exit[1]
+];
+Print["Passed: ", passed];
+Print["Failed: ", failed];
+If[failed > 0,
     Print["\nFailed tests:"];
     KeyValueMap[
         Print["  [", #2["Outcome"], "] ", #2["TestID"]] &,

--- a/Scripts/RunTests.wls
+++ b/Scripts/RunTests.wls
@@ -84,8 +84,18 @@ Do[
     $t0 = AbsoluteTime[];
     report = TestReport[FileNameJoin[{$TestsDir, file}]];
     $elapsed = Round[AbsoluteTime[] - $t0];
-    passed = report["TestsSucceededCount"];
-    failed = report["TestsFailedCount"];
+    passed = If[MatchQ[report, _TestReportObject], report["TestsSucceededCount"], 0];
+    failed = If[MatchQ[report, _TestReportObject], report["TestsFailedCount"], 0];
+    (* A failed TestReport (missing file, load abort) or a file that ran zero
+       tests must count as a failure — non-numeric counts would otherwise make
+       the final $totalFailed > 0 check non-Boolean and the script exit 0. *)
+    If[!IntegerQ[passed] || !IntegerQ[failed] || passed + failed === 0,
+        Print["  [ERROR] ", file, " produced no test results"];
+        $totalFailed += 1;
+        AppendTo[$allFailed, file <> " (no test results)"];
+        Print[];
+        Continue[]
+    ];
     $totalPassed += passed;
     $totalFailed += failed;
     Print["  Passed: ", passed, "  Failed: ", failed, "  (", $elapsed, "s)"];


### PR DESCRIPTION
## Summary

Fixes the test-infrastructure holes found by the full repo sweep.

### Harness exit-code holes (`Scripts/RunTests.wls`, `Scripts/RunSingleTest.wls`)

If `TestReport` itself failed (missing file, load abort), its counts were non-numeric: `$totalFailed` went symbolic, the final `If[$totalFailed > 0, Exit[1], Exit[0]]` condition was non-Boolean so **neither branch ran**, and wolframscript exited 0 — a broken suite reported success. `RunSingleTest.wls` had the same fall-through to its unconditional `Exit[0]`.

Both runners now fail loudly when:
- `TestReport` returns anything other than a `TestReportObject`,
- the counts are non-integer, or
- a file produces **zero** test results (a file that aborts mid-load would otherwise silently drop its tests).

Verified: a testless `.mt` file now exits 1 with a clear message.

`RunSingleTest.wls` also now filters `-flags` from its arguments, matching `RunTests.wls`.

### Vacuous test: `orchestration.mt`

`solutionResultKind` is private to `solversTools` (defined after `Begin["`Private`"]`), so the unqualified calls resolved to undefined `Global` symbols and the assertions compared unevaluated wrappers — passing by expression identity (both sides come from the solve cache), not by result kind. Now qualified as `solversTools`Private`solutionResultKind`, as `reduce-system.mt` already does.

### Mislabeled duplicate: `scenario-kernel.mt`

The test claiming to cover `getExampleScenario` Hamiltonian-default forwarding was byte-identical to the `gridScenario` test above it and never called `getExampleScenario`. It now does.

## Tests

Fast suite: **342 passed, 0 failed** (same test count — these are fixes to existing tests and the harness, not new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)