### PR TITLE
docs: sync loading instructions, suite lists, script inventory; add utilities` to API reference

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -88,7 +88,7 @@ withCriticalCongestionGuard[sys, solverName, body] evaluates body only when sys 
 
 ## withCriticalCongestionSolver
 
-withCriticalCongestionSolver[sys, solverName, bodyFunc] handles validation, input building, and rule attachment for critical-congestion structural solvers.
+withCriticalCongestionSolver[sys, solverName, bodyFunc, buildInputsFunc, attachRulesFunc] guards on critical congestion, calls buildInputsFunc[sys] to obtain {constraints, allVars, rulesAcc}, evaluates bodyFunc[constraints, allVars], and returns attachRulesFunc[result, rulesAcc]. Shared shell for the critical-congestion structural solvers.
 
 ## buildAuxiliaryTopology
 

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -46,6 +46,50 @@ $MFGraphsParallelThreshold controls the minimum list length before ParallelMap o
 
 $MFGraphsVerbose controls whether progress and timing messages are printed. Set $MFGraphsVerbose = False to suppress output. Default is False.
 
+## criticalCongestionSystemQ
+
+criticalCongestionSystemQ[sys] returns True if the system is a critical congestion system (Alpha == 1 everywhere).
+
+## exactBoundaryValue
+
+exactBoundaryValue[val] converts a numeric real boundary value to an exact rational or returns a Failure.
+
+## exactBoundaryValues
+
+exactBoundaryValues[vals] applies exactBoundaryValue to a list and returns the first Failure if conversion fails.
+
+## extractRules
+
+extractRules[sol] extracts replacement rules from a solution list or solution association.
+
+## mergeRules
+
+mergeRules[oldRules, newRules] joins rule lists while keeping the latest rule for each left-hand side.
+
+## mfgData
+
+mfgData[obj] returns the underlying Association of a typed object. mfgData[obj, key] returns the value for key, or Missing["KeyAbsent", key].
+
+## mfgTypedQ
+
+mfgTypedQ[obj, head] returns True if obj is of the form head[assoc_Association].
+
+## normalizeRules
+
+normalizeRules[rules] rewrites right-hand sides through the full rule set.
+
+## roundValues
+
+roundValues[x] rounds numerical values in x to a standard precision (10^-10).
+
+## withCriticalCongestionGuard
+
+withCriticalCongestionGuard[sys, solverName, body] evaluates body only when sys is a critical-congestion system; otherwise emits MFGraphs::noncritical and returns a Failure.
+
+## withCriticalCongestionSolver
+
+withCriticalCongestionSolver[sys, solverName, bodyFunc] handles validation, input building, and rule attachment for critical-congestion structural solvers.
+
 ## buildAuxiliaryTopology
 
 buildAuxiliaryTopology[model] returns an association with the auxiliary graph and metadata derived from the raw model.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -93,7 +93,7 @@ Current cases:
 | `chain-2v` | two-vertex chain |
 | `chain-3v-1exit` | three-vertex chain, one exit |
 | `chain-3v-2exit` | three-vertex chain, two exits |
-| `example-7` | built-in example 7 |
+| `chain-3-midentry` | three-vertex chain, entry at the middle vertex |
 | `chain-5v-1exit` | five-vertex chain, one exit |
 | `grid-2x3` | 2 by 3 grid, entry `{1, 100}`, exit `{6, 0}` |
 | `grid-3x2` | 3 by 2 grid, entry `{1, 100}`, exit `{6, 0}` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,19 +51,17 @@ primitives  →  utilities  →  scenarioTools  →  examples
                                                                                               →  graphicsTools
 ```
 
-**Optional subpackages.** Several files in the package directory are *not* loaded by `Needs["MFGraphs`"]` and must be loaded explicitly:
+**Optional subpackages.** Two files in the package directory are proper packages that are *not* loaded by `Needs["MFGraphs`"]` and must be loaded explicitly:
 
 ```
 Needs["MFGraphs`"];
 Needs["Tawaf`"];          (* makeTawafScenario, makeTawafSystem, ... *)
 Needs["numericOracle`"];  (* numericOracleClassify, solveScenarioWithOracle *)
