### PR TITLE
feat(docs): GenerateDocs arity lint — refuse to publish usage strings that contradict definitions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,8 @@ wolframscript -file Scripts/ProfileScenarioKernel.wls --case example-12 --timeou
 # Profile the DNF reducer
 wolframscript -file Scripts/ProfileDNFReduce.wls --case all --order all --timeout 60
 
-# Regenerate API_REFERENCE.md from ::usage strings (do not edit it by hand)
+# Regenerate API_REFERENCE.md from ::usage strings (do not edit it by hand);
+# exits nonzero without writing if a usage call pattern contradicts its definition's arity
 wolframscript -file Scripts/GenerateDocs.wls
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,11 @@ wolframscript -file Scripts/GenerateDocs.wls
 # Regenerates API_REFERENCE.md
 ```
 
+The script arity-lints every documented call pattern against the actual
+definitions and exits nonzero **without regenerating** when they disagree —
+check the exit code; a failed run leaves the previous `API_REFERENCE.md`
+untouched.
+
 ### Updating developer guides
 - **CLAUDE.md** is the canonical AI/developer workflow guide
 - **GEMINI.md** is a synchronized companion reference for the same workflows

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,8 +92,9 @@ wolframscript -file Scripts/GenerateDocs.wls
 # Regenerates API_REFERENCE.md
 ```
 
-The script arity-lints every documented call pattern against the actual
-definitions and exits nonzero **without regenerating** when they disagree —
+The script arity-lints every checkable documented call pattern against the
+actual definitions and exits nonzero **without regenerating** when they
+disagree —
 check the exit code; a failed run leaves the previous `API_REFERENCE.md`
 untouched.
 

--- a/Scripts/GenerateDocs.wls
+++ b/Scripts/GenerateDocs.wls
@@ -42,16 +42,209 @@ mdContent = {
    symbol metadata directly. *)
 readUsage[name_String] := ToExpression[name <> "::usage", InputForm];
 
