### PR TITLE
docs: complete staleness pass — docs/ tables, GEMINI private-symbol claims, CONTRIBUTING suite list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,10 @@ wolframscript -file Scripts/RunTests.wls fast
 # Alias for the same active suite
 wolframscript -file Scripts/RunTests.wls all
 
-# Legacy compatibility suites; opt in explicitly
+# Opt-in numeric classifier suites (numeric-oracle + fictitiousPlay)
+wolframscript -file Scripts/RunTests.wls oracle
+
+# Legacy compatibility suites; opt in explicitly (not expected to pass)
 wolframscript -file Scripts/RunTests.wls full
 ```
 
@@ -109,7 +112,7 @@ untouched.
 
 ### What NOT to manually edit
 - `API_REFERENCE.md` — auto-generated; edit `::usage` strings in source instead
-- `DNF_PERFORMANCE_HISTORY.md` / `PARALLEL_PERFORMANCE_HISTORY.md` — auto-appended by benchmark scripts
+- `DNF_PERFORMANCE_HISTORY.md` / `PARALLEL_PERFORMANCE_HISTORY.md` — historical logs written by now-archived scripts; effectively frozen (the active benchmark appends to `BENCHMARKS.md` instead)
 
 ## Repository Structure
 - `MFGraphs/`: Core package source

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -69,9 +69,12 @@ explicitly: `Needs["Tawaf`"]`, `Needs["numericOracle`"]`.
 Benchmark selector names include `dnf` (default), `optimizeddnf`, `activeset`,
 `reduce`, `boolean`, and `findinstance`.
 
-`solutionResultKind` is flow-first: primary classification depends on edge
-flows `j[_,_]` and values `u[__]`; transition-flow determinacy for `j[_,_,_]`
-is reported separately by `solutionVariableDiagnostics[sys, sol]`.
+Result-kind classification is flow-first: primary classification depends on
+edge flows `j[_,_]` and values `u[__]`; transition-flow determinacy for
+`j[_,_,_]` is reported separately. Both helpers (`solutionResultKind`,
+`solutionVariableDiagnostics`) are internal — they live in
+`` solversTools`Private` `` and are not part of the exported API; use the
+public `solutionReport[sys, sol]` for these diagnostics.
 
 Use `solutionReport[sys, sol]` for read-only solution diagnostics and
 `solutionBranchCostReport[sys, sol]` to rank residual branches. The direct and

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ Internal documentation that supports development and research but is not part of
 | `validation/` | Validation logs, session summaries, raw benchmark output text |
 | `history/` | Development history and auto-appended performance logs |
 | `research/` | Reference papers and author notes |
+| `latex/` | Long-form per-module package docs (`package_module_docs/`) and the combined-PDF builder |
+| `solvers/` | Solver method map and package-novelty notes (`methods-and-novelty.md`) |
 
 
 For user-facing documentation, see the root-level files: `README.md`, `API_REFERENCE.md`, `CONTRIBUTING.md`, `TROUBLESHOOTING.md`, `BENCHMARKS.md`.

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -5,5 +5,8 @@ This directory contains the project development history and performance logs.
 | File | Content |
 |---|---|
 | `DEVELOPMENT_HISTORY.md` | Long-form chronicle of the project's evolution since 2020 |
-| `DNF_PERFORMANCE_HISTORY.md` | Auto-appended logs for DNF reduction optimizations |
-| `PARALLEL_PERFORMANCE_HISTORY.md` | Auto-appended logs for parallel solver benchmarks |
+| `DNF_PERFORMANCE_HISTORY.md` | Historical logs for DNF reduction optimizations (appended by archived scripts) |
+| `DNF_PROCEDURAL_PERFORMANCE_HISTORY.md` | Historical logs for the procedural DNF reducer experiments |
+| `PARALLEL_PERFORMANCE_HISTORY.md` | Historical logs for parallel solver benchmarks (appended by archived scripts) |
+| `PACKAGE_FUNCTION_SURFACES.txt` | Point-in-time inventory of package function surfaces |
+| `REPO_HISTORY_SNAPSHOT.md` | Point-in-time snapshot of repository history |


### PR DESCRIPTION
## Summary

Closes out the last documentation-drift items from the 2026-07 sweep (the tail of issue #83's action item 1):

- **docs/README.md** — subdirectory table gains the existing-but-undocumented `latex/` and `solvers/` directories.
- **docs/history/README.md** — now lists all 6 files present (was 3) and notes the performance logs are written by archived scripts.
- **GEMINI.md** — no longer documents `solutionResultKind` / `solutionVariableDiagnostics` as user-facing (both are `solversTools`Private``); points at the public `solutionReport` instead.
- **CONTRIBUTING.md** — testing block gains the `oracle` suite and marks `full` as not expected to pass (see #226); the "auto-appended by benchmark scripts" claim for the frozen DNF/PARALLEL history files is corrected (active benchmark appends to BENCHMARKS.md).

Docs-only. Fast suite: **352 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)