-Needs["Jamarat`"];        (* multi-entrance/exit scenario builders *)
-Needs["HardCases`"];      (* curated stress-test scenarios *)
 ```
 
 `numericOracle.wl` is the only file that introduces floating-point work. `solveScenarioWithOracle` is the high-level wrapper for the oracle path; it composes `addSymmetryEqualities` → `numericOracleClassify` → `addOracleEqualities` → `activeSetReduceSystem` and falls back to the unpruned solve when the oracle over-prunes.
 
-**Workbooks (not subpackages).** `MFGraphs/Getting started.wl`, `MFGraphs/TawafWorkbook.wl`, and `MFGraphs/DisjunctInfluenceStudy.wl` are notebook-style worked examples meant to be opened in the Mathematica front end and evaluated cell-by-cell. They are not loadable via `Needs[]`.
+**Workbooks (not subpackages).** `MFGraphs/Getting started.wl`, `MFGraphs/TawafWorkbook.wl`, `MFGraphs/DisjunctInfluenceStudy.wl`, `MFGraphs/Jamarat.wl` (multi-entrance/exit scenario studies), and `MFGraphs/HardCases.wl` (curated stress-test scenarios) are notebook-style worked examples meant to be opened in the Mathematica front end and evaluated cell-by-cell. They are not loadable via `Needs[]` — in particular `Jamarat.wl` and `HardCases.wl` have no `BeginPackage` and run multi-minute solves if evaluated top-to-bottom.
 
 **Composition pipeline.** Every workflow is the same three-step chain, optionally followed by orchestration:
 

--- a/MFGraphs/TawafWorkbook.wl
+++ b/MFGraphs/TawafWorkbook.wl
@@ -56,6 +56,9 @@ If[!StringQ[mfgDir] || mfgDir === "",
 mfgParentDir = ParentDirectory[mfgDir];
 If[!MemberQ[$Path, mfgParentDir], PrependTo[$Path, mfgParentDir]];
 Needs["MFGraphs`"];
+(* Tawaf` is an opt-in subpackage: not loaded by MFGraphs`, and every
+   section below uses makeTawafScenario/makeTawafSystem/tawafDensities. *)
+Needs["Tawaf`"];
 
 
 (* ::Subsection:: *)

--- a/MFGraphs/Tests/README.md
+++ b/MFGraphs/Tests/README.md
@@ -4,17 +4,19 @@ This directory contains the active scenario-kernel tests and archived legacy/sol
 
 ## Runner suites (`Scripts/RunTests.wls`)
 
-- `fast`: active scenario-kernel suite.
+- `fast`: the 12 active suites (see below).
 - `all`: alias for `fast`.