+(* ---------------------------------------------------------------------- *)
+(* Arity lint. A usage string that shows name[a, b] while the definition   *)
+(* takes five arguments publishes a wrong signature into API_REFERENCE.md. *)
+(* Compare every call pattern in each usage string against the arities the *)
+(* symbol's DownValues/SubValues accept, and refuse to export on mismatch. *)
+(* Symbols with no DownValues/SubValues (inert constructors like j, u,     *)
+(* typed heads, $-variables) are skipped and tallied in the summary.       *)
+(*                                                                          *)
+(* Known limitations: each usage is scanned only for its own symbol's call *)
+(* patterns (signatures of OTHER symbols quoted in the text are not        *)
+(* checked); context-qualified occurrences (pkg`name[...]) are skipped;    *)
+(* sequence-shaped slots (PatternSequence, Longest, Repeated with a count  *)
+(* spec) are scored conservatively -- none occur in the package today.     *)
+(* ---------------------------------------------------------------------- *)
+
+(* Word-boundary class for WL identifiers. Mirrors the boundary regex in
+   Scripts/AuditPublicAPI.py (tests_for_symbol) -- keep the two in sync. *)
+symbolNameCharQ[c_String] :=
+  StringMatchQ[c, LetterCharacter | DigitCharacter | "$" | "`"];
+
+(* Scan one bracket group starting at openIdx (the "["). Returns
+   {tag, posAfterGroup} where tag is the argument count, "Ellipsis" for a
+   group containing a top-level ... (documentation shorthand, not an arity
+   claim), or "Unterminated" when the group never closes. Depth-counts
+   [] {} () <||> and skips string literals, so only top-level commas count. *)
+scanBracketGroup[usage_String, openIdx_Integer] :=
+  Module[{len = StringLength[usage], i = openIdx + 1, depth = 1, commas = 0,
+          sawContent = False, inQuote = False, dotRun = 0, hasEllipsis = False,
+          c, c2},
+    While[i <= len && depth > 0,
+      c  = StringTake[usage, {i}];
+      c2 = If[i < len, StringTake[usage, {i + 1}], ""];
+      Which[
+        inQuote,                 If[c === "\"", inQuote = False],
+        c === "\"",              inQuote = True,
+        c === "<" && c2 === "|", depth++; i++,
+        c === "|" && c2 === ">", depth--; i++,
+        c === "[" || c === "{" || c === "(", depth++,
+        c === "]" || c === "}" || c === ")", depth--,
+        c === "," && depth === 1, commas++
+      ];
+      If[depth > 0,
+        If[!StringMatchQ[c, WhitespaceCharacter], sawContent = True];
+        dotRun = If[c === "." && depth === 1 && !inQuote, dotRun + 1, 0];
+        If[dotRun >= 3, hasEllipsis = True]
+      ];
+      i++
+    ];
+    Which[
+      depth > 0,   {"Unterminated", i},
+      hasEllipsis, {"Ellipsis", i},
+      True,        {If[sawContent, commas + 1, 0], i}
+    ]
+  ];
+
+(* All call-pattern occurrences of shortName in the usage text. Returns
+   <|"Pairs" -> {{firstArity, secondArityOrMissing}, ...},
+     "Ellipsis" -> n, "Unterminated" -> n|>.
+   Occurrences preceded by a name character (suffix of a longer identifier,
+   or context-qualified) or by a double quote (a signature quoted as example
+   text) are not arity claims and are skipped. A chained second group
+   (name[...][...]) is captured for the curried SubValues check. *)
+scanUsageCallPatterns[shortName_String, usage_String] :=
+  Module[{len = StringLength[usage], starts, pairs = {}, nEllipsis = 0,
+          nUnterminated = 0, prev},
+    starts = First /@ StringPosition[usage, shortName <> "["];
+    Do[
+      Module[{openIdx = start + StringLength[shortName], tag1, next1,
+              tag2 = Missing["NoSecondGroup"]},
+        If[start > 1,
+          prev = StringTake[usage, {start - 1}];
+          If[symbolNameCharQ[prev] || prev === "\"", Continue[]]
+        ];
+        {tag1, next1} = scanBracketGroup[usage, openIdx];
+        Which[
+          tag1 === "Unterminated", nUnterminated++,
+          tag1 === "Ellipsis",     nEllipsis++,
+          True,
+            If[next1 <= len && StringTake[usage, {next1}] === "[",
+              Module[{t2, n2},
+                {t2, n2} = scanBracketGroup[usage, next1];
+                If[IntegerQ[t2], tag2 = t2]
+              ]
+            ];
+            AppendTo[pairs, {tag1, tag2}]
+        ]
+      ],
+      {start, starts}
+    ];
+    <|"Pairs" -> pairs, "Ellipsis" -> nEllipsis, "Unterminated" -> nUnterminated|>
+  ];
+
+(* {min, max} argument count contributed by a single held argument slot. *)
+slotRange[h_Hold] :=
+  Replace[h, {
+    Hold[Verbatim[Pattern][_, p_]]     :> slotRange[Hold[p]],
+    Hold[Verbatim[PatternTest][p_, _]] :> slotRange[Hold[p]],
+    Hold[Verbatim[Condition][p_, _]]   :> slotRange[Hold[p]],
+    Hold[_OptionsPattern]              :> {0, Infinity},
+    Hold[_Optional]                    :> {0, 1},
+    Hold[_BlankNullSequence]           :> {0, Infinity},
+    Hold[_BlankSequence]               :> {1, Infinity},
+    Hold[_RepeatedNull]                :> {0, Infinity},
+    Hold[_Repeated]                    :> {1, Infinity},
+    _                                  :> {1, 1}
+  }];
+
+defArityRange[Hold[args___]] :=
+  Module[{ranges = slotRange /@ (List @@ Map[Hold, Hold[args]])},
+    {Total[ranges[[All, 1]]], Total[ranges[[All, 2]]]}
+  ];
+
+(* Strip whole-LHS Conditions, repeatedly for stacked f[x_] /; c1 /; c2 --
+   an unstripped Condition head would itself be miscounted as a 2-argument
+   call by the extraction below. *)
+stripLhsCondition = Verbatim[HoldPattern][Verbatim[Condition][l_, _]] :> HoldPattern[l];
+
+(* Arity ranges per definition. "Inner" is what a usage's first bracket
+   group must satisfy (DownValues plus the inner application of curried
+   SubValues); "Outer" is what a chained second group must satisfy. The
+   _Symbol head restriction makes curry depth >= 3 fall into the
+   uncheckable pool instead of mis-attributing bracket groups. *)
+definitionArityRanges[fullName_String] :=
+  Module[{dvs, svs},
+    dvs = ToExpression[fullName, InputForm, DownValues][[All, 1]] //. stripLhsCondition;
+    svs = ToExpression[fullName, InputForm, SubValues][[All, 1]] //. stripLhsCondition;
+    <|
+      "Inner" -> Join[
+        defArityRange /@ Cases[dvs, Verbatim[HoldPattern][_Symbol[args___]] :> Hold[args]],
+        defArityRange /@ Cases[svs, Verbatim[HoldPattern][_Symbol[args___][___]] :> Hold[args]]
+      ],
+      "Outer" ->
+        (defArityRange /@ Cases[svs, Verbatim[HoldPattern][_Symbol[___][args___]] :> Hold[args]])
+    |>
+  ];
+
+(* One shared per-symbol pass feeds both the lint and the export loop, so
+   what is linted is exactly what is published. *)
+usageEntries = Map[{#, Last @ StringSplit[#, "`"], readUsage[#]} &, publicSymbols];
+
+arityIssues = {};
+lintWarnings = {};
+checkedCount = 0; noPatternCount = 0; noDefsCount = 0; ellipsisCount = 0;
+
 Do[
-  symName = Last @ StringSplit[s, "`"];
-  usage = readUsage[s];
-  If[StringQ[usage],
-    AppendTo[mdContent, "## " <> symName];
+  Module[{fullName, shortName, usage, scan, pairs, ranges, badFirst,
+          seconds, badSecond},
+    {fullName, shortName, usage} = entry;
+    If[!StringQ[usage], Continue[]];
+    scan = scanUsageCallPatterns[shortName, usage];
+    ellipsisCount += scan["Ellipsis"];
+    If[scan["Unterminated"] > 0,
+      AppendTo[lintWarnings,
+        fullName <> ": unterminated call group in usage text (occurrence not checked)"]];
+    pairs = scan["Pairs"];
+    If[pairs === {}, noPatternCount++; Continue[]];
+    ranges = definitionArityRanges[fullName];
+    If[ranges["Inner"] === {}, noDefsCount++; Continue[]];
+    checkedCount++;
+    badFirst = Select[DeleteDuplicates[pairs[[All, 1]]],
+      Function[d, NoneTrue[ranges["Inner"], #[[1]] <= d <= #[[2]] &]]];
+    seconds = DeleteDuplicates[Cases[pairs, {_, a2_Integer} :> a2]];
+    badSecond = If[ranges["Outer"] === {}, {},
+      Select[seconds, Function[d, NoneTrue[ranges["Outer"], #[[1]] <= d <= #[[2]] &]]]];
+    If[badFirst =!= {},
+      AppendTo[arityIssues,
+        fullName <> ": usage shows arity " <> ToString[badFirst] <>
+          ", definitions accept " <> ToString[ranges["Inner"]]]];
+    If[badSecond =!= {},
+      AppendTo[arityIssues,
+        fullName <> ": usage shows second-group arity " <> ToString[badSecond] <>
+          ", curried definitions accept " <> ToString[ranges["Outer"]]]]
+  ],
+  {entry, usageEntries}
+];
+
+Scan[Print["Arity lint warning: ", #] &, lintWarnings];
+If[arityIssues =!= {},
+  Print["ARITY LINT FAILED -- usage strings disagree with definitions:"];
+  Scan[Print["  ", #] &, arityIssues];
+  Print["API_REFERENCE.md was NOT regenerated. Fix the ::usage strings (or definitions) first."];
+  Exit[1]
+];
+If[checkedCount === 0,
+  Print["ARITY LINT FAILED -- zero symbols were checked; the definition introspection no longer matches the package's definition style."];
+  Print["API_REFERENCE.md was NOT regenerated."];
+  Exit[1]
+];
+Print["Arity lint: ", checkedCount, " symbols checked (",
+  noPatternCount, " without call patterns, ",
+  noDefsCount, " without introspectable definitions",
+  If[ellipsisCount > 0,
+    ", " <> ToString[ellipsisCount] <> " ellipsis shorthand groups skipped", ""],
+  "). All call patterns match."];
+
+Do[
+  If[StringQ[entry[[3]]],
+    AppendTo[mdContent, "## " <> entry[[2]]];
     AppendTo[mdContent, ""];
-    AppendTo[mdContent, usage];
+    AppendTo[mdContent, entry[[3]]];
     AppendTo[mdContent, ""];
   ],
-  {s, publicSymbols}
+  {entry, usageEntries}
 ];
 
 exportPath = FileNameJoin[{$RepoRoot, "API_REFERENCE.md"}];

--- a/Scripts/GenerateDocs.wls
+++ b/Scripts/GenerateDocs.wls
@@ -115,6 +115,9 @@ scanUsageCallPatterns[shortName_String, usage_String] :=
           prev = StringTake[usage, {start - 1}];
           If[symbolNameCharQ[prev] || prev === "\"", Continue[]]
         ];
+        (* name[[...]] is a Part expression in prose, not a call pattern. *)
+        If[openIdx < len && StringTake[usage, {openIdx + 1}] === "[",
+          Continue[]];
         {tag1, next1} = scanBracketGroup[usage, openIdx];
         Which[
           tag1 === "Unterminated", nUnterminated++,
@@ -123,7 +126,11 @@ scanUsageCallPatterns[shortName_String, usage_String] :=
             If[next1 <= len && StringTake[usage, {next1}] === "[",
               Module[{t2, n2},
                 {t2, n2} = scanBracketGroup[usage, next1];
-                If[IntegerQ[t2], tag2 = t2]
+                Which[
+                  t2 === "Unterminated", nUnterminated++,
+                  t2 === "Ellipsis",     nEllipsis++,
+                  True,                  tag2 = t2
+                ]
               ]
             ];
             AppendTo[pairs, {tag1, tag2}]
@@ -234,7 +241,8 @@ Print["Arity lint: ", checkedCount, " symbols checked (",
   noPatternCount, " without call patterns, ",
   noDefsCount, " without introspectable definitions",
   If[ellipsisCount > 0,
-    ", " <> ToString[ellipsisCount] <> " ellipsis shorthand groups skipped", ""],
+    ", " <> ToString[ellipsisCount] <> " ellipsis shorthand group" <>
+      If[ellipsisCount === 1, "", "s"] <> " skipped", ""],
   "). All call patterns match."];
 
 Do[


### PR DESCRIPTION
## Summary

Adds an arity lint to `Scripts/GenerateDocs.wls`: every call pattern in each public `::usage` string (e.g. `makeSystem[s, unk]`) is compared against the argument-count ranges the symbol's `DownValues`/`SubValues` actually accept. On mismatch the script prints the offenders and exits 1 **without regenerating** `API_REFERENCE.md`.

Motivation: the sweep found `withCriticalCongestionSolver::usage` documenting 3 arguments against a 5-argument definition, and PR #221 briefly published that wrong signature into the generated reference. This lint makes that class of drift mechanically impossible to publish. Positive control (with `utilities`` temporarily in `$PublicContexts` on this branch, where the usage bug still exists): exits 1 with `withCriticalCongestionSolver: usage shows arity {3}, definitions accept {{5, 5}}`.

## Review-hardened

An xhigh `/code-review` (10 finder angles + adversarial verification, 14 verified findings) ran against the first draft; all self-contained findings are fixed in this version:

- **Ellipsis shorthand** `f[x, ...]` is recognized (top-level `...` in a group) and skipped as a non-claim instead of counted as an argument — the review found 9 live nested occurrences plus `solveScenario[..., solver]` passing only via an optional arg, and a spurious hard-fail one rewording away.
- **Quote handling**: signatures quoted as example text (`"f[a,b]"`) are skipped; an unpaired quote now yields a named warning instead of silently dropping the occurrence.
- **Curried symbols**: both bracket groups are checked — the second group is validated against the SubValues outer application (7 live curried publics were previously half-linted); curry depth ≥ 3 is skipped into the uncheckable tally instead of mis-attributing groups (`_Symbol` head restriction).
- **Stacked LHS conditions** (`f[x_] /; c1 /; c2`) strip fully via `//.` (kernel-verified miscount otherwise). The review also adversarially confirmed `stripLhsCondition` and the `Hold` apparatus are load-bearing, not removable.
- **Coverage accounting**: the summary reports checked/skipped tallies (today: 71 checked, 15 without call patterns, 10 without introspectable definitions, 1 ellipsis group) and a zero-checked run hard-fails — the lint cannot decay into a green no-op.
- **Shared per-symbol pass** feeds both the lint and the export loop, so what is linted is exactly what is published; the word-boundary class carries a keep-in-sync comment referencing `AuditPublicAPI.py`.
- CONTRIBUTING.md and CLAUDE.md now state the script can refuse and that a failed run leaves the previous `API_REFERENCE.md` untouched.

## Explicit non-goals (from the review, deliberately not in this PR)

- **Enforcement point**: the lint fires only on manual docs regeneration; definition drift with no regen is invisible to the fast suite. The review confirmed the check is implementable as a fast-suite `.mt` — deferred to a follow-up PR because it touches `RunTests.wls`/suite tables that open PRs (#220, #221) also touch.
- Cross-symbol call patterns inside another symbol's usage, context-qualified occurrences, and sequence-shaped slots (`PatternSequence`, `Repeated` counts — zero instances in the package) are documented limitations in the header comment.
- **Merge-order note**: content-coupled with #221 — if #221's usage-fix commit (`42336e9`) ever gets dropped while its `utilities`` context addition survives, this lint will (correctly) fail the next docs regen.

## Verification

- Pass run: exit 0, `API_REFERENCE.md` byte-identical.
- Positive control: exit 1, file untouched.
- 14-case synthetic self-test (scanner edge cases, stacked conditions, triple curry, live `altSwitch` inner/outer): all pass.
- Fast suite: **342 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)