### PR TITLE
feat(tests): enforce the usage-arity lint in the fast suite via shared UsageArityLint.wls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ Active `.mt` files under `MFGraphs/Tests/`:
 | `boolean-minimize.mt` | `booleanMinimizeSystem` / `booleanMinimizeReduceSystem` |
 | `orchestration.mt` | `solveScenario` / `SolveMFG`, full pipeline, and `clearSolveCache` memoization |
 | `utilities.mt` | typed-object infra (`mfgTypedQ`/`mfgData`), rule management, boundary exactification, critical-congestion guard |
+| `usage-arity.mt` | usage-string call patterns vs definition arities (shared lint with `GenerateDocs.wls` via `Scripts/UsageArityLint.wls`) |
 | `graphicsTools.mt` | `rawNetworkPlot`, `richNetworkPlot` |
 | `tawaf.mt` | unrolled-circumambulation scenario builder (opt-in `Tawaf`` context) |
 | `example-coverage.mt` | per-example smoke + cached-solution regression check across every key in `$ExampleScenarios` |

--- a/MFGraphs/Tests/README.md
+++ b/MFGraphs/Tests/README.md
@@ -4,7 +4,7 @@ This directory contains the active scenario-kernel tests and archived legacy/sol
 
 ## Runner suites (`Scripts/RunTests.wls`)
 
-- `fast`: the 12 active suites (see below).
+- `fast`: the 13 active suites (see below).
 - `all`: alias for `fast`.
 - `oracle`: `numeric-oracle.mt` + `fictitiousPlay.mt` (the opt-in `numericOracle`` classifier suites).
 - `archive`: archived compatibility/legacy suites (explicit use only; they target the removed legacy API and are not expected to pass).
@@ -12,7 +12,7 @@ This directory contains the active scenario-kernel tests and archived legacy/sol
 
 ## File groups
 
-- Active tests (`fast`): `scenario-kernel`, `symbolic-unknowns`, `reduce-system`, `scenario-consistency`, `graphicsTools`, `orchestration`, `dnf-reducer`, `boolean-minimize`, `tawaf`, `example-coverage`, `numeric-oracle`, `utilities`.
+- Active tests (`fast`): `scenario-kernel`, `symbolic-unknowns`, `reduce-system`, `scenario-consistency`, `graphicsTools`, `orchestration`, `dnf-reducer`, `boolean-minimize`, `tawaf`, `example-coverage`, `numeric-oracle`, `utilities`, `usage-arity`.
 - Oracle extra: `fictitiousPlay` (runs in `oracle` and `full`, not `fast`).
 - Archived tests: `archive/` (legacy or non-core surfaces).
 

--- a/MFGraphs/Tests/usage-arity.mt
+++ b/MFGraphs/Tests/usage-arity.mt
@@ -1,0 +1,45 @@
+(* Usage-arity lint as a fast-suite regression (issue #242): a definition
+   arity change without a docs regeneration must fail here, not lie dormant
+   until the next manual GenerateDocs.wls run. Shares its implementation
+   with Scripts/GenerateDocs.wls via Scripts/UsageArityLint.wls. *)
+
+Module[{root},
+    root = Which[
+        StringQ[$RepoRoot], $RepoRoot,
+        StringQ[$InputFileName] && $InputFileName =!= "",
+            FileNameJoin[{DirectoryName[$InputFileName], "..", ".."}],
+        True, Directory[]
+    ];
+    Get[FileNameJoin[{root, "Scripts", "UsageArityLint.wls"}]]
+];
+
+$usageArityReport = usageArityReport[];
+
+(* Expected value {} means a failure prints the offending mismatch
+   descriptions directly in the test report. *)
+Test[
+    $usageArityReport["Issues"]
+    ,
+    {}
+    ,
+    TestID -> "Usage arity: every checkable documented call pattern matches its definition"
+]
+
+Test[
+    $usageArityReport["Warnings"]
+    ,
+    {}
+    ,
+    TestID -> "Usage arity: no unterminated call groups in usage strings"
+]
+
+(* Decay guard: if the definition introspection stops matching the package's
+   definition style, the lint silently checks nothing -- fail loudly instead.
+   82 symbols are checked as of 2026-07; the floor is deliberately loose. *)
+Test[
+    $usageArityReport["Checked"] >= 50
+    ,
+    True
+    ,
+    TestID -> "Usage arity: coverage has not decayed (at least 50 symbols checked)"
+]

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ wolframscript -file Scripts/RunSingleTest.wls MFGraphs/Tests/scenario-kernel.mt
 the runner to load the package and wrap them in `TestReport`.)
 
 Current active runner suites (`Scripts/RunTests.wls`):