-- `archive`: archived compatibility/legacy suites (explicit use only).
-- `full`: `fast + archive`.
+- `oracle`: `numeric-oracle.mt` + `fictitiousPlay.mt` (the opt-in `numericOracle`` classifier suites).
+- `archive`: archived compatibility/legacy suites (explicit use only; they target the removed legacy API and are not expected to pass).
+- `full`: `fast` + `fictitiousPlay.mt` + `archive`.
 
 ## File groups
 
-- Active tests: root `.mt` files (`scenario-kernel`, `symbolic-unknowns`, `reduce-system`, `scenario-consistency`, `graphicsTools`, `orchestration`).
+- Active tests (`fast`): `scenario-kernel`, `symbolic-unknowns`, `reduce-system`, `scenario-consistency`, `graphicsTools`, `orchestration`, `dnf-reducer`, `boolean-minimize`, `tawaf`, `example-coverage`, `numeric-oracle`, `utilities`.
+- Oracle extra: `fictitiousPlay` (runs in `oracle` and `full`, not `fast`).
 - Archived tests: `archive/` (legacy or non-core surfaces).
 
 ## Notes
 
-- `reference_solutions.json` is generated fixture data for solver regression checks.
+- The live solution cache used by `example-coverage.mt` is `<repo>/solutions/*.wxf` (see `Scripts/SolutionCacheHelpers.wls`); `reference_solutions.json` is a legacy fixture referenced only by archived scripts.
 - Keep `archive/` tests out of CI unless intentionally validating legacy compatibility.

--- a/MFGraphs/utilities.wl
+++ b/MFGraphs/utilities.wl
@@ -32,8 +32,10 @@ criticalCongestionSystemQ::usage =
 "criticalCongestionSystemQ[sys] returns True if the system is a critical congestion system (Alpha == 1 everywhere).";
 
 withCriticalCongestionSolver::usage =
-"withCriticalCongestionSolver[sys, solverName, bodyFunc] handles validation, input building, \
-and rule attachment for critical-congestion structural solvers.";
+"withCriticalCongestionSolver[sys, solverName, bodyFunc, buildInputsFunc, attachRulesFunc] \
+guards on critical congestion, calls buildInputsFunc[sys] to obtain {constraints, allVars, \
+rulesAcc}, evaluates bodyFunc[constraints, allVars], and returns attachRulesFunc[result, \
+rulesAcc]. Shared shell for the critical-congestion structural solvers.";
 
 withCriticalCongestionGuard::usage =
 "withCriticalCongestionGuard[sys, solverName, body] evaluates body only when sys is a \

--- a/README.md
+++ b/README.md
@@ -229,15 +229,18 @@ From repository root:
 
 ```bash
 wolframscript -file Scripts/RunTests.wls fast
-wolframscript -file MFGraphs/Tests/scenario-kernel.mt
-wolframscript -file MFGraphs/Tests/symbolic-unknowns.mt
+wolframscript -file Scripts/RunSingleTest.wls MFGraphs/Tests/scenario-kernel.mt
 ```
 
+(`.mt` files cannot be run directly with `wolframscript -file` — they rely on
+the runner to load the package and wrap them in `TestReport`.)
+
 Current active runner suites (`Scripts/RunTests.wls`):
-- `fast`: `scenario-kernel.mt`, `symbolic-unknowns.mt`, `reduce-system.mt`, `scenario-consistency.mt`, `graphicsTools.mt`, `orchestration.mt`, `dnf-reducer.mt`, `boolean-minimize.mt`, `tawaf.mt`, `example-coverage.mt`, `numeric-oracle.mt`
+- `fast`: `scenario-kernel.mt`, `symbolic-unknowns.mt`, `reduce-system.mt`, `scenario-consistency.mt`, `graphicsTools.mt`, `orchestration.mt`, `dnf-reducer.mt`, `boolean-minimize.mt`, `tawaf.mt`, `example-coverage.mt`, `numeric-oracle.mt`, `utilities.mt`
 - `all`: alias for `fast`
+- `oracle`: `numeric-oracle.mt` + `fictitiousPlay.mt` (opt-in classifier suites)
 - `archive`: archived compatibility/legacy suites (explicit use only)
-- `full`: `fast + archive`
+- `full`: `fast` + `fictitiousPlay.mt` + `archive`
 
 ## Repository structure
 
@@ -245,6 +248,7 @@ Current active runner suites (`Scripts/RunTests.wls`):
 MFGraphs/
   MFGraphs.wl
   primitives.wl
+  utilities.wl
   scenarioTools.wl
   examples.wl
   unknownsTools.wl

--- a/Scripts/GenerateDocs.wls
+++ b/Scripts/GenerateDocs.wls
@@ -12,6 +12,7 @@ Print["Generating API Reference..."];
 
 $PublicContexts = {
   "primitives`",
+  "utilities`",
   "scenarioTools`",
   "examples`",
   "unknownsTools`",

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -2,21 +2,63 @@
 
 This directory contains active maintenance scripts and an `archive/` folder with legacy or experiment-only scripts.
 
-## Active scripts
+## Test and docs infrastructure
 
-- `RunTests.wls`: suite runner (`fast`, `all`, `archive`, `full`).
+- `RunTests.wls`: suite runner (`fast`, `all`, `oracle`, `archive`, `full`).
 - `RunSingleTest.wls`: run one `.mt` file and print pass/fail summary.
-- `GenerateDocs.wls`: regenerate API documentation artifacts.
+- `GenerateDocs.wls`: regenerate `API_REFERENCE.md` from `::usage` strings.
 - `AuditPublicAPI.py`: API surface inventory/audit helper.
 - `CheckCriticalSurfaceTests.wls`: gate checks for critical-surface test policy.
-- `BenchmarkSystemSolver.wls`: DNF-first scenario-kernel solver benchmark; use `--solver` to compare alternatives.
+- `CheckReportPlaceholders.wls`: fails when committed history/report files still contain placeholder prose.
+
+## Benchmarks
+
+- `BenchmarkSystemSolver.wls`: **the active solver benchmark** (required for before/after runs on solver-sensitive PRs). Flags: `--solver dnf|optimizeddnf|activeset|reduce|boolean|findinstance`, `--tag`, `--timeout`, `--case`. Appends a history entry to `BENCHMARKS.md` and stores solutions under `Results/`.
 - `BenchmarkReduceSystem.wls`: historical focused benchmark for raw `reduceSystem`.
-- `ProfileScenarioKernel.wls`: non-mutating staged profiler for scenario construction, symbolic unknown construction, system construction, and solver time.
+- `BenchmarkDNF.wls`: DNF reducer micro-benchmark (assumes cwd is the repo root).
+- `BenchmarkBFSDNFReduce.wls`: head-to-head `dnfReduceSystem` (DFS) vs `bfsDNFReduceSystem` (BFS).
+- `BenchmarkActiveSetLPPrecheck.wls`: head-to-head `activeSetReduceSystem` with/without `LPPrecheck`.
+- `BaselinePruningBenchmark.wls`: measures the paper §5.4 `booleanReduceSystem` baseline (materializes all complementarity branches).
+- `PaperBenchmark.wls`: paper §5.4 benchmark (A.2) + C.9 smoke test; modes `merge|fork|jamarat|all`.
+- `SweepBranchStateThreshold.wls`: sweeps `$optimizedDNFVarThreshold` to find the branch-state/dnfReduce crossover.
 
-## Analysis/report helpers
+## Profilers
 
-- `ExtractPaperResults.wls`, `RegenPaperFigures.wls`, `CheckReportPlaceholders.wls`
-- `MergeBenchmarkResults.py`
+- `ProfileScenarioKernel.wls`: non-mutating staged profiler for scenario → unknowns → system → solver (`--solver`, `--case`, `--timeout`).
+- `ProfileDNFReduce.wls`: DNF reducer profiler (`--case name|all`, `--order`, `--timeout`).
+- `ProfileDNFProcedural.wls`: baseline profiler for `dnfReduceProcedural`.
+
+## Solver comparison and diagnostics
+
+- `CompareDNFRecursiveProcedural.wls`: correctness comparison of `dnfReduce` (recursive) vs `dnfReduceProcedural` (stack-based); writes a markdown report.
+- `CompareSingleCase.wls`: runs the solver columns on one case in a fresh kernel (for big grids); delegates single stages to `CompareSingleCaseBC.wls` (BooleanConvert), `CompareSingleCaseBM.wls` (`booleanMinimizeSystem`), and `CompareSingleCaseBMR.wls` (`booleanMinimizeReduceSystem`).
+- `CompareSolverSolutions.wls`: compares residuals/rules between stored benchmark solution files (`Results/*_latest.wl`).
+- `AnalyzeSolutionBranches.wls`: analyzes residual solution branches by entry costs.
+- `NonCriticalDiagnostic.wls`: convergence diagnostic for the iterative non-critical (Alpha != 1) solver.
+
+## Solution cache
+
+- `RegenerateSolutions.wls`: regenerates cached example solutions under `<repo>/solutions/*.wxf`.
+- `SolutionCacheHelpers.wls`: shared cache helpers sourced by `RegenerateSolutions.wls` and `MFGraphs/Tests/example-coverage.mt` (not a standalone CLI).
+
+## Paper artifacts
+
+These regenerate material for the stationary-MFG paper; the Regen*/Render*/NonCritical scripts write into the Overleaf/Dropbox paper directory and are machine-specific.
+
+- `RegenPaperFigures.wls`: regenerates the paper's network diagrams.
+- `RegenPaperResults.wls`: regenerates the paper's §5 result plots.
+- `RenderJamaratFigures.wls`: renders the Jamarat `richNetworkPlot` figures as PDFs.
+- `ExtractPaperResults.wls`: extracts/validates paper-tier benchmark results (consumes the archived `BenchmarkSuite.wls` output format).
+- `MergeBenchmarkResults.py`: merges `Results/benchmark_*.json` outputs (archived pipeline format).
+
+## Research
+
+- `Research/`: self-contained investigation scripts with their committed result data (branching studies and related experiments).
+
+## One-off snapshots
+
+- `perf_review_targeted.wls` + `perf_review_targeted_results.json`: targeted performance-review snapshot.
+- `benchmark_preprocessing_results.json`: preprocessing benchmark snapshot (its producer now lives in `archive/`).
 
 ## Legacy notes
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -105,8 +105,12 @@ symbols. Use the active benchmark unless you are explicitly working on legacy
 solver migration:
 
 ```bash
-wolframscript -file Scripts/BenchmarkReduceSystem.wls --tag "my change"
+wolframscript -file Scripts/BenchmarkSystemSolver.wls --tag "my change" --timeout 60
 ```
+
+(`Scripts/BenchmarkReduceSystem.wls` still exists but is the historical
+focused benchmark for raw `reduceSystem`; `BenchmarkSystemSolver.wls` is the
+active benchmark referenced by the PR policy.)
 
 ## Getting More Help
 


### PR DESCRIPTION
## Summary

Documentation-sync batch from the full repo sweep — every item below is a doc statement that was verified false against the code.

- **CLAUDE.md**: `Needs["Jamarat`"]` / `Needs["HardCases`"]` cannot work — neither file has a `BeginPackage`, so `Needs` evaluates them top-to-bottom (running multi-minute solves) and then fails with `Needs::nocont`. Reclassified as workbooks, consistent with README/GEMINI/TROUBLESHOOTING.
- **TawafWorkbook.wl**: never loaded the opt-in `Tawaf`` context, so on a fresh kernel every cell from §1.1 on returned unevaluated. Adds the missing `Needs["Tawaf`"]`.
- **GenerateDocs.wls / API_REFERENCE.md**: `$PublicContexts` omitted `utilities``, so its 11 public `::usage` symbols were missing from the generated reference. Added and regenerated (+44 lines; the rest of the file is byte-identical, confirming no other drift).
- **README.md**: removed the dead `wolframscript -file MFGraphs/Tests/<file>.mt` commands (`Test` is not a System symbol — the file evaluates silently and does nothing) in favor of `RunSingleTest.wls`; fixed suite lists (`utilities.mt` in `fast`, missing `oracle` suite, `full` = fast + fictitiousPlay + archive); added `utilities.wl` to the structure tree.
- **MFGraphs/Tests/README.md**: same suite-list sync; documents that the live solution cache is `solutions/*.wxf` and `reference_solutions.json` is a legacy fixture.
- **TROUBLESHOOTING.md**: pointed the benchmarking section at `BenchmarkSystemSolver.wls` (the active benchmark per CLAUDE.md/CONTRIBUTING/BENCHMARKS) instead of the historical `BenchmarkReduceSystem.wls`.
- **BENCHMARKS.md**: current-cases table listed the removed `example-7` and omitted `chain-3-midentry`, which `$BenchCases` actually runs.
- **Scripts/README.md**: rewritten as a genuinely full inventory — the old file covered 15 of ~36 items (even `ProfileDNFReduce.wls` from CLAUDE.md's own Commands block was undocumented) while CLAUDE.md calls it "the full inventory". Grouped by role; descriptions sourced from each script's own header comment.

## Tests

Docs-only apart from the workbook `Needs` line and the GenerateDocs context list. Fast suite: **342 passed, 0 failed**. API reference regenerated via `Scripts/GenerateDocs.wls` (not hand-edited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)