-- `fast`: `scenario-kernel.mt`, `symbolic-unknowns.mt`, `reduce-system.mt`, `scenario-consistency.mt`, `graphicsTools.mt`, `orchestration.mt`, `dnf-reducer.mt`, `boolean-minimize.mt`, `tawaf.mt`, `example-coverage.mt`, `numeric-oracle.mt`, `utilities.mt`
+- `fast`: `scenario-kernel.mt`, `symbolic-unknowns.mt`, `reduce-system.mt`, `scenario-consistency.mt`, `graphicsTools.mt`, `orchestration.mt`, `dnf-reducer.mt`, `boolean-minimize.mt`, `tawaf.mt`, `example-coverage.mt`, `numeric-oracle.mt`, `utilities.mt`, `usage-arity.mt`
 - `all`: alias for `fast`
 - `oracle`: `numeric-oracle.mt` + `fictitiousPlay.mt` (opt-in classifier suites)
 - `archive`: archived compatibility/legacy suites (explicit use only)

--- a/Scripts/GenerateDocs.wls
+++ b/Scripts/GenerateDocs.wls
@@ -8,27 +8,34 @@ $RepoRoot = DirectoryName[DirectoryName[$InputFileName]];
 PrependTo[$Path, $RepoRoot];
 Needs["MFGraphs`"];
 
+(* Shared usage-arity lint (also enforced by MFGraphs/Tests/usage-arity.mt
+   in the fast suite): doc generation refuses to publish a call pattern
+   that contradicts its definition's arity. *)
+Get[FileNameJoin[{$RepoRoot, "Scripts", "UsageArityLint.wls"}]];
+
 Print["Generating API Reference..."];
 
-$PublicContexts = {
-  "primitives`",
-  "utilities`",
-  "scenarioTools`",
-  "examples`",
-  "unknownsTools`",
-  "systemTools`",
-  "solversTools`",
-  "orchestrationTools`",
-  "graphicsTools`"
-};
+report = usageArityReport[];
 
-(* `Names[ctx<>"*"]` already matches `$`-prefixed symbols, so a single pass
-   suffices. ($-symbols are surfaced correctly by `readUsage` below, not here.) *)
-symbols = DeleteDuplicates @ Flatten[Names[# <> "*"] & /@ $PublicContexts];
-publicSymbols = Select[
-  symbols,
-  !StringContainsQ[#, "Private`"] && !StringEndsQ[#, "$"] &
+Scan[Print["Arity lint warning: ", #] &, report["Warnings"]];
+If[report["Issues"] =!= {},
+  Print["ARITY LINT FAILED -- usage strings disagree with definitions:"];
+  Scan[Print["  ", #] &, report["Issues"]];
+  Print["API_REFERENCE.md was NOT regenerated. Fix the ::usage strings (or definitions) first."];
+  Exit[1]
 ];
+If[report["Checked"] === 0,
+  Print["ARITY LINT FAILED -- zero symbols were checked; the definition introspection no longer matches the package's definition style."];
+  Print["API_REFERENCE.md was NOT regenerated."];
+  Exit[1]
+];
+Print["Arity lint: ", report["Checked"], " symbols checked (",
+  report["NoPattern"], " without call patterns, ",
+  report["NoDefs"], " without introspectable definitions",
+  If[report["Ellipsis"] > 0,
+    ", " <> ToString[report["Ellipsis"]] <> " ellipsis shorthand group" <>
+      If[report["Ellipsis"] === 1, "", "s"] <> " skipped", ""],
+  "). All call patterns match."];
 
 mdContent = {
   "# MFGraphs API Reference",
@@ -37,215 +44,6 @@ mdContent = {
   ""
 };
 
-(* Symbols with values (e.g. $MFGraphsVerbose = False) cause
-   `Information[Symbol[s], "Usage"]` to read the value's usage instead of the
-   symbol's. Use `MessageName` on a held symbol so the usage is read off the
-   symbol metadata directly. *)
-readUsage[name_String] := ToExpression[name <> "::usage", InputForm];
-
-(* ---------------------------------------------------------------------- *)
-(* Arity lint. A usage string that shows name[a, b] while the definition   *)
-(* takes five arguments publishes a wrong signature into API_REFERENCE.md. *)
-(* Compare every call pattern in each usage string against the arities the *)
-(* symbol's DownValues/SubValues accept, and refuse to export on mismatch. *)
-(* Symbols with no DownValues/SubValues (inert constructors like j, u,     *)
-(* typed heads, $-variables) are skipped and tallied in the summary.       *)
-(*                                                                          *)
-(* Known limitations: each usage is scanned only for its own symbol's call *)
-(* patterns (signatures of OTHER symbols quoted in the text are not        *)
-(* checked); context-qualified occurrences (pkg`name[...]) are skipped;    *)
-(* sequence-shaped slots (PatternSequence, Longest, Repeated with a count  *)
-(* spec) are scored conservatively -- none occur in the package today.     *)
-(* ---------------------------------------------------------------------- *)
-
-(* Word-boundary class for WL identifiers. Mirrors the boundary regex in
-   Scripts/AuditPublicAPI.py (tests_for_symbol) -- keep the two in sync. *)
-symbolNameCharQ[c_String] :=
-  StringMatchQ[c, LetterCharacter | DigitCharacter | "$" | "`"];
-
-(* Scan one bracket group starting at openIdx (the "["). Returns
-   {tag, posAfterGroup} where tag is the argument count, "Ellipsis" for a
-   group containing a top-level ... (documentation shorthand, not an arity
-   claim), or "Unterminated" when the group never closes. Depth-counts
-   [] {} () <||> and skips string literals, so only top-level commas count. *)
-scanBracketGroup[usage_String, openIdx_Integer] :=
-  Module[{len = StringLength[usage], i = openIdx + 1, depth = 1, commas = 0,
-          sawContent = False, inQuote = False, dotRun = 0, hasEllipsis = False,
-          c, c2},
-    While[i <= len && depth > 0,
-      c  = StringTake[usage, {i}];
-      c2 = If[i < len, StringTake[usage, {i + 1}], ""];
-      Which[
-        inQuote,                 If[c === "\"", inQuote = False],
-        c === "\"",              inQuote = True,
-        c === "<" && c2 === "|", depth++; i++,
-        c === "|" && c2 === ">", depth--; i++,
-        c === "[" || c === "{" || c === "(", depth++,
-        c === "]" || c === "}" || c === ")", depth--,
-        c === "," && depth === 1, commas++
-      ];
-      If[depth > 0,
-        If[!StringMatchQ[c, WhitespaceCharacter], sawContent = True];
-        dotRun = If[c === "." && depth === 1 && !inQuote, dotRun + 1, 0];
-        If[dotRun >= 3, hasEllipsis = True]
-      ];
-      i++
-    ];
-    Which[
-      depth > 0,   {"Unterminated", i},
-      hasEllipsis, {"Ellipsis", i},
-      True,        {If[sawContent, commas + 1, 0], i}
-    ]
-  ];
-
-(* All call-pattern occurrences of shortName in the usage text. Returns
-   <|"Pairs" -> {{firstArity, secondArityOrMissing}, ...},
-     "Ellipsis" -> n, "Unterminated" -> n|>.
-   Occurrences preceded by a name character (suffix of a longer identifier,
-   or context-qualified) or by a double quote (a signature quoted as example
-   text) are not arity claims and are skipped. A chained second group
-   (name[...][...]) is captured for the curried SubValues check. *)
-scanUsageCallPatterns[shortName_String, usage_String] :=
-  Module[{len = StringLength[usage], starts, pairs = {}, nEllipsis = 0,
-          nUnterminated = 0, prev},
-    starts = First /@ StringPosition[usage, shortName <> "["];
-    Do[
-      Module[{openIdx = start + StringLength[shortName], tag1, next1,
-              tag2 = Missing["NoSecondGroup"]},
-        If[start > 1,
-          prev = StringTake[usage, {start - 1}];
-          If[symbolNameCharQ[prev] || prev === "\"", Continue[]]
-        ];
-        (* name[[...]] is a Part expression in prose, not a call pattern. *)
-        If[openIdx < len && StringTake[usage, {openIdx + 1}] === "[",
-          Continue[]];
-        {tag1, next1} = scanBracketGroup[usage, openIdx];
-        Which[
-          tag1 === "Unterminated", nUnterminated++,
-          tag1 === "Ellipsis",     nEllipsis++,
-          True,
-            If[next1 <= len && StringTake[usage, {next1}] === "[",
-              Module[{t2, n2},
-                {t2, n2} = scanBracketGroup[usage, next1];
-                Which[
-                  t2 === "Unterminated", nUnterminated++,
-                  t2 === "Ellipsis",     nEllipsis++,
-                  True,                  tag2 = t2
-                ]
-              ]
-            ];
-            AppendTo[pairs, {tag1, tag2}]
-        ]
-      ],
-      {start, starts}
-    ];
-    <|"Pairs" -> pairs, "Ellipsis" -> nEllipsis, "Unterminated" -> nUnterminated|>
-  ];
-
-(* {min, max} argument count contributed by a single held argument slot. *)
-slotRange[h_Hold] :=
-  Replace[h, {
-    Hold[Verbatim[Pattern][_, p_]]     :> slotRange[Hold[p]],
-    Hold[Verbatim[PatternTest][p_, _]] :> slotRange[Hold[p]],
-    Hold[Verbatim[Condition][p_, _]]   :> slotRange[Hold[p]],
-    Hold[_OptionsPattern]              :> {0, Infinity},
-    Hold[_Optional]                    :> {0, 1},
-    Hold[_BlankNullSequence]           :> {0, Infinity},
-    Hold[_BlankSequence]               :> {1, Infinity},
-    Hold[_RepeatedNull]                :> {0, Infinity},
-    Hold[_Repeated]                    :> {1, Infinity},
-    _                                  :> {1, 1}
-  }];
-
-defArityRange[Hold[args___]] :=
-  Module[{ranges = slotRange /@ (List @@ Map[Hold, Hold[args]])},
-    {Total[ranges[[All, 1]]], Total[ranges[[All, 2]]]}
-  ];
-
-(* Strip whole-LHS Conditions, repeatedly for stacked f[x_] /; c1 /; c2 --
-   an unstripped Condition head would itself be miscounted as a 2-argument
-   call by the extraction below. *)
-stripLhsCondition = Verbatim[HoldPattern][Verbatim[Condition][l_, _]] :> HoldPattern[l];
-
-(* Arity ranges per definition. "Inner" is what a usage's first bracket
-   group must satisfy (DownValues plus the inner application of curried
-   SubValues); "Outer" is what a chained second group must satisfy. The
-   _Symbol head restriction makes curry depth >= 3 fall into the
-   uncheckable pool instead of mis-attributing bracket groups. *)
-definitionArityRanges[fullName_String] :=
-  Module[{dvs, svs},
-    dvs = ToExpression[fullName, InputForm, DownValues][[All, 1]] //. stripLhsCondition;
-    svs = ToExpression[fullName, InputForm, SubValues][[All, 1]] //. stripLhsCondition;
-    <|
-      "Inner" -> Join[
-        defArityRange /@ Cases[dvs, Verbatim[HoldPattern][_Symbol[args___]] :> Hold[args]],
-        defArityRange /@ Cases[svs, Verbatim[HoldPattern][_Symbol[args___][___]] :> Hold[args]]
-      ],
-      "Outer" ->
-        (defArityRange /@ Cases[svs, Verbatim[HoldPattern][_Symbol[___][args___]] :> Hold[args]])
-    |>
-  ];
-
-(* One shared per-symbol pass feeds both the lint and the export loop, so
-   what is linted is exactly what is published. *)
-usageEntries = Map[{#, Last @ StringSplit[#, "`"], readUsage[#]} &, publicSymbols];
-
-arityIssues = {};
-lintWarnings = {};
-checkedCount = 0; noPatternCount = 0; noDefsCount = 0; ellipsisCount = 0;
-
-Do[
-  Module[{fullName, shortName, usage, scan, pairs, ranges, badFirst,
-          seconds, badSecond},
-    {fullName, shortName, usage} = entry;
-    If[!StringQ[usage], Continue[]];
-    scan = scanUsageCallPatterns[shortName, usage];
-    ellipsisCount += scan["Ellipsis"];
-    If[scan["Unterminated"] > 0,
-      AppendTo[lintWarnings,
-        fullName <> ": unterminated call group in usage text (occurrence not checked)"]];
-    pairs = scan["Pairs"];
-    If[pairs === {}, noPatternCount++; Continue[]];
-    ranges = definitionArityRanges[fullName];
-    If[ranges["Inner"] === {}, noDefsCount++; Continue[]];
-    checkedCount++;
-    badFirst = Select[DeleteDuplicates[pairs[[All, 1]]],
-      Function[d, NoneTrue[ranges["Inner"], #[[1]] <= d <= #[[2]] &]]];
-    seconds = DeleteDuplicates[Cases[pairs, {_, a2_Integer} :> a2]];
-    badSecond = If[ranges["Outer"] === {}, {},
-      Select[seconds, Function[d, NoneTrue[ranges["Outer"], #[[1]] <= d <= #[[2]] &]]]];
-    If[badFirst =!= {},
-      AppendTo[arityIssues,
-        fullName <> ": usage shows arity " <> ToString[badFirst] <>
-          ", definitions accept " <> ToString[ranges["Inner"]]]];
-    If[badSecond =!= {},
-      AppendTo[arityIssues,
-        fullName <> ": usage shows second-group arity " <> ToString[badSecond] <>
-          ", curried definitions accept " <> ToString[ranges["Outer"]]]]
-  ],
-  {entry, usageEntries}
-];
-
-Scan[Print["Arity lint warning: ", #] &, lintWarnings];
-If[arityIssues =!= {},
-  Print["ARITY LINT FAILED -- usage strings disagree with definitions:"];
-  Scan[Print["  ", #] &, arityIssues];
-  Print["API_REFERENCE.md was NOT regenerated. Fix the ::usage strings (or definitions) first."];
-  Exit[1]
-];
-If[checkedCount === 0,
-  Print["ARITY LINT FAILED -- zero symbols were checked; the definition introspection no longer matches the package's definition style."];
-  Print["API_REFERENCE.md was NOT regenerated."];
-  Exit[1]
-];
-Print["Arity lint: ", checkedCount, " symbols checked (",
-  noPatternCount, " without call patterns, ",
-  noDefsCount, " without introspectable definitions",
-  If[ellipsisCount > 0,
-    ", " <> ToString[ellipsisCount] <> " ellipsis shorthand group" <>
-      If[ellipsisCount === 1, "", "s"] <> " skipped", ""],
-  "). All call patterns match."];
-
 Do[
   If[StringQ[entry[[3]]],
     AppendTo[mdContent, "## " <> entry[[2]]];
@@ -253,7 +51,7 @@ Do[
     AppendTo[mdContent, entry[[3]]];
     AppendTo[mdContent, ""];
   ],
-  {entry, usageEntries}
+  {entry, report["Entries"]}
 ];
 
 exportPath = FileNameJoin[{$RepoRoot, "API_REFERENCE.md"}];

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -6,7 +6,8 @@ This directory contains active maintenance scripts and an `archive/` folder with
 
 - `RunTests.wls`: suite runner (`fast`, `all`, `oracle`, `archive`, `full`).
 - `RunSingleTest.wls`: run one `.mt` file and print pass/fail summary.
-- `GenerateDocs.wls`: regenerate `API_REFERENCE.md` from `::usage` strings.
+- `GenerateDocs.wls`: regenerate `API_REFERENCE.md` from `::usage` strings; refuses to publish when the usage-arity lint fails.
+- `UsageArityLint.wls`: shared usage-arity lint sourced by `GenerateDocs.wls` and `MFGraphs/Tests/usage-arity.mt` (not a standalone CLI).
 - `AuditPublicAPI.py`: API surface inventory/audit helper.
 - `CheckCriticalSurfaceTests.wls`: gate checks for critical-surface test policy.
 - `CheckReportPlaceholders.wls`: fails when committed history/report files still contain placeholder prose.

--- a/Scripts/RunTests.wls
+++ b/Scripts/RunTests.wls
@@ -25,7 +25,8 @@ $TestSuites = <|
         "tawaf.mt",
         "example-coverage.mt",
         "numeric-oracle.mt",
-        "utilities.mt"
+        "utilities.mt",
+        "usage-arity.mt"
     },
     (* Opt-in oracle suite: the float-isolated numericOracle` classifiers.
        numeric-oracle.mt also runs in fast; fictitiousPlay.mt (the K-fold

--- a/Scripts/UsageArityLint.wls
+++ b/Scripts/UsageArityLint.wls
@@ -1,0 +1,221 @@
+(* UsageArityLint.wls -- usage-string arity lint shared by
+   Scripts/GenerateDocs.wls (doc generation refuses to publish mismatches)
+   and MFGraphs/Tests/usage-arity.mt (fast-suite enforcement, issue #242).
+
+   Sourced with Get[] after MFGraphs` is loaded. Defines functions only:
+   no Exit, no Print, no file writes.
+
+   A usage string that shows name[a, b] while the definition takes five
+   arguments publishes a wrong signature into API_REFERENCE.md. The lint
+   compares every call pattern in each public ::usage string against the
+   arities the symbol's DownValues/SubValues accept. Symbols with no
+   DownValues/SubValues (inert constructors like j, u, typed heads,
+   $-variables) are skipped and tallied.
+
+   Known limitations: each usage is scanned only for its own symbol's call
+   patterns (signatures of OTHER symbols quoted in the text are not
+   checked); context-qualified occurrences (pkg`name[...]) are skipped;
+   sequence-shaped slots (PatternSequence, Longest, Repeated with a count
+   spec) are scored conservatively -- none occur in the package today. *)
+
+(* The canonical public surface. GenerateDocs.wls publishes exactly these
+   contexts; the lint checks exactly what is published. *)
+$UsageArityContexts = {
+  "primitives`",
+  "utilities`",
+  "scenarioTools`",
+  "examples`",
+  "unknownsTools`",
+  "systemTools`",
+  "solversTools`",
+  "orchestrationTools`",
+  "graphicsTools`"
+};
+
+(* Symbols with values (e.g. $MFGraphsVerbose = False) cause
+   `Information[Symbol[s], "Usage"]` to read the value's usage instead of the
+   symbol's. Use `MessageName` on a held symbol so the usage is read off the
+   symbol metadata directly. *)
+readUsage[name_String] := ToExpression[name <> "::usage", InputForm];
+
+(* `Names[ctx<>"*"]` already matches `$`-prefixed symbols, so a single pass
+   suffices. *)
+usagePublicSymbols[] :=
+  Select[
+    DeleteDuplicates @ Flatten[Names[# <> "*"] & /@ $UsageArityContexts],
+    !StringContainsQ[#, "Private`"] && !StringEndsQ[#, "$"] &
+  ];
+
+(* Word-boundary class for WL identifiers. Mirrors the boundary regex in
+   Scripts/AuditPublicAPI.py (tests_for_symbol) -- keep the two in sync. *)
+symbolNameCharQ[c_String] :=
+  StringMatchQ[c, LetterCharacter | DigitCharacter | "$" | "`"];
+
+(* Scan one bracket group starting at openIdx (the "["). Returns
+   {tag, posAfterGroup} where tag is the argument count, "Ellipsis" for a
+   group containing a top-level ... (documentation shorthand, not an arity
+   claim), or "Unterminated" when the group never closes. Depth-counts
+   [] {} () <||> and skips string literals, so only top-level commas count. *)
+scanBracketGroup[usage_String, openIdx_Integer] :=
+  Module[{len = StringLength[usage], i = openIdx + 1, depth = 1, commas = 0,
+          sawContent = False, inQuote = False, dotRun = 0, hasEllipsis = False,
+          c, c2},
+    While[i <= len && depth > 0,
+      c  = StringTake[usage, {i}];
+      c2 = If[i < len, StringTake[usage, {i + 1}], ""];
+      Which[
+        inQuote,                 If[c === "\"", inQuote = False],
+        c === "\"",              inQuote = True,
+        c === "<" && c2 === "|", depth++; i++,
+        c === "|" && c2 === ">", depth--; i++,
+        c === "[" || c === "{" || c === "(", depth++,
+        c === "]" || c === "}" || c === ")", depth--,
+        c === "," && depth === 1, commas++
+      ];
+      If[depth > 0,
+        If[!StringMatchQ[c, WhitespaceCharacter], sawContent = True];
+        dotRun = If[c === "." && depth === 1 && !inQuote, dotRun + 1, 0];
+        If[dotRun >= 3, hasEllipsis = True]
+      ];
+      i++
+    ];
+    Which[
+      depth > 0,   {"Unterminated", i},
+      hasEllipsis, {"Ellipsis", i},
+      True,        {If[sawContent, commas + 1, 0], i}
+    ]
+  ];
+
+(* All call-pattern occurrences of shortName in the usage text. Returns
+   <|"Pairs" -> {{firstArity, secondArityOrMissing}, ...},
+     "Ellipsis" -> n, "Unterminated" -> n|>.
+   Occurrences preceded by a name character (suffix of a longer identifier,
+   or context-qualified) or by a double quote (a signature quoted as example
+   text) are not arity claims and are skipped, as are Part expressions
+   name[[...]]. A chained second group (name[...][...]) is captured for the
+   curried SubValues check. *)
+scanUsageCallPatterns[shortName_String, usage_String] :=
+  Module[{len = StringLength[usage], starts, pairs = {}, nEllipsis = 0,
+          nUnterminated = 0, prev},
+    starts = First /@ StringPosition[usage, shortName <> "["];
+    Do[
+      Module[{openIdx = start + StringLength[shortName], tag1, next1,
+              tag2 = Missing["NoSecondGroup"]},
+        If[start > 1,
+          prev = StringTake[usage, {start - 1}];
+          If[symbolNameCharQ[prev] || prev === "\"", Continue[]]
+        ];
+        (* name[[...]] is a Part expression in prose, not a call pattern. *)
+        If[openIdx < len && StringTake[usage, {openIdx + 1}] === "[",
+          Continue[]];
+        {tag1, next1} = scanBracketGroup[usage, openIdx];
+        Which[
+          tag1 === "Unterminated", nUnterminated++,
+          tag1 === "Ellipsis",     nEllipsis++,
+          True,
+            If[next1 <= len && StringTake[usage, {next1}] === "[",
+              Module[{t2, n2},
+                {t2, n2} = scanBracketGroup[usage, next1];
+                Which[
+                  t2 === "Unterminated", nUnterminated++,
+                  t2 === "Ellipsis",     nEllipsis++,
+                  True,                  tag2 = t2
+                ]
+              ]
+            ];
+            AppendTo[pairs, {tag1, tag2}]
+        ]
+      ],
+      {start, starts}
+    ];
+    <|"Pairs" -> pairs, "Ellipsis" -> nEllipsis, "Unterminated" -> nUnterminated|>
+  ];
+
+(* {min, max} argument count contributed by a single held argument slot. *)
+slotRange[h_Hold] :=
+  Replace[h, {
+    Hold[Verbatim[Pattern][_, p_]]     :> slotRange[Hold[p]],
+    Hold[Verbatim[PatternTest][p_, _]] :> slotRange[Hold[p]],
+    Hold[Verbatim[Condition][p_, _]]   :> slotRange[Hold[p]],
+    Hold[_OptionsPattern]              :> {0, Infinity},
+    Hold[_Optional]                    :> {0, 1},
+    Hold[_BlankNullSequence]           :> {0, Infinity},
+    Hold[_BlankSequence]               :> {1, Infinity},
+    Hold[_RepeatedNull]                :> {0, Infinity},
+    Hold[_Repeated]                    :> {1, Infinity},
+    _                                  :> {1, 1}
+  }];
+
+defArityRange[Hold[args___]] :=
+  Module[{ranges = slotRange /@ (List @@ Map[Hold, Hold[args]])},
+    {Total[ranges[[All, 1]]], Total[ranges[[All, 2]]]}
+  ];
+
+(* Strip whole-LHS Conditions, repeatedly for stacked f[x_] /; c1 /; c2 --
+   an unstripped Condition head would itself be miscounted as a 2-argument
+   call by the extraction below. *)
+stripLhsCondition = Verbatim[HoldPattern][Verbatim[Condition][l_, _]] :> HoldPattern[l];
+
+(* Arity ranges per definition. "Inner" is what a usage's first bracket
+   group must satisfy (DownValues plus the inner application of curried
+   SubValues); "Outer" is what a chained second group must satisfy. The
+   _Symbol head restriction makes curry depth >= 3 fall into the
+   uncheckable pool instead of mis-attributing bracket groups. *)
+definitionArityRanges[fullName_String] :=
+  Module[{dvs, svs},
+    dvs = ToExpression[fullName, InputForm, DownValues][[All, 1]] //. stripLhsCondition;
+    svs = ToExpression[fullName, InputForm, SubValues][[All, 1]] //. stripLhsCondition;
+    <|
+      "Inner" -> Join[
+        defArityRange /@ Cases[dvs, Verbatim[HoldPattern][_Symbol[args___]] :> Hold[args]],
+        defArityRange /@ Cases[svs, Verbatim[HoldPattern][_Symbol[args___][___]] :> Hold[args]]
+      ],
+      "Outer" ->
+        (defArityRange /@ Cases[svs, Verbatim[HoldPattern][_Symbol[___][args___]] :> Hold[args]])
+    |>
+  ];
+
+(* Run the lint over the canonical public surface. Returns
+   <|"Entries"   -> {{fullName, shortName, usage}, ...}   (the exportable surface),
+     "Issues"    -> {description, ...}                    (arity mismatches; empty = pass),
+     "Warnings"  -> {description, ...}                    (unterminated call groups),
+     "Checked"/"NoPattern"/"NoDefs"/"Ellipsis" -> tallies|>. *)
+usageArityReport[] :=
+  Module[{entries, issues = {}, warnings = {}, checked = 0, noPattern = 0,
+          noDefs = 0, ellipsis = 0},
+    entries = Map[{#, Last @ StringSplit[#, "`"], readUsage[#]} &, usagePublicSymbols[]];
+    Do[
+      Module[{fullName, shortName, usage, scan, pairs, ranges, badFirst,
+              seconds, badSecond},
+        {fullName, shortName, usage} = entry;
+        If[!StringQ[usage], Continue[]];
+        scan = scanUsageCallPatterns[shortName, usage];
+        ellipsis += scan["Ellipsis"];
+        If[scan["Unterminated"] > 0,
+          AppendTo[warnings,
+            fullName <> ": unterminated call group in usage text (occurrence not checked)"]];
+        pairs = scan["Pairs"];
+        If[pairs === {}, noPattern++; Continue[]];
+        ranges = definitionArityRanges[fullName];
+        If[ranges["Inner"] === {}, noDefs++; Continue[]];
+        checked++;
+        badFirst = Select[DeleteDuplicates[pairs[[All, 1]]],
+          Function[d, NoneTrue[ranges["Inner"], #[[1]] <= d <= #[[2]] &]]];
+        seconds = DeleteDuplicates[Cases[pairs, {_, a2_Integer} :> a2]];
+        badSecond = If[ranges["Outer"] === {}, {},
+          Select[seconds, Function[d, NoneTrue[ranges["Outer"], #[[1]] <= d <= #[[2]] &]]]];
+        If[badFirst =!= {},
+          AppendTo[issues,
+            fullName <> ": usage shows arity " <> ToString[badFirst] <>
+              ", definitions accept " <> ToString[ranges["Inner"]]]];
+        If[badSecond =!= {},
+          AppendTo[issues,
+            fullName <> ": usage shows second-group arity " <> ToString[badSecond] <>
+              ", curried definitions accept " <> ToString[ranges["Outer"]]]]
+      ],
+      {entry, entries}
+    ];
+    <|"Entries" -> entries, "Issues" -> issues, "Warnings" -> warnings,
+      "Checked" -> checked, "NoPattern" -> noPattern, "NoDefs" -> noDefs,
+      "Ellipsis" -> ellipsis|>
+  ];


### PR DESCRIPTION
## Summary

Closes #242 — the enforcement-point gap confirmed by PR #241's code review: the arity lint previously ran only on manual docs regeneration, so a definition-arity change with no docs regen shipped undetected, and the eventual `Exit[1]` blocked whoever regenerated docs next.

## Changes

- **`Scripts/UsageArityLint.wls`** (new): the lint extracted verbatim into a shared, side-effect-free helper — functions only, no `Exit`/`Print`/file writes — owning the canonical `$UsageArityContexts` list. `usageArityReport[]` returns `Entries`/`Issues`/`Warnings` plus coverage tallies.
- **`Scripts/GenerateDocs.wls`**: now `Get`s the helper and keeps exactly its prior behavior (refuse-to-export on issues, zero-checked hard fail, tallied summary). Output verified byte-identical.
- **`MFGraphs/Tests/usage-arity.mt`** (new, in the `fast` suite): asserts `Issues === {}` (a failure prints the offending mismatches in the test report), `Warnings === {}`, and a coverage-decay floor (≥ 50 symbols checked; 82 today).
- Suite lists updated: `RunTests.wls`, CLAUDE.md suite table, README.md, Tests/README.md, Scripts/README.md.

## Verification

- `GenerateDocs.wls`: exit 0, same `82 symbols checked` summary, `API_REFERENCE.md` byte-identical — the extraction is behavior-preserving.
- `usage-arity.mt`: 3/3 via `RunSingleTest.wls`.
- Planted-mismatch control: defining a mis-documented public symbol yields exactly `bogusLintProbe: usage shows arity {2}, definitions accept {{1, 1}}` — the test fails on real drift.
- Fast suite: **350 passed, 0 failed** (347 post-merge baseline + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)